### PR TITLE
`init` command and improvements to clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ $ /path/to/snowdrop/snowdrop-docker.sh snow ...
    * changing feature PKs is supported
    * schema changes should be detected, but aren't supported yet (will error).
    * Use F5 to refresh your QGIS map after changing the underlying working-copy data using `snow`.
-6. With your working copy, `snow` commands should work if run from the `myproject.snow/` folder. Check `--help` for options, the most important ones are supported. In some cases options are passed straight through to an underlying git command:
+5. With your working copy, `snow` commands should work if run from the `myproject.snow/` folder. Check `--help` for options, the most important ones are supported. In some cases options are passed straight through to an underlying git command:
     * `snow diff` diff the working copy against the repository (no index!)
     * `snow commit -m {message}` commit outstanding changes from the working copy
     * `snow log` review commit history
@@ -134,9 +134,10 @@ $ /path/to/snowdrop/snowdrop-docker.sh snow ...
     * `snow tag ...`
     * `snow remote ...`. Remember simple remotes can just be another local directory.
     * `snow push` / `snow pull`
-7. Other git commands will _possibly_ work if run from the `myproject.snow/` folder. eg:
+    * `snow clone` initialise a new repository from a remote URL,
+6. Other git commands will _possibly_ work if run from the `myproject.snow/` folder. eg:
     * `git reset --soft {commitish}`
-8. If you need a remote, head to https://kxgit-gitea.kx.gd and create a repository. Add it as a remote via:
+7. If you need a remote, head to https://kxgit-gitea.kx.gd and create a repository. Add it as a remote via:
    ```console
    $ git remote add origin https://kxgit-gitea.kx.gd/myuser/myrepo.git
    # enter your gitea username/password when prompted

--- a/snowdrop/checkout.py
+++ b/snowdrop/checkout.py
@@ -96,11 +96,7 @@ def checkout(ctx, branch, refish, working_copy, layer, force, fmt):
 
     click.echo(f'Checkout {layer}@{refish or "HEAD"} to {working_copy} as {fmt} ...')
 
-    repo.reset(commit.oid, pygit2.GIT_RESET_SOFT)
-
     checkout_new(repo, working_copy, layer, commit, fmt)
-
-    repo.config["kx.workingcopy"] = f"{fmt}:{working_copy}:{layer}"
 
 
 def checkout_new(repo, working_copy, layer, commit, fmt, skip_create=False, db=None):
@@ -334,6 +330,8 @@ def checkout_new(repo, working_copy, layer, commit, fmt, skip_create=False, db=N
         ), f"gpkg_contents update: expected 1Δ, got {dbcur.rowcount}"
 
     db.commit()
+
+    core.set_working_copy(repo, path=working_copy, layer=layer, fmt=fmt)
 
 
 def checkout_update(repo, working_copy, layer, commit, force=False, base_commit=None):

--- a/snowdrop/cli.py
+++ b/snowdrop/cli.py
@@ -8,7 +8,7 @@ import click
 import pygit2
 
 from . import core  # noqa
-from . import checkout, commit, diff, init, fsck, merge, pull, status
+from . import checkout, clone, commit, diff, init, fsck, merge, pull, status
 
 
 def print_version(ctx, param, value):
@@ -51,6 +51,7 @@ def cli(ctx, repo_dir):
 # commands from modules
 
 cli.add_command(checkout.checkout)
+cli.add_command(clone.clone)
 cli.add_command(commit.commit)
 cli.add_command(diff.diff)
 cli.add_command(fsck.fsck)
@@ -191,56 +192,6 @@ def tag(ctx, args):
         raise click.BadParameter("Not an existing repository", param_hint="--repo")
 
     _execvp("git", ["git", "-C", repo_dir, "tag"] + list(args))
-
-
-@cli.command(context_settings=dict(ignore_unknown_options=True))
-@click.argument("repository", nargs=1)
-@click.argument("directory", required=False)
-def clone(repository, directory):
-    """ Clone a repository into a new directory """
-    repo_dir = directory or os.path.split(repository)[1]
-    if not repo_dir.endswith(".snow") or len(repo_dir) == 4:
-        raise click.BadParameter("Repository should be myproject.snow")
-
-    subprocess.check_call(["git", "clone", "--bare", repository, repo_dir])
-    subprocess.check_call(
-        [
-            "git",
-            "-C",
-            repo_dir,
-            "config",
-            "--local",
-            "--add",
-            "remote.origin.fetch",
-            "+refs/heads/*:refs/remotes/origin/*",
-        ]
-    )
-    subprocess.check_call(["git", "-C", repo_dir, "fetch"])
-
-    repo = pygit2.Repository(repo_dir)
-    head_ref = repo.head.shorthand  # master
-    subprocess.check_call(
-        [
-            "git",
-            "-C",
-            repo_dir,
-            "config",
-            "--local",
-            f"branch.{head_ref}.remote",
-            "origin",
-        ]
-    )
-    subprocess.check_call(
-        [
-            "git",
-            "-C",
-            repo_dir,
-            "config",
-            "--local",
-            f"branch.{head_ref}.merge",
-            "refs/heads/master",
-        ]
-    )
 
 
 if __name__ == "__main__":

--- a/snowdrop/clone.py
+++ b/snowdrop/clone.py
@@ -1,0 +1,81 @@
+import json
+import os
+import subprocess
+import urllib.parse
+from pathlib import Path
+
+import click
+import pygit2
+
+from . import checkout
+
+
+def get_repo_layer(repo):
+    tree = repo.head.peel(pygit2.Tree)
+
+    if len(tree) != 1 or tree[0].type != 'tree':
+        raise ValueError("Repository structure error")
+
+    layer = tree[0].name
+
+    layer_tree = tree / layer
+    meta_tree = layer_tree / "meta"
+    meta_info = json.loads((meta_tree / "gpkg_contents").obj.data)
+
+    if meta_info["table_name"] != layer:
+        raise ValueError(f"Layer mismatch (table_name={meta_info['table_name']}; layer={layer}")
+
+    return layer
+
+
+@click.command()
+@click.pass_context
+@click.option("--checkout/--no-checkout", "do_checkout", is_flag=True, default=True, help="Whether to checkout a working copy in the repository")
+@click.argument("url", nargs=1)
+@click.argument("directory", type=click.Path(exists=False, file_okay=False, writable=True), required=False)
+def clone(ctx, do_checkout, url, directory):
+    """ Clone a repository into a new directory """
+    layer = None
+    url_parts = urllib.parse.urlsplit(url)
+    if url_parts.fragment:
+        layer = url_parts.fragment
+        url = urllib.parse.urlunsplit(url_parts[:-1] + ('',))
+
+    repo_dir = Path(directory or os.path.split(url)[1])
+    if not repo_dir.suffix == ".snow":
+        raise click.BadParameter("name should end in .snow", param_hint="directory")
+
+    # we use subprocess because it deals with credentials much better & consistently than we can do at the moment.
+    # pygit2.clone_repository() works fine except for that
+    subprocess.check_call([
+        "git", "clone",
+        "--bare",
+        "--config", "remote.origin.fetch=+refs/heads/*:refs/remotes/origin/*",
+        url,
+        repo_dir.resolve()
+    ])
+
+    repo = pygit2.Repository(str(repo_dir.resolve()))
+    head_ref = repo.head.shorthand  # master
+    repo.config[f"branch.{head_ref}.remote"] = "origin"
+    repo.config[f"branch.{head_ref}.merge"] = f"refs/heads/{head_ref}"
+
+    if do_checkout:
+        if not layer:
+            layer = get_repo_layer(repo)
+
+        # Checkout a working copy
+        wc_path = repo_dir / f"{repo_dir.stem}.gpkg"
+
+        click.echo(f'Checkout {layer} to {wc_path} as GPKG ...')
+
+        try:
+            checkout.checkout_new(
+                repo=repo,
+                working_copy=str(wc_path),
+                layer=layer,
+                commit=repo.head.peel(pygit2.Commit),
+                fmt="GPKG"
+            )
+        except KeyError as e:
+            raise click.ClickException(f"Couldn't find layer {e} to checkout.")

--- a/snowdrop/init.py
+++ b/snowdrop/init.py
@@ -278,10 +278,13 @@ def init(ctx, import_from, do_checkout, directory):
         if do_checkout:
             # Checkout a working copy
             wc_path = repo_dir / f"{repo_dir.stem}.gpkg"
-            ctx.obj["repo_dir"] = str(repo_dir)
-            ctx.invoke(
-                checkout.checkout,
+
+            click.echo(f'Checkout {import_table} to {wc_path} as GPKG ...')
+
+            checkout.checkout_new(
+                repo=repo,
+                working_copy=wc_path.name,
                 layer=import_table,
-                fmt="GPKG",
-                working_copy=str(wc_path),
+                commit=repo.head.peel(pygit2.Commit),
+                fmt="GPKG"
             )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -149,8 +149,9 @@ def test_init_import(archive, gpkg, table, data_archive, tmp_path, cli_runner, c
             # working copy exists
             wc = (repo_path / f"{repo_path.stem}.gpkg")
             assert wc.exists() and wc.is_file()
+            print("workingcopy at", wc)
 
-            assert repo.config["kx.workingcopy"] == f"GPKG:{wc}:{table}"
+            assert repo.config["kx.workingcopy"] == f"GPKG:{wc.name}:{table}"
 
             db = geopackage(wc)
             nrows = db.execute(f"SELECT COUNT(*) FROM {table};").fetchone()[0]


### PR DESCRIPTION
Fixes #4 

```console
$ mkdir project.snow
$ cd project.snow
$ snow init --import GPKG:/path/to/my.gpkg:mylayer
# will create a repository in the current project.snow directory
# and create project.gpkg as a working copy
```

* This deprecates `snow import-gpkg`
* If you run with `--import GPKG:/path/to/my.gpkg` (ie. no layer) then it'll list the layers and prompt you for which one to use.
* You still can't create an empty repository, I figure we'll handle that when we think through multiple layer support better.

Similarly to `init`, `clone` now creates a working copy as well:
```console
$ snow clone url/to/some/remote/project.snow
# will clone to project.snow/
# and create project.snow/project.gpkg as a working copy
```

You can opt out of the working copy creation via `--no-checkout`