### PR TITLE
Handle dataset imports to non-default paths more consistently.

### DIFF
--- a/sno/gpkg.py
+++ b/sno/gpkg.py
@@ -41,7 +41,7 @@ def db(path, **kwargs):
 
 
 def get_meta_info(db, layer, repo_version='0.0.1'):
-    yield ("version", json.dumps({"version": repo_version}))
+    yield ("version", {"version": repo_version})
 
     dbcur = db.cursor()
     table = layer
@@ -115,7 +115,7 @@ def get_meta_info(db, layer, repo_version='0.0.1'):
             ]
             if rtype is dict:
                 value = value[0] if len(value) else None
-            yield (filename, json.dumps(value))
+            yield (filename, value)
     except Exception:
         print(f"Error building meta/{filename}")
         raise

--- a/sno/working_copy.py
+++ b/sno/working_copy.py
@@ -231,6 +231,7 @@ class WorkingCopyGPKG(WorkingCopy):
             # our repo copy doesn't include all fields from gpkg_contents
             # but the default value for last_change (now), and NULL for {min_x,max_x,min_y,max_y}
             # should deal with the remaining fields
+
             sql = f"""
                 INSERT INTO gpkg_contents
                     ({','.join([gpkg.ident(k) for k in keys])})
@@ -308,9 +309,9 @@ class WorkingCopyGPKG(WorkingCopy):
             gdal.OF_VECTOR | gdal.OF_UPDATE | gdal.OF_VERBOSE_ERROR,
             ["GPKG"],
         )
-        gdal_ds.ExecuteSQL(
-            f"SELECT CreateSpatialIndex({gpkg.ident(dataset.name)}, {gpkg.ident(geom_col)});"
-        )
+        sql = f"SELECT CreateSpatialIndex({gpkg.param_str(dataset.name)}, {gpkg.param_str(geom_col)});"
+        L.debug("Creating spatial index for %s.%s: %s", dataset.name, geom_col, sql)
+        gdal_ds.ExecuteSQL(sql)
         del gdal_ds
         L.info("Created spatial index in %ss", time.time()-t0)
 


### PR DESCRIPTION
Fix for #13 

If you've imported to `foo/bar/mylayer`, then the working copy table will now be named `foo__bar__mylayer` and spatial index files will be `foo__bar__mylayer.idx*`.

When the dataset is initially imported, `table_name` in gpkg_* are renamed once.

SQLite supports anything as a table name as long as it's quoted, so arguably `foo/bar/mylayer` is a valid table name. Would that be better? You'd need to quote it every time it's used in any SQL though: maybe that's too prohibitive?

