### PR TITLE
Use monotonic clocks for timing operations

### DIFF
--- a/sno/init.py
+++ b/sno/init.py
@@ -170,7 +170,7 @@ class ImportGPKG:
 
         self.db.create_function(func_name, 1, pk_callback)
 
-        t0 = time.time()
+        t0 = time.monotonic()
         self.dbcur.execute(f"""
             CREATE TEMPORARY TABLE {tbl_name} (
                 sort TEXT PRIMARY KEY,
@@ -188,12 +188,12 @@ class ImportGPKG:
         if limit is not None:
             sql += f" LIMIT {limit:d}"
         self.dbcur.execute(sql)
-        t1 = time.time()
+        t1 = time.monotonic()
         click.echo(f"Build link/sort mapping table in {t1-t0:0.1f}s")
         self.dbcur.execute(f"""
             CREATE INDEX temp.{tbl_hash}_idxm ON {tbl_name}(sort,link);
         """)
-        t2 = time.time()
+        t2 = time.monotonic()
         click.echo(f"Build pk/sort mapping index in {t2-t1:0.1f}s")
 
         # Print the Query Plan
@@ -212,7 +212,7 @@ class ImportGPKG:
                 INNER JOIN {gpkg.ident(self.table)} ON ({tbl_name}.link={gpkg.ident(self.table)}.{gpkg.ident(self.primary_key)})
             ORDER BY {tbl_name}.sort;
         """)
-        click.echo(f"Ran SELECT query in {time.time()-t2:0.1f}s")
+        click.echo(f"Ran SELECT query in {time.monotonic()-t2:0.1f}s")
         return self.dbcur
 
     def iter_features(self):

--- a/sno/query.py
+++ b/sno/query.py
@@ -53,9 +53,9 @@ def query(ctx, path, command, params):
     if command == "index":
         USAGE = "index"
 
-        t0 = time.time()
+        t0 = time.monotonic()
         dataset.build_spatial_index(dataset.name)
-        t1 = time.time()
+        t1 = time.monotonic()
         L.debug("Indexed {dataset} in %0.3fs", t1-t0)
         return
 
@@ -75,9 +75,9 @@ def query(ctx, path, command, params):
         else:
             lookup = params[0]
 
-        t0 = time.time()
+        t0 = time.monotonic()
         results = dataset.get_feature(lookup)[1]
-        t1 = time.time()
+        t1 = time.monotonic()
 
     elif command == 'geo-nearest':
         USAGE = "geo-nearest X0,Y0[,X1,Y1] [LIMIT]"
@@ -93,9 +93,9 @@ def query(ctx, path, command, params):
             raise click.BadParameter(USAGE)
 
         index = dataset.get_spatial_index(path)
-        t0 = time.time()
+        t0 = time.monotonic()
         results = [dataset.get_feature(pk)[1] for pk in index.nearest(coordinates, limit)]
-        t1 = time.time()
+        t1 = time.monotonic()
 
     elif command == 'geo-intersects':
         USAGE = "geo-intersects X0,Y0,X1,Y1"
@@ -107,9 +107,9 @@ def query(ctx, path, command, params):
             raise click.BadParameter(USAGE)
 
         index = dataset.get_spatial_index(path)
-        t0 = time.time()
+        t0 = time.monotonic()
         results = [dataset.get_feature(pk)[1] for pk in index.intersection(coordinates)]
-        t1 = time.time()
+        t1 = time.monotonic()
 
     elif command == 'geo-count':
         USAGE = "geo-count X0,Y0,X1,Y1"
@@ -121,9 +121,9 @@ def query(ctx, path, command, params):
             raise click.BadParameter(USAGE)
 
         index = dataset.get_spatial_index(path)
-        t0 = time.time()
+        t0 = time.monotonic()
         results = index.count(coordinates)
-        t1 = time.time()
+        t1 = time.monotonic()
 
     else:
         raise NotImplementedError(f"Unknown command: {command}")
@@ -132,6 +132,6 @@ def query(ctx, path, command, params):
     json_params = {
         'indent': 2 if sys.stdout.isatty() else None,
     }
-    t2 = time.time()
+    t2 = time.monotonic()
     json.dump(results, sys.stdout, default=_json_encode_default, **json_params)
-    L.debug("Output in %0.3fs", time.time()-t2)
+    L.debug("Output in %0.3fs", time.monotonic()-t2)

--- a/sno/working_copy.py
+++ b/sno/working_copy.py
@@ -303,7 +303,7 @@ class WorkingCopyGPKG(WorkingCopy):
         geom_col = dataset.geom_column_name
 
         # Create the GeoPackage Spatial Index
-        t0 = time.time()
+        t0 = time.monotonic()
         gdal_ds = gdal.OpenEx(
             str(self.full_path),
             gdal.OF_VECTOR | gdal.OF_UPDATE | gdal.OF_VERBOSE_ERROR,
@@ -313,7 +313,7 @@ class WorkingCopyGPKG(WorkingCopy):
         L.debug("Creating spatial index for %s.%s: %s", dataset.name, geom_col, sql)
         gdal_ds.ExecuteSQL(sql)
         del gdal_ds
-        L.info("Created spatial index in %ss", time.time()-t0)
+        L.info("Created spatial index in %ss", time.monotonic()-t0)
 
     def _create_triggers(self, dbcur, table):
         raise NotImplementedError()
@@ -509,7 +509,7 @@ class WorkingCopy_GPKG_1(WorkingCopyGPKG):
                         ({','.join(['?'] * len(col_names))});
                 """
                 feat_count = 0
-                t0 = time.time()
+                t0 = time.monotonic()
                 t0p = t0
 
                 CHUNK_SIZE = 10000
@@ -519,11 +519,11 @@ class WorkingCopy_GPKG_1(WorkingCopyGPKG):
 
                     nc = feat_count / CHUNK_SIZE
                     if nc % 5 == 0 or not nc.is_integer():
-                        t0a = time.time()
+                        t0a = time.monotonic()
                         L.info("%s features... @%.1fs (+%.1fs, ~%d F/s)", feat_count, t0a-t0, t0a-t0p, (CHUNK_SIZE*5)/(t0a-t0p))
                         t0p = t0a
 
-                t1 = time.time()
+                t1 = time.monotonic()
                 L.info("Added %d features to GPKG in %.1fs", feat_count, t1-t0)
                 L.info("Overall rate: %d features/s", (feat_count / (t1 - t0)))
 

--- a/tests/scripts/history-creator.py
+++ b/tests/scripts/history-creator.py
@@ -202,7 +202,7 @@ def main():
     num_updates = options.updates * options.scale
     num_deletes = options.deletes * options.scale
 
-    t0 = time.time()
+    t0 = time.monotonic()
     try:
         for i in range(options.commits or 1):
             db.execute("BEGIN")
@@ -229,9 +229,9 @@ def main():
                 ])
 
             if i and (i % 10 == 0):
-                print(f"\t{i+1} @ {(time.time()-t0):0.1f}s ...")
+                print(f"\t{i+1} @ {(time.monotonic()-t0):0.1f}s ...")
     finally:
-        t1 = time.time()
+        t1 = time.monotonic()
         print(f"Completed {options.commits or 1} loops in {(t1-t0):.1f}s ({((options.commits or 1)/(t1-t0)):.1f}/s)")
 
 


### PR DESCRIPTION
relevant to #16 

`time.monotonic()` was added in python 3.3.

It's the right thing to use when you're comparing two time values to represent a duration.