### PR TITLE
init: Mirror git behaviour with respect to directory creation/handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,8 @@ See the [documentation](https://github.com/koordinates/sno/wiki) for tutorials a
 1. Export a GeoPackage from [Koordinates](https://koordinates.com/) with any combination of vector layers and tables.
 2. Create a new Sno repository and import the GeoPackage (eg. `kx-foo-layer.gpkg`).
    ```console
-   $ mkdir myproject
+   $ sno init myproject --import GPKG:kx-foo-layer.gpkg
    $ cd myproject
-   $ sno init --import GPKG:kx-foo-layer.gpkg
    ```
    Use this repository as the directory to run all the other commands in.
    This will also create a working copy as `myproject/myproject.gpkg` to edit.

--- a/sno/init.py
+++ b/sno/init.py
@@ -314,7 +314,7 @@ def import_table(ctx, source, directory, do_list, version, method):
 @click.pass_context
 @click.option("--import", "import_from", type=ImportPath(), help='Import from data: "FORMAT:PATH:TABLE" eg. "GPKG:my.gpkg:my_table"')
 @click.option("--checkout/--no-checkout", "do_checkout", is_flag=True, default=True, help="Whether to checkout a working copy in the repository")
-@click.argument("directory", type=click.Path(exists=True, writable=True, file_okay=False), required=False, default=os.curdir)
+@click.argument("directory", type=click.Path(writable=True, file_okay=False), required=False)
 def init(ctx, import_from, do_checkout, directory):
     """
     Initialise a new repository and optionally import data
@@ -361,6 +361,11 @@ def init(ctx, import_from, do_checkout, directory):
             else:
                 click.secho(f'\nSpecify a table to import from via "{import_prefix}:{import_path}:MYTABLE"', fg='yellow')
                 ctx.exit(1)
+
+    if directory is None:
+        directory = os.curdir
+    elif not Path(directory).exists():
+        Path(directory).mkdir(parents=True)
 
     repo_dir = Path(directory).resolve()
     if any(repo_dir.iterdir()):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -218,10 +218,48 @@ def test_init_empty(tmp_path, cli_runner, chdir):
     repo_path = tmp_path / "data.sno"
     repo_path.mkdir()
 
+    # empty dir
     r = cli_runner.invoke(
         ["init", repo_path]
     )
     assert r.exit_code == 0, r
+    assert (repo_path / 'HEAD').exists()
+
+    # makes dir tree
+    repo_path = tmp_path / 'foo' / 'bar' / 'wiz.sno'
+    r = cli_runner.invoke(
+        ["init", repo_path]
+    )
+    assert r.exit_code == 0, r
+    assert (repo_path / 'HEAD').exists()
+
+    # current dir
+    repo_path = tmp_path / "planet.sno"
+    repo_path.mkdir()
+    with chdir(repo_path):
+        r = cli_runner.invoke(
+            ["init"]
+        )
+        assert r.exit_code == 0, r
+        assert (repo_path / 'HEAD').exists()
+
+    # dir isn't empty
+    repo_path = tmp_path / 'tree'
+    repo_path.mkdir()
+    (repo_path / 'a.file').touch()
+    r = cli_runner.invoke(
+        ["init", repo_path]
+    )
+    assert r.exit_code == 2, r
+    assert not (repo_path / 'HEAD').exists()
+
+    # current dir isn't empty
+    with chdir(repo_path):
+        r = cli_runner.invoke(
+            ["init"]
+        )
+        assert r.exit_code == 2, r
+        assert not (repo_path / 'HEAD').exists()
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Fix for #15

1. can specify a directory, which is created if it doesn't exist (including parents)
2. default is current working directory
3. any existing directory needs to be empty

Makes the Quick Start _slightly_ simpler, though still need the `cd` to get people into the right place to run commands.