### PR TITLE
branch: Prevent deleting the current branch

### DIFF
--- a/sno/cli.py
+++ b/sno/cli.py
@@ -153,6 +153,14 @@ def branch(ctx, args):
     if not repo or not repo.is_bare:
         raise click.BadParameter("Not an existing repository", param_hint="--repo")
 
+    # git's branch protection behaviour doesn't apply if it's a bare repository
+    # attempt to apply it here.
+    sargs = set(args)
+    if sargs & {'-d', '--delete', '-D'}:
+        branch = repo.head.shorthand
+        if branch in sargs:
+            raise click.ClickException(f"Cannot delete the branch '{branch}' which you are currently on.")
+
     _execvp("git", ["git", "-C", repo_dir, "branch"] + list(args))
 
 

--- a/tests/test_workingcopy.py
+++ b/tests/test_workingcopy.py
@@ -642,3 +642,23 @@ def test_restore(source, pathspec, data_working_copy, cli_runner, geopackage):
         r = db.execute(f"SELECT {pk_field} FROM {layer} WHERE {pk_field} = 300;")
         if not r.fetchone():
             print("E: Previous PK bad? ({pk_field}=300)")
+
+
+def test_delete_branch(data_working_copy, cli_runner):
+    with data_working_copy("points") as (repo_path, wc):
+        # prevent deleting the current branch
+        r = cli_runner.invoke(["branch", "-d", "master"])
+        assert r.exit_code == 1, r
+        assert "Cannot delete" in r.stdout
+
+        r = cli_runner.invoke(["checkout", "-b", "test"])
+        assert r.exit_code == 0, r
+
+        r = cli_runner.invoke(["branch", "-d", "test"])
+        assert r.exit_code == 1, r
+
+        r = cli_runner.invoke(["checkout", "master"])
+        assert r.exit_code == 0, r
+
+        r = cli_runner.invoke(["branch", "-d", "test"])
+        assert r.exit_code == 0, r


### PR DESCRIPTION
Fixes #7 

Git's safety behaviour doesn't apply to bare repos, so diy it:

```console
$ git branch -d master
Error: Cannot delete the branch 'master' which you are currently on.
```