### PR TITLE
Import datasets into repositories with an existing working copy (fixes #26)

### DIFF
--- a/sno/checkout.py
+++ b/sno/checkout.py
@@ -104,7 +104,7 @@ def checkout_new(repo_structure, path, *, datasets=None, commit=None):
     wc = WorkingCopy.new(repo_structure.repo, path)
     wc.create()
     for dataset in datasets:
-        wc.write_full(commit, dataset)
+        wc.write_full(commit, dataset, safe=False)
     wc.save_config()
 
 

--- a/sno/init.py
+++ b/sno/init.py
@@ -314,6 +314,13 @@ def import_table(ctx, source, directory, do_list, version, method):
     else:
         importer.fast_import_table(repo, source_loader, **params)
 
+    rs = structure.RepositoryStructure(repo)
+    wc = rs.working_copy
+    if wc:
+        # Update working copy with new dataset
+        dataset = rs[directory]
+        wc.write_full(rs.head_commit, dataset)
+
 
 @click.command()
 @click.pass_context

--- a/sno/structure.py
+++ b/sno/structure.py
@@ -90,6 +90,10 @@ class RepositoryStructure:
                         to_examine.append((te_path, te.obj))
 
     @property
+    def head_commit(self):
+        return self._commit
+
+    @property
     def tree(self):
         return self._commit.peel(pygit2.Tree)
 


### PR DESCRIPTION
- don't do optimised imports when we have existing data
- improved support for importing the same gpkg multiple times