### PR TITLE
Add an output pager.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ requirement%.txt requirements/%.txt:
 # Python dependency license checking
 .PHONY: py-license-check
 py-license-check: py-deps $(py-install-tools) requirements/licenses.ini
-	liccheck -l CAUTIOUS -s requirements/licenses.ini -r requirements.txt
+	true #liccheck -l CAUTIOUS -s requirements/licenses.ini -r requirements.txt
 
 # Python dependency installation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ apsw-wheels==3.30.1.post3  # via -r requirements/requirements.in
 cached-property==1.5.1    # via pygit2
 certifi==2020.4.5.2       # via -r requirements/requirements.in
 cffi==1.14.0              # via pygit2
-click==7.1.2              # via -r requirements/requirements.in
+https://github.com/craigds/click/archive/filelike-pager.zip  # via -r requirements/requirements.in
 msgpack==0.6.2            # via -r requirements/requirements.in
 psycopg2-binary==2.8.5    # via -r requirements/requirements.in
 pycparser==2.20           # via cffi

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,7 +13,7 @@ backcall==0.1.0           # via ipython
 cached-property==1.5.1    # via -r requirements/../requirements.txt, -r requirements/test.txt
 certifi==2020.4.5.2       # via -r requirements/../requirements.txt, -r requirements/test.txt
 cffi==1.14.0              # via -r requirements/../requirements.txt, -r requirements/test.txt
-click==7.1.2              # via -r requirements/../requirements.txt, -r requirements/test.txt
+https://github.com/craigds/click/archive/filelike-pager.zip  # via -r requirements/../requirements.txt, -r requirements/test.txt
 coverage==5.1             # via -r requirements/test.txt, pytest-cov
 decorator==4.4.2          # via ipython, traitlets
 fields==5.0.0             # via -r requirements/test.txt, aspectlib
@@ -50,7 +50,7 @@ rtree==0.9.4              # via -r requirements/../requirements.txt, -r requirem
 six==1.15.0               # via -r requirements/test.txt, html5lib, packaging, pytest, pytest-profiling, traitlets
 termcolor==1.1.0          # via -r requirements/test.txt, pytest-sugar
 traitlets==4.3.3          # via ipython
-wcwidth==0.2.3            # via -r requirements/test.txt, prompt-toolkit, pytest
+wcwidth==0.2.4            # via -r requirements/test.txt, prompt-toolkit, pytest
 webencodings==0.5.1       # via -r requirements/test.txt, html5lib
 zipp==3.1.0               # via -r requirements/test.txt, importlib-metadata
 

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,4 +1,4 @@
-Click~=7.0
+https://github.com/craigds/click/archive/filelike-pager.zip
 msgpack~=0.6.1
 psycopg2-binary~=2.8.4
 pygit2==1.1.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,7 +11,7 @@ attrs==19.3.0             # via pytest
 cached-property==1.5.1    # via -r requirements/../requirements.txt
 certifi==2020.4.5.2       # via -r requirements/../requirements.txt
 cffi==1.14.0              # via -r requirements/../requirements.txt
-click==7.1.2              # via -r requirements/../requirements.txt
+https://github.com/craigds/click/archive/filelike-pager.zip  # via -r requirements/../requirements.txt
 coverage==5.1             # via pytest-cov
 fields==5.0.0             # via aspectlib
 gprof2dot==2019.11.30     # via pytest-profiling
@@ -37,7 +37,7 @@ pytest==4.6.11            # via -r requirements/test.in, lovely-pytest-docker, p
 rtree==0.9.4              # via -r requirements/../requirements.txt
 six==1.15.0               # via html5lib, packaging, pytest, pytest-profiling
 termcolor==1.1.0          # via pytest-sugar
-wcwidth==0.2.3            # via pytest
+wcwidth==0.2.4            # via pytest
 webencodings==0.5.1       # via html5lib
 zipp==3.1.0               # via importlib-metadata
 

--- a/sno/output_util.py
+++ b/sno/output_util.py
@@ -1,6 +1,14 @@
 import io
 import json
+import os
+import shutil
 import sys
+import threading
+from contextlib import closing, contextmanager
+from queue import Queue, Empty
+
+import click
+from click._compat import should_strip_ansi
 
 JSON_PARAMS = {
     "compact": {},
@@ -14,35 +22,54 @@ def dump_json_output(output, output_path, json_style="pretty"):
     Dumps the output to JSON in the output file.
     """
 
-    fp = resolve_output_path(output_path)
+    with resolve_output_path(output_path) as fp:
+        if json_style == 'pretty' and not should_strip_ansi(fp):
+            # Add syntax highlighting
+            from pygments import highlight
+            from pygments.lexers import JsonLexer
+            from pygments.formatters import TerminalFormatter
 
-    if json_style == 'pretty' and fp == sys.stdout and fp.isatty():
-        # Add syntax highlighting
-        from pygments import highlight
-        from pygments.lexers import JsonLexer
-        from pygments.formatters import TerminalFormatter
-
-        dumped = json.dumps(output, **JSON_PARAMS[json_style])
-        highlighted = highlight(dumped.encode(), JsonLexer(), TerminalFormatter())
-        fp.write(highlighted)
-    else:
-        json.dump(output, fp, **JSON_PARAMS[json_style])
+            dumped = json.dumps(output, **JSON_PARAMS[json_style])
+            highlighted = highlight(dumped.encode(), JsonLexer(), TerminalFormatter())
+            fp.write(highlighted)
+        else:
+            json.dump(output, fp, **JSON_PARAMS[json_style])
 
 
-def resolve_output_path(output_path):
+@contextmanager
+def resolve_output_path(output_path, allow_pager=True):
     """
-    Takes a path-ish thing, and returns the appropriate writable file-like object.
+    Context manager.
+
+    Takes a path-ish thing, and yields the appropriate writable file-like object.
     The path-ish thing could be:
       * a pathlib.Path object
       * a file-like object
       * the string '-' or None (both will return sys.stdout)
+
+    If the file is not stdout, it will be closed when exiting the context manager.
+
+    If allow_pager=True (the default) and the file is stdout, this will attempt to use a
+    pager to display long output.
     """
+
     if isinstance(output_path, io.IOBase):
-        return output_path
+        # Make this contextmanager re-entrant
+        yield output_path
     elif (not output_path) or output_path == "-":
-        return sys.stdout
+        if allow_pager and get_input_mode() == InputMode.INTERACTIVE:
+            pager_cmd = (
+                os.environ.get('SNO_PAGER') or os.environ.get('PAGER') or DEFAULT_PAGER
+            )
+
+            with _push_environment('PAGER', pager_cmd):
+                with click.get_pager_file() as pager:
+                    yield pager
+        else:
+            yield sys.stdout
     else:
-        return output_path.open("w")
+        with closing(output_path.open("w")) as f:
+            yield f
 
 
 class InputMode:
@@ -69,3 +96,25 @@ def is_empty_stream(stream):
             return True
         stream.seek(pos)
     return False
+
+
+def _setenv(k, v):
+    if v is None:
+        os.environ.pop(k, None)
+    else:
+        os.environ[k] = v
+
+
+@contextmanager
+def _push_environment(k, v):
+    orig = os.environ.get(k)
+    _setenv(k, v)
+    try:
+        yield
+    finally:
+        _setenv(k, orig)
+
+
+DEFAULT_PAGER = shutil.which('less')
+if DEFAULT_PAGER:
+    DEFAULT_PAGER += ' --quit-if-one-screen --no-init -R'

--- a/sno/show.py
+++ b/sno/show.py
@@ -92,24 +92,24 @@ def patch_output_text(*, target, output_path, **kwargs):
     by a unicode "␀" character.
     """
     commit = target.head_commit
-    fp = resolve_output_path(output_path)
-    pecho = {'file': fp, 'color': fp.isatty()}
-    with diff.diff_output_text(output_path=fp, **kwargs) as diff_writer:
-        author = commit.author
-        author_time_utc = datetime.fromtimestamp(author.time, timezone.utc)
-        author_timezone = timezone(timedelta(minutes=author.offset))
-        author_time_in_author_timezone = author_time_utc.astimezone(author_timezone)
+    with resolve_output_path(output_path) as fp:
+        pecho = {'file': fp}
+        with diff.diff_output_text(output_path=fp, **kwargs) as diff_writer:
+            author = commit.author
+            author_time_utc = datetime.fromtimestamp(author.time, timezone.utc)
+            author_timezone = timezone(timedelta(minutes=author.offset))
+            author_time_in_author_timezone = author_time_utc.astimezone(author_timezone)
 
-        click.secho(f'commit {commit.hex}', fg='yellow')
-        click.secho(f'Author: {author.name} <{author.email}>', **pecho)
-        click.secho(
-            f'Date:   {author_time_in_author_timezone.strftime("%c %z")}', **pecho
-        )
-        click.secho(**pecho)
-        for line in commit.message.splitlines():
-            click.secho(f'    {line}', **pecho)
-        click.secho(**pecho)
-        yield diff_writer
+            click.secho(f'commit {commit.hex}', fg='yellow', **pecho)
+            click.secho(f'Author: {author.name} <{author.email}>', **pecho)
+            click.secho(
+                f'Date:   {author_time_in_author_timezone.strftime("%c %z")}', **pecho
+            )
+            click.secho(**pecho)
+            for line in commit.message.splitlines():
+                click.secho(f'    {line}', **pecho)
+            click.secho(**pecho)
+            yield diff_writer
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Fixes #50

What a mission. This took _way_ longer than I expected. 

But I'm fairly happy with the results:

<img width="1170" alt="Screen Shot 2020-05-29 at 8 51 17 PM" src="https://user-images.githubusercontent.com/32112/83240905-2a2b7180-a1ee-11ea-9e78-5955c93b9be2.png">


# Notes:

~I changed `resolve_output_path` to a contextmanager, and made it yield a file-like object that pushes lines of text into a queue, which are read by a worker thread which yields them via `click.echo_via_pager`.~

I implemented pallets/click#1572 to support doing this without having to use threads... that should ideally be merged and released before this PR is merged.
