### PR TITLE
Fix URIs to refer to koordinates/kart

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,10 +4,10 @@
 
 ## Related links:
 
-<!-- If you have links to [issues](https://github.com/koordinates/sno/issues) etc, link them here. -->
+<!-- If you have links to [issues](https://github.com/koordinates/kart/issues) etc, link them here. -->
 
 ## Checklist:
 
 - [ ] Have you reviewed your own change?
 - [ ] Have you included test(s)?
-- [ ] Have you updated the [changelog](https://github.com/koordinates/sno/blob/master/CHANGELOG.md)?
+- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ### Other changes
 * Various local config and structure which was named after `sno` is now named after `kart` - for instance, a Kart repo's objects are now hidden inside a `.kart` folder. Sno repos with the older names will continue to be supported going forward. To modify a repo in place to use the `kart` based names instead of the `sno` ones, use `kart upgrade-to-kart PATH`.
-* `import` & `init` are often much faster now because they do imports in parallel subprocesses. Use `--num-processes` to control this behaviour. [#408](https://github.com/koordinates/sno/pull/408)
+* `import` & `init` are often much faster now because they do imports in parallel subprocesses. Use `--num-processes` to control this behaviour. [#408](https://github.com/koordinates/kart/pull/408)
 * `status -o json` now shows which branch you are on, even if that branch doesn't yet have any commits yet.
 
 ## 0.8.0 (Last "Sno" release)
@@ -20,20 +20,20 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 ### Breaking changes
 
  * Internally, Sno now stores XML metadata in an XML file, instead of nested inside a JSON file. This is part of a longer term plan to make it easier to attach metadata or other files to a repository in a straight-forward way, without having to understand JSON internals. Unfortunately, diffing commits where the XML metadata has been written by Sno 0.8.0 won't work in Sno 0.7.1 or earlier - it will fail with `binascii.Error`
- * Backwards compatibility with Datasets V1 ends at Sno 0.8.0 - all Sno commands except `sno upgrade` will no longer work in a V1 repository. Since Datasets V2 has been the default since Sno 0.5.0, most users will be unaffected. Remaining V1 repositories can be upgraded to V2 using `sno upgrade EXISTING_REPO NEW_REPO`, and the ability to upgrade from V1 to V2 continues to be supported indefinitely. [#342](https://github.com/koordinates/sno/pull/342)
+ * Backwards compatibility with Datasets V1 ends at Sno 0.8.0 - all Sno commands except `sno upgrade` will no longer work in a V1 repository. Since Datasets V2 has been the default since Sno 0.5.0, most users will be unaffected. Remaining V1 repositories can be upgraded to V2 using `sno upgrade EXISTING_REPO NEW_REPO`, and the ability to upgrade from V1 to V2 continues to be supported indefinitely. [#342](https://github.com/koordinates/kart/pull/342)
  * `sno init` now sets the head branch to `main` by default, instead of `master`. To override this, add `--initial-branch=master`
- * `reset` now behaves more like `git reset` - specifically, `sno reset COMMIT` stays on the same branch but sets the branch tip to be `COMMIT`. [#60](https://github.com/koordinates/sno/issues/60)
- * `import` now accepts a `--replace-ids` argument for much faster importing of small changesets from large sources. [#378](https://github.com/koordinates/sno/issues/378)
+ * `reset` now behaves more like `git reset` - specifically, `sno reset COMMIT` stays on the same branch but sets the branch tip to be `COMMIT`. [#60](https://github.com/koordinates/kart/issues/60)
+ * `import` now accepts a `--replace-ids` argument for much faster importing of small changesets from large sources. [#378](https://github.com/koordinates/kart/issues/378)
 
 ### Other changes
 
- * The working copy can now be a SQL Server database (previously only GPKG and PostGIS working copies were supported). The commands `init`, `clone` and `create-workingcopy` now all accept working copy paths in the form `mssql://[HOST]/DBNAME/SCHEMA` [#362](https://github.com/koordinates/sno/issues/362)
+ * The working copy can now be a SQL Server database (previously only GPKG and PostGIS working copies were supported). The commands `init`, `clone` and `create-workingcopy` now all accept working copy paths in the form `mssql://[HOST]/DBNAME/SCHEMA` [#362](https://github.com/koordinates/kart/issues/362)
      - Currently requires that the ODBC driver for SQL Server is installed.
      - Read the documentation at `docs/SQL_SERVER_WC.md`
- * Support for detecting features which have changed slightly during a re-import from a data source without a primary key, and reimporting them with the same primary key as last time so they show as edits as opposed to inserts. [#212](https://github.com/koordinates/sno/issues/212)
+ * Support for detecting features which have changed slightly during a re-import from a data source without a primary key, and reimporting them with the same primary key as last time so they show as edits as opposed to inserts. [#212](https://github.com/koordinates/kart/issues/212)
  * Optimised GPKG working copies for better performance for large datasets.
  * Bugfix - fixed issues roundtripping certain type metadata in the PostGIS working copy: specifically geometry types with 3 or more dimensions (Z/M values) and numeric types with scale.
- * Bugfix - if a database schema already exists, Sno shouldn't try to create it, and it shouldn't matter if Sno lacks permission to do so [#391](https://github.com/koordinates/sno/issues/391)
+ * Bugfix - if a database schema already exists, Sno shouldn't try to create it, and it shouldn't matter if Sno lacks permission to do so [#391](https://github.com/koordinates/kart/issues/391)
  * Internal dependency change - Sno no longer depends on [apsw](https://pypi.org/project/apsw/), instead it depends on [SQLAlchemy](https://www.sqlalchemy.org/).
  * `init` now accepts a `--initial-branch` option
  * `clone` now accepts a `--filter` option (advanced users only)
@@ -46,52 +46,52 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 #### JSON syntax-highlighting fix
 
-* Any command which outputs JSON would fail in 0.7.0 when run in a terminal unless a JSON style other than `--pretty` was explicitly specified, due to a change in the pygments library which Sno's JSON syntax-highlighting code failed to accomodate. This is fixed in the 0.7.1 release. [#335](https://github.com/koordinates/sno/pull/335)
+* Any command which outputs JSON would fail in 0.7.0 when run in a terminal unless a JSON style other than `--pretty` was explicitly specified, due to a change in the pygments library which Sno's JSON syntax-highlighting code failed to accomodate. This is fixed in the 0.7.1 release. [#335](https://github.com/koordinates/kart/pull/335)
 
 ## 0.7.0
 
 ### Major changes in this release
 
- * Support for importing data without a primary key. Since the Sno model requires that every feature has a primary key, primary keys are assigned during import. [#212](https://github.com/koordinates/sno/issues/212)
- * Support for checking out a dataset with a string primary key (or other non-integer primary key) as a GPKG working copy. [#307](https://github.com/koordinates/sno/issues/307)
+ * Support for importing data without a primary key. Since the Sno model requires that every feature has a primary key, primary keys are assigned during import. [#212](https://github.com/koordinates/kart/issues/212)
+ * Support for checking out a dataset with a string primary key (or other non-integer primary key) as a GPKG working copy. [#307](https://github.com/koordinates/kart/issues/307)
 
 ### Minor features / fixes:
 
- * Improved error recovery: Sno commands now write to the working copy within a single transaction, which is rolled back if the command fails. [#281](https://github.com/koordinates/sno/pull/281)
- * Dependency upgrades (GDAL; Git; Pygit2; Libgit2; Spatialite; GEOS) [#327](https://github.com/koordinates/sno/pull/327)
+ * Improved error recovery: Sno commands now write to the working copy within a single transaction, which is rolled back if the command fails. [#281](https://github.com/koordinates/kart/pull/281)
+ * Dependency upgrades (GDAL; Git; Pygit2; Libgit2; Spatialite; GEOS) [#327](https://github.com/koordinates/kart/pull/327)
  * Bugfixes:
    - `sno meta set` didn't allow updates to `schema.json`
    - Fixed a potential `KeyError` in `Schema._try_align`
    - Fixed a potential `unexpected NoneType` in `WorkingCopy.is_dirty`
    - Imports now preserve fixed-precision numeric types in most situations.
    - Imports now preserve length of text/string fields.
-   - Imported fields of type `numeric` now stored internally as strings, as required by datasets V2 spec. [#325](https://github.com/koordinates/sno/pull/325)
+   - Imported fields of type `numeric` now stored internally as strings, as required by datasets V2 spec. [#325](https://github.com/koordinates/kart/pull/325)
 
 
 ## 0.6.0
 
 ### Major changes in this release
 
- * Newly created Sno repositories no longer have git internals visible in the main folder - they are hidden away in a '.sno' folder. [#147](https://github.com/koordinates/sno/issues/147)
- * The working copy can now be a PostgreSQL / PostGIS database (previously only GPKG working copies were supported). The commands `init`, `clone` and `create-workingcopy` now all accept working copy paths in the form `postgresql://[HOST]/DBNAME/SCHEMA` [#267](https://github.com/koordinates/sno/issues/267)
+ * Newly created Sno repositories no longer have git internals visible in the main folder - they are hidden away in a '.sno' folder. [#147](https://github.com/koordinates/kart/issues/147)
+ * The working copy can now be a PostgreSQL / PostGIS database (previously only GPKG working copies were supported). The commands `init`, `clone` and `create-workingcopy` now all accept working copy paths in the form `postgresql://[HOST]/DBNAME/SCHEMA` [#267](https://github.com/koordinates/kart/issues/267)
      - Read the documentation at `docs/POSTGIS_WC.md`
- * Patches that create or delete datasets are now supported in Datasets V2 [#239](https://github.com/koordinates/sno/issues/239)
+ * Patches that create or delete datasets are now supported in Datasets V2 [#239](https://github.com/koordinates/kart/issues/239)
 
 ### Minor features / fixes:
 
- * `apply` and `import` no longer create empty commits unless you specify `--allow-empty` [#243](https://github.com/koordinates/sno/issues/243), [#245](https://github.com/koordinates/sno/issues/245)
- * `apply` can now apply patches to branches other than `HEAD` [#294](https://github.com/koordinates/sno/issues/294)
- * `apply`, `commit` and `merge` commands now optimise repositories after committing, to avoid poor repo performance. [#250](https://github.com/koordinates/sno/issues/250)
- * `commit` now checks that the diff to be committed matches the schema, and rejects diffs that do not - this is possible in working copy formats that have relatively lax type enforcement, ie GPKG [#300](https://github.com/koordinates/sno/pull/300)
- *  Added GPKG support for Sno types that GPKG doesn't support - they are approximated as strings. [#304](https://github.com/koordinates/sno/pull/304)
- *  `schema.json` no longer stores attributes that are null - a missing attribute has the same meaning as that attribute being present and null. [#304](https://github.com/koordinates/sno/pull/304)
+ * `apply` and `import` no longer create empty commits unless you specify `--allow-empty` [#243](https://github.com/koordinates/kart/issues/243), [#245](https://github.com/koordinates/kart/issues/245)
+ * `apply` can now apply patches to branches other than `HEAD` [#294](https://github.com/koordinates/kart/issues/294)
+ * `apply`, `commit` and `merge` commands now optimise repositories after committing, to avoid poor repo performance. [#250](https://github.com/koordinates/kart/issues/250)
+ * `commit` now checks that the diff to be committed matches the schema, and rejects diffs that do not - this is possible in working copy formats that have relatively lax type enforcement, ie GPKG [#300](https://github.com/koordinates/kart/pull/300)
+ *  Added GPKG support for Sno types that GPKG doesn't support - they are approximated as strings. [#304](https://github.com/koordinates/kart/pull/304)
+ *  `schema.json` no longer stores attributes that are null - a missing attribute has the same meaning as that attribute being present and null. [#304](https://github.com/koordinates/kart/pull/304)
  * `data ls` now accepts an optional ref argument
  * `meta get` now accepts a `--ref=REF` option
  * `clone` now accepts a `--branch` option to clone a specific branch.
- * `switch BRANCH` now switches to a newly created local branch that tracks `BRANCH`, if `BRANCH` is a remote branch and not a local branch [#259](https://github.com/koordinates/sno/issues/259)
+ * `switch BRANCH` now switches to a newly created local branch that tracks `BRANCH`, if `BRANCH` is a remote branch and not a local branch [#259](https://github.com/koordinates/kart/issues/259)
  * `gc` command added (delegates to `git gc`)
- * Bugfix - don't drop the user-supplied authority from the supplied CRS and generate a new unrelated one. [#278](https://github.com/koordinates/sno/issues/278)
- * Bugfix - generated CRS numbers are now within the user range: 200000 to 209199 [#296](https://github.com/koordinates/sno/issues/296)
+ * Bugfix - don't drop the user-supplied authority from the supplied CRS and generate a new unrelated one. [#278](https://github.com/koordinates/kart/issues/278)
+ * Bugfix - generated CRS numbers are now within the user range: 200000 to 209199 [#296](https://github.com/koordinates/kart/issues/296)
 
 ## 0.5.0
 
@@ -117,9 +117,9 @@ Existing commands are backward compatible with V1 datasets, however some new fun
 
 #### Missing functionality in Datasets V2
 
- * String primary keys and tables without primary keys are not yet supported. [#212](https://github.com/koordinates/sno/issues/212)
- * Changing the primary key column is not yet supported. [#238](https://github.com/koordinates/sno/issues/238)
- * Patches which create or delete datasets are not supported. [#239](https://github.com/koordinates/sno/issues/239)
+ * String primary keys and tables without primary keys are not yet supported. [#212](https://github.com/koordinates/kart/issues/212)
+ * Changing the primary key column is not yet supported. [#238](https://github.com/koordinates/kart/issues/238)
+ * Patches which create or delete datasets are not supported. [#239](https://github.com/koordinates/kart/issues/239)
  * Schema changes might not be correctly interpreted if too many changes are made at once (eg adding a new column with the same name as a deleted column - sno may incorrectly assume it is the same column).
     - It is safest to commit schema changes to any existing columns, then commit schema changes adding any new columns, then commit any feature changes.
 
@@ -133,51 +133,51 @@ Existing commands are backward compatible with V1 datasets, however some new fun
 
 ### Other changes in this release
 
- * Added `sno create-patch <refish>` - creates a JSON patch file, which can be applied using `sno apply` [#210](https://github.com/koordinates/sno/issues/210)
- * Added `sno data ls` - shows a list of datasets in the sno repository [#203](https://github.com/koordinates/sno/issues/203)
- * `sno help [command]` is a synonym for `sno [subcommand] --help` [#221](https://github.com/koordinates/sno/issues/221)
- * `sno clone` now support shallow clones (`--depth N`) to avoid cloning a repo's entire history [#174](https://github.com/koordinates/sno/issues/174)
- * `sno log` now supports JSON output with `--output-format json` [#170](https://github.com/koordinates/sno/issues/170)
- * `sno meta get` now prints text items as text (not encoded as JSON) [#211](https://github.com/koordinates/sno/issues/211)
- * `sno meta get` without arguments now outputs multiple datasets [#217](https://github.com/koordinates/sno/issues/217)
- * `sno diff` and `sno show` now accept a `--crs` parameter to reproject output [#213](https://github.com/koordinates/sno/issues/213)
- * Streaming diffs: less time until first change is shown when diffing large changes. [#156](https://github.com/koordinates/sno/issues/156)
- * Working copies are now created automatically. [#192](https://github.com/koordinates/sno/issues/192)
- * Commands which are misspelled now suggest the correct spelling [#199](https://github.com/koordinates/sno/issues/199)
- * Bugfix: operations that should immediately fail due to dirty working copy no longer partially succeed. [#181](https://github.com/koordinates/sno/issues/181)
+ * Added `sno create-patch <refish>` - creates a JSON patch file, which can be applied using `sno apply` [#210](https://github.com/koordinates/kart/issues/210)
+ * Added `sno data ls` - shows a list of datasets in the sno repository [#203](https://github.com/koordinates/kart/issues/203)
+ * `sno help [command]` is a synonym for `sno [subcommand] --help` [#221](https://github.com/koordinates/kart/issues/221)
+ * `sno clone` now support shallow clones (`--depth N`) to avoid cloning a repo's entire history [#174](https://github.com/koordinates/kart/issues/174)
+ * `sno log` now supports JSON output with `--output-format json` [#170](https://github.com/koordinates/kart/issues/170)
+ * `sno meta get` now prints text items as text (not encoded as JSON) [#211](https://github.com/koordinates/kart/issues/211)
+ * `sno meta get` without arguments now outputs multiple datasets [#217](https://github.com/koordinates/kart/issues/217)
+ * `sno diff` and `sno show` now accept a `--crs` parameter to reproject output [#213](https://github.com/koordinates/kart/issues/213)
+ * Streaming diffs: less time until first change is shown when diffing large changes. [#156](https://github.com/koordinates/kart/issues/156)
+ * Working copies are now created automatically. [#192](https://github.com/koordinates/kart/issues/192)
+ * Commands which are misspelled now suggest the correct spelling [#199](https://github.com/koordinates/kart/issues/199)
+ * Bugfix: operations that should immediately fail due to dirty working copy no longer partially succeed. [#181](https://github.com/koordinates/kart/issues/181)
  * Bugfix: some column datatype conversion issues during import and checkout.
- * Linux: Add openssh client dependency into rpm & deb packages. [#121](https://github.com/koordinates/sno/issues/121)
- * Windows: Fix missing PROJ data files in packages. [#235](https://github.com/koordinates/sno/issues/235)
+ * Linux: Add openssh client dependency into rpm & deb packages. [#121](https://github.com/koordinates/kart/issues/121)
+ * Windows: Fix missing PROJ data files in packages. [#235](https://github.com/koordinates/kart/issues/235)
 
 ## 0.4.1
 
 ### Packaging fix:
 
-* packaging: Fix issue with broken git component paths in packages on macOS and Linux ([#143](https://github.com/koordinates/sno/issues/143))
+* packaging: Fix issue with broken git component paths in packages on macOS and Linux ([#143](https://github.com/koordinates/kart/issues/143))
 * packaging: Exclude dev dependency in macOS package
 
 ### Minor features / fixes:
 
-* Added a `sno meta get` command for viewing dataset metadata ([#136](https://github.com/koordinates/sno/issues/136))
-* `merge`, `commit`, `init`, `import` commands can now take commit messages as files with `--message=@filename.txt`. This replaces the `sno commit -F` option ([#138](https://github.com/koordinates/sno/issues/138))
-* `import`: Added `--table-info` option to set dataset metadata, when it can't be autodetected from the source database ([#139](https://github.com/koordinates/sno/issues/139))
-* `pull`, `push`, `fetch`, `clone` commands now show progress - disabled with `--quiet` ([#144](https://github.com/koordinates/sno/issues/144))
-* `import` now works while on an empty branch ([#149](https://github.com/koordinates/sno/issues/149))
+* Added a `sno meta get` command for viewing dataset metadata ([#136](https://github.com/koordinates/kart/issues/136))
+* `merge`, `commit`, `init`, `import` commands can now take commit messages as files with `--message=@filename.txt`. This replaces the `sno commit -F` option ([#138](https://github.com/koordinates/kart/issues/138))
+* `import`: Added `--table-info` option to set dataset metadata, when it can't be autodetected from the source database ([#139](https://github.com/koordinates/kart/issues/139))
+* `pull`, `push`, `fetch`, `clone` commands now show progress - disabled with `--quiet` ([#144](https://github.com/koordinates/kart/issues/144))
+* `import` now works while on an empty branch ([#149](https://github.com/koordinates/kart/issues/149))
 
 ## 0.4.0
 
 ### Major changes in this release
 
 * Basic conflict resolution:
-    - `sno merge` now puts the repo in a merging state when there are conflicts ([#80](https://github.com/koordinates/sno/issues/80))
-    - Added `sno conflicts` to list conflicts ([#84](https://github.com/koordinates/sno/issues/84))
-    - Added `sno resolve` ([#101](https://github.com/koordinates/sno/issues/101))
-    - Added `sno merge --continue`  ([#94](https://github.com/koordinates/sno/issues/94))
+    - `sno merge` now puts the repo in a merging state when there are conflicts ([#80](https://github.com/koordinates/kart/issues/80))
+    - Added `sno conflicts` to list conflicts ([#84](https://github.com/koordinates/kart/issues/84))
+    - Added `sno resolve` ([#101](https://github.com/koordinates/kart/issues/101))
+    - Added `sno merge --continue`  ([#94](https://github.com/koordinates/kart/issues/94))
 * Major improvements to `sno import` and `sno init --import`:
-    - Can now import from postgres databases ([#90](https://github.com/koordinates/sno/issues/90))
-    - Multiple tables can be imported at once ([#118](https://github.com/koordinates/sno/issues/118))
-* Added `sno show`: shows a commit. With `-o json` generates a patch ([#48](https://github.com/koordinates/sno/issues/48))
-* Added `sno apply` to apply the patches generated by `sno show -o json` ([#61](https://github.com/koordinates/sno/issues/61))
+    - Can now import from postgres databases ([#90](https://github.com/koordinates/kart/issues/90))
+    - Multiple tables can be imported at once ([#118](https://github.com/koordinates/kart/issues/118))
+* Added `sno show`: shows a commit. With `-o json` generates a patch ([#48](https://github.com/koordinates/kart/issues/48))
+* Added `sno apply` to apply the patches generated by `sno show -o json` ([#61](https://github.com/koordinates/kart/issues/61))
 
 ### Minor features / fixes:
 
@@ -189,23 +189,23 @@ Existing commands are backward compatible with V1 datasets, however some new fun
     - Added `--message` to customize the commit message
     - `--list` no longer requires a repository
 * `sno init --import` enhancements:
-    - imports are much faster ([#55](https://github.com/koordinates/sno/issues/55))
+    - imports are much faster ([#55](https://github.com/koordinates/kart/issues/55))
     - now imports _all_ tables from database, doesn't allow table to be specified
 * Many JSON output improvements:
-    - JSON output is specified with `-o json` instead of `--json` ([#98](https://github.com/koordinates/sno/issues/98))
-    - Added syntax highlighting to JSON output when viewed in a terminal ([#54](https://github.com/koordinates/sno/issues/54))
-    - `sno diff` JSON output layout has changed - features are now flat objects instead of GeoJSON objects. This is much more compact ([#71](https://github.com/koordinates/sno/issues/71))
+    - JSON output is specified with `-o json` instead of `--json` ([#98](https://github.com/koordinates/kart/issues/98))
+    - Added syntax highlighting to JSON output when viewed in a terminal ([#54](https://github.com/koordinates/kart/issues/54))
+    - `sno diff` JSON output layout has changed - features are now flat objects instead of GeoJSON objects. This is much more compact ([#71](https://github.com/koordinates/kart/issues/71))
     - Added JSON output option for most commands
-    - Added `--json-style` option to several commands to control JSON formatting ([#70](https://github.com/koordinates/sno/issues/70))
+    - Added `--json-style` option to several commands to control JSON formatting ([#70](https://github.com/koordinates/kart/issues/70))
 * `sno diff`:
-    - `a..b` now refers to the same changes as `sno log a..b` ([#116](https://github.com/koordinates/sno/issues/116))
-    - can now diff against tree objects, particularly the empty tree ([#53](https://github.com/koordinates/sno/issues/53))
+    - `a..b` now refers to the same changes as `sno log a..b` ([#116](https://github.com/koordinates/kart/issues/116))
+    - can now diff against tree objects, particularly the empty tree ([#53](https://github.com/koordinates/kart/issues/53))
     - can now view some subset of the changes by supplying filter args, ie `[dataset[:pk]]`
 * `sno commit`:
-    - can now commit some subset of the changes by supplying filter args, ie `[dataset[:pk]]` ([#69](https://github.com/koordinates/sno/issues/69))
-* removed `import-gpkg` command; use `import` instead ([#85](https://github.com/koordinates/sno/issues/85))
-* Error messages now go to stderr instead of stdout ([#57](https://github.com/koordinates/sno/issues/57))
-* Error conditions now use exit codes to indicate different types of errors ([#46](https://github.com/koordinates/sno/issues/46))
+    - can now commit some subset of the changes by supplying filter args, ie `[dataset[:pk]]` ([#69](https://github.com/koordinates/kart/issues/69))
+* removed `import-gpkg` command; use `import` instead ([#85](https://github.com/koordinates/kart/issues/85))
+* Error messages now go to stderr instead of stdout ([#57](https://github.com/koordinates/kart/issues/57))
+* Error conditions now use exit codes to indicate different types of errors ([#46](https://github.com/koordinates/kart/issues/46))
 
 ## 0.3.1
 
@@ -241,7 +241,7 @@ We have an initial preview available of our Sno repository hosting. This allows 
 ### Compatibility
 
 
-Repositories created with Sno v0.2 are compatible with v0.3. For assistance upgrading any v0.1 repositories, please read our [upgrade guide](https://github.com/koordinates/sno/wiki/Upgrading).
+Repositories created with Sno v0.2 are compatible with v0.3. For assistance upgrading any v0.1 repositories, please read our [upgrade guide](https://github.com/koordinates/kart/wiki/Upgrading).
 
 
 ## 0.2.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,13 +14,13 @@ Requirements (install via Homebrew/somehow):
 * jq
 
 ```console
-$ git clone git@github.com:koordinates/sno.git
-$ cd sno
+$ git clone git@github.com:koordinates/kart.git
+$ cd kart
 $ make
 
 # check it's working
 $ venv/bin/kart --version
-Kart v0.9.1.dev0, Copyright (c) Sno Contributors
+Kart v0.9.1.dev0, Copyright (c) Kart Contributors
 » GDAL v3.0.4
 » PyGit2 v1.1.0; Libgit2 v0.99.0; Git v2.25.1.windows.1
 » APSW v3.30.1-r3; SQLite v3.30.1; SpatiaLite v5.0.0-beta0
@@ -34,13 +34,13 @@ Requirements:
 * wget
 
 ```console
-$ git clone git@github.com:koordinates/sno.git
-$ cd sno
+$ git clone git@github.com:koordinates/kart.git
+$ cd kart
 $ make
 
 # check it's working
 $ venv/bin/kart --version
-Kart v0.9.1.dev0, Copyright (c) Sno Contributors
+Kart v0.9.1.dev0, Copyright (c) Kart Contributors
 » GDAL v3.0.4
 » PyGit2 v1.1.0; Libgit2 v0.99.0; Git v2.25.1.windows.1
 » APSW v3.30.1-r3; SQLite v3.30.1; SpatiaLite v5.0.0-beta0
@@ -60,13 +60,13 @@ Requirements:
 Run the following from the "x64 Native Tools Command Prompt for VS 2019":
 
 ```console
-> git clone git@github.com:koordinates/sno.git
-> cd sno
+> git clone git@github.com:koordinates/kart.git
+> cd kart
 > nmake /F makefile.vc
 
 # check it's working
 > venv\Scripts\kart --version
-Kart v0.9.1.dev0, Copyright (c) Sno Contributors
+Kart v0.9.1.dev0, Copyright (c) Kart Contributors
 » GDAL v3.0.4
 » PyGit2 v1.1.0; Libgit2 v0.99.0; Git v2.25.1.windows.1
 » APSW v3.30.1-r3; SQLite v3.30.1; SpatiaLite v5.0.0-beta0

--- a/HOWTO-RELEASE.md
+++ b/HOWTO-RELEASE.md
@@ -29,7 +29,7 @@ This process only supports a single release branch (master). It'll need to be ex
    $ git push origin v1.2.3
    ```
 
-9. CI will build and sign the installers and packages, and create a [new draft release in github](https://github.com/koordinates/sno/releases). Check CI passes and the RPM/DEB/MSI/PKG archives are all attached.
+9. CI will build and sign the installers and packages, and create a [new draft release in github](https://github.com/koordinates/kart/releases). Check CI passes and the RPM/DEB/MSI/PKG archives are all attached.
 
 10. Write the release notes. Use `CHANGELOG.md` as a starting point. Topic/section suggestions:
     * Overview
@@ -43,8 +43,8 @@ This process only supports a single release branch (master). It'll need to be ex
 12. If it's _not_ an alpha/beta/candidate release, update the Homebrew Tap:
 
     1. Get the SHA256 hash of the macOS PKG installer: `sha256 Kart-1.2.3.pkg`
-    2. Pull [homebrew-sno](https://github.com/koordinates/homebrew-sno/)
-    3. Edit `Casks/sno.rb` and update the `version` and `sha256` fields
+    2. Pull [homebrew-kart](https://github.com/koordinates/homebrew-kart/)
+    3. Edit `Casks/kart.rb` and update the `version` and `sha256` fields
     4. Commit with a message like "Update to release v1.2.3"
     5. Push
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
 Kart: Distributed version-control for datasets
 ---------------------------------------------
 
-![Build](https://github.com/koordinates/sno/workflows/Build/badge.svg?event=push)
+![Build](https://github.com/koordinates/kart/workflows/Build/badge.svg?event=push)
 
 ## Installing
 
 ### Upgrading to v0.9.0
 
-See the [v0.9.0 release notes](https://github.com/koordinates/sno/releases/tag/v0.9.0) for changes, upgrading, and compatibility notes.
+See the [v0.9.0 release notes](https://github.com/koordinates/kart/releases/tag/v0.9.0) for changes, upgrading, and compatibility notes.
 
 ### Windows
 
-Download the .msi installer from the [release page](https://github.com/koordinates/sno/releases/tag/v0.9.0).
+Download the .msi installer from the [release page](https://github.com/koordinates/kart/releases/tag/v0.9.0).
 
 > 💡 If Windows Defender SmartScreen says "it prevented an unrecognized app from starting" after downloading, you'll need to click "Run anyway".
 
 ### macOS
 
-Download the .pkg installer from the [release page](https://github.com/koordinates/sno/releases/tag/v0.9.0);
+Download the .pkg installer from the [release page](https://github.com/koordinates/kart/releases/tag/v0.9.0);
 
-Or use [Homebrew](https://brew.sh) to install: `brew cask install koordinates/sno/sno`
+Or use [Homebrew](https://brew.sh) to install: `brew cask install koordinates/kart/kart`
 
 ### Linux
 
-For Debian/Ubuntu-based distributions, download the .deb package from the [release page](https://github.com/koordinates/sno/releases/tag/v0.9.0) and install via `dpkg -i kart_*.deb`.
+For Debian/Ubuntu-based distributions, download the .deb package from the [release page](https://github.com/koordinates/kart/releases/tag/v0.9.0) and install via `dpkg -i kart_*.deb`.
 
-For RPM-based distributions, download the .rpm package from the [release page](https://github.com/koordinates/sno/releases/tag/v0.9.0) and install via `rpm -i kart-*.rpm`.
+For RPM-based distributions, download the .rpm package from the [release page](https://github.com/koordinates/kart/releases/tag/v0.9.0) and install via `rpm -i kart-*.rpm`.
 
 ### Source
 
@@ -33,7 +33,7 @@ For Kart development see the [Contributing Notes](CONTRIBUTING.md).
 
 ## Usage
 
-See the [documentation](https://github.com/koordinates/sno/wiki) for tutorials and reference.
+See the [documentation](https://github.com/koordinates/kart/wiki) for tutorials and reference.
 
 > ##### 💡 If you're new to git
 > Configure the identity you will use for Kart commits with:

--- a/sno/data.py
+++ b/sno/data.py
@@ -65,7 +65,7 @@ def data_version(ctx, output_format):
         click.echo(f"This Kart repo uses Datasets v{version}")
         if version >= 1:
             click.echo(
-                f"(See https://github.com/koordinates/sno/blob/master/docs/DATASETS_v{version}.md)"
+                f"(See https://github.com/koordinates/kart/blob/master/docs/DATASETS_v{version}.md)"
             )
     elif output_format == "json":
         dump_json_output({"kart.data.version": version}, sys.stdout)

--- a/sno/ogr_import_source.py
+++ b/sno/ogr_import_source.py
@@ -33,7 +33,7 @@ from .working_copy import gpkg_adapter
 FORMAT_TO_OGR_MAP = {
     "GPKG": "GPKG",
     "SHP": "ESRI Shapefile",
-    # https://github.com/koordinates/sno/issues/86
+    # https://github.com/koordinates/kart/issues/86
     # 'TAB': 'MapInfo File',
     "PG": "PostgreSQL",
 }

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -276,7 +276,7 @@ def _compare_ogr_and_gpkg_meta_items(dataset, gpkg_dataset):
     "source_format,source_ogr_driver",
     [
         ("SHP", "ESRI Shapefile"),
-        # https://github.com/koordinates/sno/issues/86
+        # https://github.com/koordinates/kart/issues/86
         # This test starts by converting a GPKG into a TAB, and then imports then TAB.
         # But the TAB ended up with very broken SRS info, and then during import GDAL
         # failed to find an EPSG code for the projection.

--- a/vendor/github-download.sh
+++ b/vendor/github-download.sh
@@ -9,7 +9,7 @@ if ! command -v jq >/dev/null; then
     exit 2
 fi
 
-REPO=koordinates/sno
+REPO=koordinates/kart
 WORKFLOW=build.yml
 
 if [ -n "${1-}" ]; then


### PR DESCRIPTION
Can be merged as soon as github.com/koordinates/sno is renamed to github.com/koordinates/kart
Doesn't need to be merged immediately, since github.com promises to redirect from old name to new name.
