### PR TITLE
Switch to sqlalchemy import source for GPKG.

### DIFF
--- a/kart/init.py
+++ b/kart/init.py
@@ -245,9 +245,7 @@ def import_(
             "Illegal usage: '--output-format=json' only supports --list"
         )
     if do_list:
-        OgrImportSource.open(source, None).print_table_list(
-            do_json=output_format == "json"
-        )
+        ImportSource.open(source).print_table_list(do_json=output_format == "json")
         return
 
     repo = ctx.obj.repo
@@ -260,7 +258,7 @@ def import_(
         )
         do_checkout = True
 
-    base_import_source = OgrImportSource.open(source, None)
+    base_import_source = ImportSource.open(source)
     if all_tables:
         tables = base_import_source.get_tables().keys()
     elif not tables:

--- a/kart/ogr_import_source.py
+++ b/kart/ogr_import_source.py
@@ -22,7 +22,7 @@ from .exceptions import (
 from .geometry import Geometry, ogr_to_gpkg_geom
 from .import_source import ImportSource
 from .ogr_util import get_type_value_adapter
-from .output_util import dump_json_output, get_input_mode, InputMode
+from .output_util import dump_json_output
 from .schema import Schema, ColumnSchema
 from .sqlalchemy.gpkg import Db_GPKG
 from .sqlalchemy.postgis import Db_Postgis
@@ -269,24 +269,6 @@ class OgrImportSource(ImportSource):
             for table_name, pretty_name in names.items():
                 click.echo(f"  {table_name} - {pretty_name}")
         return names
-
-    def prompt_for_table(self, prompt):
-        table_list = list(self.get_tables().keys())
-
-        if len(table_list) == 1:
-            return table_list[0]
-        else:
-            self.print_table_list()
-            if get_input_mode() == InputMode.NO_INPUT:
-                raise NotFound("No table specified", exit_code=NO_TABLE)
-            t_choices = click.Choice(choices=table_list)
-            t_default = table_list[0] if len(table_list) == 1 else None
-            return click.prompt(
-                f"\n{prompt}",
-                type=t_choices,
-                show_choices=False,
-                default=t_default,
-            )
 
     def __str__(self):
         s = str(self.source)

--- a/kart/sqlalchemy/base.py
+++ b/kart/sqlalchemy/base.py
@@ -16,6 +16,11 @@ class BaseDb:
         raise NotImplementedError()
 
     @classmethod
+    def create_preparer(cls, engine):
+        """Create an identifier preparer for the given engine."""
+        raise NotImplementedError()
+
+    @classmethod
     def _pool_class(cls):
         # Ordinarily, sqlalchemy engine's maintain a pool of connections ready to go.
         # When running tests, we run lots of kart commands, and each command creates an engine, and each engine maintains

--- a/kart/sqlalchemy/gpkg.py
+++ b/kart/sqlalchemy/gpkg.py
@@ -1,7 +1,7 @@
-import logging
-
+import os
 
 import sqlalchemy
+from sqlalchemy.dialects.sqlite.base import SQLiteIdentifierPreparer
 from pysqlite3 import dbapi2 as sqlite
 
 from kart import spatialite_path
@@ -12,8 +12,6 @@ class Db_GPKG(BaseDb):
     """Functionality for using sqlalchemy to connect to a GPKG database."""
 
     GPKG_CACHE_SIZE_MiB = 200
-
-    L = logging.getLogger("kart.sqlalchemy.Db_GPKG")
 
     @classmethod
     def create_engine(cls, path):
@@ -27,6 +25,42 @@ class Db_GPKG(BaseDb):
             dbcur.execute("PRAGMA foreign_keys = ON;")
             dbcur.execute(f"PRAGMA cache_size = -{cls.GPKG_CACHE_SIZE_MiB * 1024};")
 
+        path = os.path.expanduser(path)
         engine = sqlalchemy.create_engine(f"sqlite:///{path}", module=sqlite)
         sqlalchemy.event.listen(engine, "connect", _on_connect)
         return engine
+
+    @classmethod
+    def create_preparer(cls, engine):
+        return SQLiteIdentifierPreparer(engine.dialect)
+
+    @classmethod
+    def list_tables(cls, sess, db_schema=None, with_titles=False):
+        if db_schema is not None:
+            raise RuntimeError("GPKG files don't have a db_schema")
+
+        if with_titles:
+            gpkg_contents_exists = sess.scalar(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='gpkg_contents';",
+            )
+            if gpkg_contents_exists:
+                r = sess.execute(
+                    """
+                    SELECT SM.name, GC.identifier FROM sqlite_master SM
+                    LEFT OUTER JOIN gpkg_contents GC ON GC.table_name = SM.name
+                    WHERE SM.type='table'
+                    AND SM.name NOT LIKE 'sqlite%' AND SM.name NOT LIKE 'gpkg%' and SM.name NOT LIKE 'rtree%';
+                    """
+                )
+                return {row['name']: row['identifier'] for row in r}
+
+        r = sess.execute(
+            """
+            SELECT name FROM sqlite_master SM WHERE type='table'
+            AND name NOT LIKE 'sqlite%' AND name NOT LIKE 'gpkg%' and name NOT LIKE 'rtree%';
+            """
+        )
+        if with_titles:
+            return {row['name']: None for row in r}
+        else:
+            return [row['name'] for row in r]

--- a/kart/sqlalchemy/mysql.py
+++ b/kart/sqlalchemy/mysql.py
@@ -1,6 +1,8 @@
 from urllib.parse import urlsplit, urlunsplit
 
 import sqlalchemy
+from sqlalchemy.dialects.mysql.base import MySQLIdentifierPreparer
+
 
 from .base import BaseDb
 
@@ -29,3 +31,7 @@ class Db_MySql(BaseDb):
         sqlalchemy.event.listen(engine, "checkout", _on_checkout)
 
         return engine
+
+    @classmethod
+    def create_preparer(cls, engine):
+        return MySQLIdentifierPreparer(engine.dialect)

--- a/kart/sqlalchemy/postgis.py
+++ b/kart/sqlalchemy/postgis.py
@@ -1,6 +1,7 @@
 from binascii import unhexlify
 
 import sqlalchemy
+from sqlalchemy.dialects.postgresql.base import PGIdentifierPreparer
 import psycopg2
 from psycopg2.extensions import Binary, new_type, register_adapter, register_type
 
@@ -107,3 +108,7 @@ class Db_Postgis(BaseDb):
         sqlalchemy.event.listen(engine, "checkout", _on_checkout)
 
         return engine
+
+    @classmethod
+    def create_preparer(cls, engine):
+        return PGIdentifierPreparer(engine.dialect)

--- a/kart/sqlalchemy/sqlserver.py
+++ b/kart/sqlalchemy/sqlserver.py
@@ -3,6 +3,8 @@ import re
 from urllib.parse import urlsplit, urlunsplit
 
 import sqlalchemy
+from sqlalchemy.dialects.mssql.base import MSIdentifierPreparer
+
 
 from kart.exceptions import NotFound, NO_DRIVER
 from .base import BaseDb
@@ -36,6 +38,10 @@ class Db_SqlServer(BaseDb):
 
         engine = sqlalchemy.create_engine(msurl, poolclass=cls._pool_class())
         return engine
+
+    @classmethod
+    def create_preparer(cls, engine):
+        return MSIdentifierPreparer(engine.dialect)
 
     @classmethod
     def get_odbc_drivers(cls):

--- a/kart/sqlalchemy_import_source.py
+++ b/kart/sqlalchemy_import_source.py
@@ -1,0 +1,242 @@
+import functools
+import os
+import sys
+
+import click
+import sqlalchemy
+
+from .exceptions import (
+    NotFound,
+    NotYetImplemented,
+    NO_TABLE,
+)
+from .geometry import Geometry
+from .import_source import ImportSource
+from .sqlalchemy import DbType, separate_last_path_part
+from .output_util import dump_json_output
+from .utils import ungenerator, chunk
+
+
+class SqlAlchemyImportSource(ImportSource):
+    """
+    ImportSource that uses SqlAlchemy directly to import into Kart.
+    Currently only GPKG is supported, but in theory should work for Postgis, SQL Server, MySQL.
+    """
+
+    CURSOR_SIZE = 10000
+
+    @classmethod
+    def open(cls, spec):
+        db_type = DbType.from_spec(spec)
+        if db_type is None:
+            raise cls._bad_import_source_spec(spec)
+
+        # TODO - add support for other DB types.
+        if db_type is not DbType.GPKG:
+            raise NotYetImplemented(
+                "Only GPKG is currently supported by the SqlAlchemyImportSource"
+            )
+
+        path_length = db_type.path_length(spec)
+        longest_allowed_path_length = db_type.path_length_for_table
+        shortest_allowed_path_length = max(
+            db_type.path_length_for_table_container - 1, 0
+        )
+
+        if (
+            path_length > longest_allowed_path_length
+            or path_length < shortest_allowed_path_length
+        ):
+            raise cls._bad_import_source_spec(spec)
+
+        connect_url = spec
+        db_schema = None
+        table = None
+
+        # Handle the case where specification already points to a single table.
+        if path_length == db_type.path_length_for_table:
+            connect_url, table = separate_last_path_part(connect_url)
+            path_length -= 1
+
+        # Handle the case where specification points to a database schema (or similar).
+        if path_length > shortest_allowed_path_length:
+            connect_url, db_schema = separate_last_path_part(connect_url)
+
+        engine = db_type.class_.create_engine(connect_url)
+        return SqlAlchemyImportSource(spec, db_type, engine, db_schema, table)
+
+    @classmethod
+    def _bad_import_source_spec(self, spec):
+        return click.UsageError(
+            f"Unrecognised import-source specification: {spec}\n"
+            "Try one of:\n"
+            "  PATH.gpkg\n"
+            "  postgresql://HOST/DBNAME[/DBSCHEMA[/TABLE]]\n"
+            "  mssql://HOST/DBNAME[/DBSCHEMA[/TABLE]]\n"
+            "  mysql://HOST[/DBNAME[/TABLE]]"
+        )
+
+    def __init__(
+        self,
+        original_spec,
+        db_type,
+        engine,
+        db_schema,
+        table,
+        **meta_overrides,
+    ):
+        self.original_spec = original_spec
+        self.db_type = db_type
+        self.db_class = db_type.class_
+        self.engine = engine
+        self.preparer = self.db_class.create_preparer(engine)
+
+        self.db_schema = db_schema
+        self.table = table
+        self.meta_overrides = {k: v for k, v in meta_overrides.items() if v is not None}
+
+    @property
+    def source_name(self):
+        # TODO - this only works for GPKG.
+        return os.path.basename(self.original_spec)
+
+    def import_source_desc(self):
+        return f"Import from {self.source_name}:{self.table} to {self.dest_path}/"
+
+    def aggregate_import_source_desc(self, import_sources):
+        if len(import_sources) == 1:
+            return next(iter(import_sources)).import_source_desc()
+
+        desc = f"Import {len(import_sources)} datasets from {self.source_name}:"
+        for source in import_sources:
+            if source.dest_path == source.table:
+                desc += f"\n * {source.table}/"
+            else:
+                desc += f"\n * {source.dest_path} (from {source.table})"
+        return desc
+
+    @functools.lru_cache(maxsize=1)
+    def get_tables(self):
+        with self.engine.connect() as conn:
+            # TODO - this only works for GPKG
+            tables = self.db_class.list_tables(conn, self.db_schema, with_titles=True)
+
+        if self.table is not None:
+            return {self.table: self.tables.get(self.table)}
+        else:
+            return tables
+
+    def print_table_list(self, do_json=False):
+        tables = self.get_tables()
+        if do_json:
+            dump_json_output({"kart.tables/v1": tables}, sys.stdout)
+        else:
+            click.secho("Tables found:", bold=True)
+            for table_name, title in tables.items():
+                click.echo(f"  {table_name} - {title or ''}")
+        return tables
+
+    def check_table(self, table_name):
+        if table_name not in self.get_tables():
+            raise NotFound(
+                f"Table '{table_name}' not found",
+                exit_code=NO_TABLE,
+            )
+
+    def clone_for_table(self, table, primary_key=None, **meta_overrides):
+        meta_overrides = {**self.meta_overrides, **meta_overrides}
+        self.check_table(table)
+
+        if primary_key is not None:
+            raise NotYetImplemented(
+                "Sorry, overriding the primary key is not yet supported"
+            )
+
+        return SqlAlchemyImportSource(
+            self.original_spec,
+            self.db_type,
+            self.engine,
+            self.db_schema,
+            table,
+            **meta_overrides,
+        )
+
+    def get_meta_item(self, name):
+        if name in self.meta_overrides:
+            return self.meta_overrides[name]
+        elif name == "metadata.xml" and "xml_metadata" in self.meta_overrides:
+            return self.meta_overrides["xml_metadata"]
+        return self.meta_items.get(name)
+
+    @property
+    @functools.lru_cache(maxsize=1)
+    def meta_items(self):
+        # TODO - this only works for GPKG.
+        from kart.working_copy import gpkg_adapter
+
+        id_salt = f"{self.engine.url} {self.db_schema} {self.table}"
+        with self.engine.connect() as conn:
+            return dict(gpkg_adapter.all_v2_meta_items(conn, self.table, id_salt))
+
+    def crs_definitions(self):
+        for key, value in self.meta_items.items():
+            if key.startswith("crs/") and key.endswith(".wkt"):
+                yield key[4:-4], value
+
+    @ungenerator(dict)
+    def _sqlalchemy_row_to_kart_feature(self, sa_row):
+        # TODO - this only works for GPKG. Use the adapter code from working copies.
+        for key, value in sa_row.items():
+            if key in self.geometry_column_names:
+                yield (key, Geometry.of(value))
+            else:
+                yield key, value
+
+    def _sqlalchemy_to_kart_features(self, resultset):
+        for sa_row in resultset:
+            yield self._sqlalchemy_row_to_kart_feature(sa_row)
+
+    def quote(self, ident):
+        """Conditionally quote an identifier - eg if it is a reserved word or contains special characters."""
+        return self.preparer.quote(ident)
+
+    def features(self):
+        with self.engine.connect() as conn:
+            r = (
+                conn.execution_options(stream_results=True)
+                .execute(f"SELECT * FROM {self.quote(self.table)};")
+                .yield_per(self.CURSOR_SIZE)
+            )
+            yield from self._sqlalchemy_to_kart_features(r)
+
+    def _first_pk_values(self, row_pks):
+        # (123,) --> 123. we only handle one pk field
+        for x in row_pks:
+            assert len(x) == 1
+            yield x[0]
+
+    def get_features(self, row_pks, *, ignore_missing=False):
+        with self.engine.connect() as conn:
+            pk_field = self.primary_key
+            batch_query = sqlalchemy.text(
+                f"SELECT * FROM {self.quote(self.table)} "
+                f"WHERE {self.quote(pk_field)} IN :pks ;"
+            ).bindparams(sqlalchemy.bindparam("pks", expanding=True))
+
+            for batch in chunk(self._first_pk_values(row_pks), 1000):
+                r = conn.execute(batch_query, {"pks": batch})
+                yield from self._sqlalchemy_to_kart_features(r)
+
+    @property
+    @functools.lru_cache(maxsize=1)
+    def geometry_column_names(self):
+        return [c.name for c in self.schema.geometry_columns]
+
+    @property
+    @functools.lru_cache(maxsize=1)
+    def primary_key(self):
+        # TODO - this only works for GPKG.
+        from kart.working_copy import gpkg_adapter
+
+        with self.engine.connect() as conn:
+            return gpkg_adapter.pk(conn, self.table)


### PR DESCRIPTION
![](https://media1.giphy.com/media/l4FAZhmFIElckjrtC/giphy.gif)

## Description

No longer using OGR at all for GPKG imports - now only using sqlalchemy.

Kind of a proof-of-concept, getting the structure set up right - what we actually want is to use sqlalchemy for PostGIS imports. That would allow us to be more discerning about types than OGR, which would let us distinguish between timestamp-in-UTC and timestamp-without-timezone.

As a bonus, I'll probably get SQL Server and MySQL imports working too.