### PR TITLE
Switch PostGIS import to use sqlalchemy

### DIFF
--- a/kart/import_source.py
+++ b/kart/import_source.py
@@ -24,20 +24,20 @@ class ImportSource:
         return spec
 
     @classmethod
-    def open(cls, spec):
+    def open(cls, full_spec, table=None):
         from kart.sqlalchemy import DbType
 
-        spec = cls._remove_unnecessary_prefix(spec)
+        spec = cls._remove_unnecessary_prefix(str(full_spec))
 
         db_type = DbType.from_spec(spec)
-        if db_type == DbType.GPKG:
+        if db_type in (DbType.GPKG, DbType.POSTGIS):
             from .sqlalchemy_import_source import SqlAlchemyImportSource
 
-            return SqlAlchemyImportSource.open(spec)
+            return SqlAlchemyImportSource.open(spec, table=table)
         else:
             from .ogr_import_source import OgrImportSource
 
-            return OgrImportSource.open(spec)
+            return OgrImportSource.open(full_spec, table=table)
 
     @classmethod
     def check_valid(cls, import_sources, param_hint=None):

--- a/kart/init.py
+++ b/kart/init.py
@@ -17,7 +17,7 @@ from .cli_util import (
 )
 from .exceptions import InvalidOperation
 from .import_source import ImportSource
-from .ogr_import_source import OgrImportSource, FORMAT_TO_OGR_MAP
+from .ogr_import_source import FORMAT_TO_OGR_MAP
 from .pk_generation import PkGeneratingImportSource
 from .fast_import import fast_import_tables, ReplaceExisting
 from .repo import KartRepo, PotentialRepo

--- a/kart/sqlalchemy/adapter/gpkg.py
+++ b/kart/sqlalchemy/adapter/gpkg.py
@@ -170,7 +170,7 @@ class KartAdapter_GPKG(BaseKartAdapter, Db_GPKG):
             "table_name": table_name,
             "column_name": geom_columns[0].name,
             "geometry_type_name": type_name,
-            "srs_id": crs_util.get_identifier_int_from_dataset(v2_obj),
+            "srs_id": crs_util.get_identifier_int_from_dataset(v2_obj) or 0,
             "z": z,
             "m": m,
         }
@@ -508,7 +508,6 @@ class KartAdapter_GPKG(BaseKartAdapter, Db_GPKG):
     def _gpkg_meta_items_from_db(cls, sess, table_name, keys=None):
         """
         Returns metadata from the gpkg_* tables about this GPKG.
-        Keep this in sync with OgrImportSource.gpkg_meta_items for other datasource types.
         """
 
         QUERIES = {

--- a/kart/sqlalchemy/base.py
+++ b/kart/sqlalchemy/base.py
@@ -26,6 +26,19 @@ class BaseDb:
         return cls.preparer.quote(identifier)
 
     @classmethod
+    def list_tables(cls, sess, db_schema=None):
+        """
+        Find all the user tables (not system tables) in the database (or in a specific db_schema).
+        Returns a dict of {table_name: table_title}
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def db_schema_searchpath(cls, sess):
+        """Returns a list of the db_schemas that the connection is configured to search in by default."""
+        raise NotImplementedError()
+
+    @classmethod
     def _pool_class(cls):
         # Ordinarily, sqlalchemy engine's maintain a pool of connections ready to go.
         # When running tests, we run lots of kart commands, and each command creates an engine, and each engine

--- a/kart/sqlalchemy/postgis.py
+++ b/kart/sqlalchemy/postgis.py
@@ -139,3 +139,7 @@ class Db_Postgis(BaseDb):
             )
 
         return {row['name']: row['title'] for row in r}
+
+    @classmethod
+    def db_schema_searchpath(cls, sess):
+        return sess.scalar("SELECT current_schemas(true);")

--- a/kart/working_copy/db_server.py
+++ b/kart/working_copy/db_server.py
@@ -1,6 +1,7 @@
 import functools
 import re
 from urllib.parse import urlsplit, urlunsplit
+from pathlib import PurePosixPath
 
 import click
 from sqlalchemy.exc import DBAPIError
@@ -61,7 +62,7 @@ class DatabaseServer_WorkingCopy(BaseWorkingCopy):
 
         if path_length != required_path_length:
             if (path_length + 1) == required_path_length:
-                suggested_path = url.path / cls.default_db_schema(repo)
+                suggested_path = PurePosixPath(url.path) / cls.default_db_schema(repo)
                 suggested_uri = urlunsplit(
                     [url.scheme, url.netloc, str(suggested_path), url.query, ""]
                 )

--- a/tests/test_import_source.py
+++ b/tests/test_import_source.py
@@ -1,54 +1,9 @@
 import os
-import pytest
 
 from osgeo import gdal
 
-from kart.ogr_import_source import PostgreSQLImportSource
+from kart.ogr_import_source import postgres_url_to_ogr_conn_str
 from kart.repo import KartRepo
-
-
-def test_postgres_url_parsing():
-    func = PostgreSQLImportSource.postgres_url_to_ogr_conn_str
-    with pytest.raises(ValueError):
-        func("https://example.com/")
-
-    # this is valid (AFAICT), means connect on the default domain socket
-    # to the default database with the current posix user
-    assert func("postgres://") == "PG:"
-    assert func("postgresql://") == "PG:"
-    assert func("postgres:///") == "PG:"
-
-    assert func("postgres://myhost/") == "PG:host=myhost"
-    assert func("postgres:///?host=myhost") == "PG:host=myhost"
-    # querystring params take precedence
-    assert func("postgres://otherhost/?host=myhost") == "PG:host=myhost"
-
-    assert func("postgres://myhost:1234/") == "PG:host=myhost port=1234"
-    assert func("postgres://myhost/?port=1234") == "PG:host=myhost port=1234"
-    assert (
-        func("postgres://myhost/dbname?port=1234")
-        == "PG:dbname=dbname host=myhost port=1234"
-    )
-    # everything, including extra options
-    assert (
-        func("postgres://u:p@h:1234/d?client_encoding=utf16")
-        == "PG:client_encoding=utf16 dbname=d host=h password=p port=1234 user=u"
-    )
-
-    # domain socket hostnames starting with a '/' are handled, but
-    # must be url-quoted if they're part of the URL
-    assert (
-        func("postgres://%2Fvar%2Flib%2Fpostgresql/d")
-        == "PG:dbname=d host=/var/lib/postgresql"
-    )
-    # but url-quoting seems to be optional when they're in the querystring
-    assert (
-        func("postgres:///?host=/var/lib/postgresql") == "PG:host=/var/lib/postgresql"
-    )
-    assert (
-        func("postgres:///?host=%2Fvar%2Flib%2Fpostgresql")
-        == "PG:host=/var/lib/postgresql"
-    )
 
 
 def _dataset_col_types(dataset):
@@ -122,9 +77,7 @@ def test_import_various_field_types(tmp_path, postgis_db, cli_runner):
     }
 
     # Now generate a DBF file, and try again from there.
-    ogr_conn_str = PostgreSQLImportSource.postgres_url_to_ogr_conn_str(
-        os.environ["KART_POSTGRES_URL"]
-    )
+    ogr_conn_str = postgres_url_to_ogr_conn_str(os.environ["KART_POSTGRES_URL"])
     gdal.VectorTranslate(
         str(tmp_path / "typoes.dbf"),
         ogr_conn_str,


### PR DESCRIPTION
![](https://media2.giphy.com/media/ExGU3vxox8Pvy/giphy-downsized-medium.gif)

Uses the same code from working-copy adapters to import PostGIS tables into Kart.

Allows us to be more discerning about the difference between different PostGIS types, which is needed for mirroring.
