### PR TITLE
Postgres imports: Hide postgis internal views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 * A few bugfixes involving accurately roundtripping boolean and blob types through different working copy types.
 * Bugfix: 3D and 4D geometries are now properly roundtripped through SQL Server working copy.
 * Fix help text for discarding changes to refer to `kart restore` instead of `kart reset`, as `kart restore` is now the simplest way to discard changes. [#426](https://github.com/koordinates/kart/issues/426)
+* `import`: PostGIS internal views/tables are no longer listed by `--list` or imported by `--all-tables`, and can't be imported by name either. [#439](https://github.com/koordinates/kart/issues/439)
 
 ### Calculating feature counts for diffs
 

--- a/kart/sqlalchemy_import_source.py
+++ b/kart/sqlalchemy_import_source.py
@@ -155,10 +155,10 @@ class SqlAlchemyImportSource(ImportSource):
         if table in all_tables:
             if (
                 self.db_schema is None
-                and '.' in table
+                and "." in table
                 and self.db_type is not DbType.GPKG
             ):
-                db_schema, table = table.split('.', maxsplit=1)
+                db_schema, table = table.split(".", maxsplit=1)
                 return db_schema, table
             else:
                 return self.db_schema, table


### PR DESCRIPTION

## Description

Hides these views/tables from `kart import '<postgres-url>'`:

```
 extname | extschema |      relname      | relkind
---------+-----------+-------------------+---------
 postgis | public    | spatial_ref_sys   | r
 postgis | public    | geography_columns | v
 postgis | public    | geometry_columns  | v
 postgis | public    | raster_columns    | v
 postgis | public    | raster_overviews  | v
```

These aren't importable things and they just cause potential problems,
especially when used with `--all-tables` (but they are noisy when
listing/prompting for tables also)

## Related links:

re #434

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
