### PR TITLE
Add documentation for datasets V3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Kart v0.10.0 introduces a new repository structure, which is the default, dubbed
 
  * Entire repositories can be upgraded from V2 to V3 using `kart upgrade EXISTING_REPO NEW_REPO`.
  * Anything which works in a V2 repo should work in a V3 repo and vice versa.
- * V3 repos are much more performant when dealing with extremely large datasets.
+ * V3 repos are more performant for large datasets - compared to V2 repos where size-on-disk climbs quickly once dataset size exceeds 16 million features.
 
 ### Other major changes in this release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,22 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## 0.10.0 (UNRELEASED)
 
-### Major changes in this release
+Kart v0.10.0 introduces a new repository structure, which is the default, dubbed 'Datasets V3'. Datasets V2 continues to be supported, but all newly created repos are V3 going forward.
+
+### Datasets V3
+
+ * Entire repositories can be upgraded from V2 to V3 using `kart upgrade EXISTING_REPO NEW_REPO`.
+ * Anything which works in a V2 repo should work in a V3 repo and vice versa.
+ * V3 repos are much more performant when dealing with extremely large datasets.
+
+### Other major changes in this release
+
 * The working copy can now be a MySQL database (previously only GPKG, PostGIS and SQL Server working copies were supported). The commands `init`, `clone` and `create-workingcopy` now all accept working copy paths in the form `mysql://HOST/DBNAME` [#399](https://github.com/koordinates/kart/pull/399)
   - Read the documentation at [docs/MYSQL_WC.md](docs/MYSQL_WC.md)
 * Import of tables using `kart import` is now supported from any type of database that Kart also supports writing to as a working copy - namely, GPKG, PostGIS, SQL Server and MySQL.
+* Support for rapidly calculating or estimating feature-counts - see below.
 
-### Other changes
+### Other minor changes
 * Change to `kart data ls` JSON output, now includes whether repo is Kart or Sno branded.
 * Importing from a datasource now samples the first geometry to check the number of dimensions - in case the datasource actually has 3 or 4 dimensions but this fact is not stored in the column metadata (which is not necessarily required by all source types). [#337](https://github.com/koordinates/kart/issues/337)
 * Bugfix: Creating a working copy while switching branch now creates a working copy with the post-switch branch checked out, not the pre-switch branch.

--- a/docs/DATASETS_v1.md
+++ b/docs/DATASETS_v1.md
@@ -1,5 +1,9 @@
 # Datasets V1 (& earlier)
 
+[Datasets V3](Datasets_v3.md) is the current repository structure Kart uses - Datasets V1 is no longer supported except that Kart can upgrade an old repo from Datasets V1 to Datasets V3, using `kart upgrade SOURCE DEST`.
+
+Nevertheless, documentation for Datasets V1 follows.
+
 Repository Layout:
 
 ## v0.2 with working copy

--- a/docs/DATASETS_v2.md
+++ b/docs/DATASETS_v2.md
@@ -1,0 +1,36 @@
+# Datasets V2
+
+[Datasets V3](Datasets_v3.md) is the current repository structure Kart uses, and is a good starting point for learning about Datasets V2. Kart 0.10 continues to support Datasets V2, but all newly created repos will use Datasets V3.
+
+### Differences
+
+A V2 dataset is exactly like a V3 dataset, except:
+
+- The folder that contains the entire dataset is called `.sno-dataset` instead of `.table-dataset`.
+- Attaching a particular path structure to the dataset within the `path-structure.json` meta item is not supported - instead, all V2 datasets use the same path structure, known as the legacy path structure.
+
+#### Legacy path-structure
+
+The legacy path structure information isn't written to a `path-structure.json` file, but if it was, it would look as follows: 
+```json
+{
+  "scheme": "msgpack/hash",
+  "branches": 256,
+  "levels": 2,
+  "encoding": "hex"
+}
+```
+
+This means that every feature path looks something like the following:
+
+`3c/57/kU0=`
+
+This example is for a feature with one primary key column only, and a primary key value of `[77]`.
+
+##### To generate the path to the file:
+
+`[77]` -> MessagePack -> `bytes([0x91, 0x4d])` -> SHA256 -> `bytes([0x3c, 0x57, 0x8e, 0x75, ...])` -> hex encode first two bytes as a 2-level path -> `3c/57`
+
+##### To generate the filename:
+
+`[77]` -> MessagePack -> `bytes([0x91, 0x4d])` -> Base64 -> `kU0=`


### PR DESCRIPTION
![](https://media0.giphy.com/media/6GQm8hBpvO1kA/giphy-downsized-medium.gif)

## Description

New dataset path layout is not backwards compatible with Kart 0.9, so it needs its own repository structure version number. It will be Datasets V3.

The path layout we used was not previously particularly documented, so I've had to document both the old way and the new way(s) so that I can explain what the difference between v2 and v3 is.