### PR TITLE
Set core.ignoreCase=false always

### DIFF
--- a/kart/cli_util.py
+++ b/kart/cli_util.py
@@ -44,6 +44,19 @@ GIT_CONFIG_DEFAULT_OVERRIDES = {
     "pack.depth": 0,
     "pack.window": 0,
 }
+# These are the settings that Kart always *overrides* in git config.
+# i.e. regardless of your local git settings, kart will use these settings instead.
+GIT_CONFIG_FORCE_OVERRIDES = {
+    # We use base64 for feature paths.
+    # "kcya" and "kcyA" are *not* the same feature; that way lies data loss
+    "core.ignoreCase": "false",
+}
+
+
+# from https://github.com/git/git/blob/ebf3c04b262aa27fbb97f8a0156c2347fecafafb/quote.c#L12-L44
+def _git_sq_quote_buf(src):
+    dst = src.replace("'", r"'\''").replace("!", r"'\!'")
+    return f"'{dst}'"
 
 
 @functools.lru_cache()
@@ -54,15 +67,14 @@ def init_git_config():
     configs = list(_pygit2_configs())
     new_config_params = []
     for k, v in GIT_CONFIG_DEFAULT_OVERRIDES.items():
-        v = str(v)
-        # not sure *exactly* how this quoting works; for now let's just check it's safe
-        assert "'" not in k
-        assert "'" not in v
         for config in configs:
             if k in config:
                 break
         else:
-            new_config_params.append(f"'{k}={v}'")
+            new_config_params.append(_git_sq_quote_buf(f"{k}={v}"))
+    for k, v in GIT_CONFIG_FORCE_OVERRIDES.items():
+        new_config_params.append(_git_sq_quote_buf(f"{k}={v}"))
+
     if new_config_params:
         existing = ""
         if "GIT_CONFIG_PARAMETERS" in os.environ:


### PR DESCRIPTION

## Description
Since we use base64 for blob names, and base64 requires case
sensitivity, it's an error to treat them case insensitively.

Oddly, git doesn't only use this setting for working copy paths,
it seems to use it during fast-import also.

This change turns off core.ignoreCase always, even if it's enabled in
the repo's config file (or the global/system config file)


## Related links:

Extracted from #436 (case clashes are up to 65536x more likely to occur on that branch, but are (at least theoretically) also possible on master if you have enough features)

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
