### PR TITLE
upgrade: Don't create extra 'main' branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Kart v0.10.0 introduces a new repository structure, which is the default, dubbed
 * Bugfix: 3D and 4D geometries are now properly roundtripped through SQL Server working copy.
 * Fix help text for discarding changes to refer to `kart restore` instead of `kart reset`, as `kart restore` is now the simplest way to discard changes. [#426](https://github.com/koordinates/kart/issues/426)
 * `import`: PostGIS internal views/tables are no longer listed by `--list` or imported by `--all-tables`, and can't be imported by name either. [#439](https://github.com/koordinates/kart/issues/439)
+* `upgrade` no longer adds a `main` or `master` branch to upgraded repos.
 
 ### Calculating feature counts for diffs
 

--- a/kart/upgrade/__init__.py
+++ b/kart/upgrade/__init__.py
@@ -119,6 +119,7 @@ def upgrade(ctx, source, dest):
                 )
 
         _upgrade_commit(
+            ctx,
             i,
             source_repo,
             source_commit,
@@ -163,6 +164,7 @@ def upgrade(ctx, source, dest):
 
 
 def _upgrade_commit(
+    ctx,
     i,
     source_repo,
     source_commit,
@@ -200,7 +202,7 @@ def _upgrade_commit(
             dest_repo,
             source_datasets,
             replace_existing=ReplaceExisting.ALL,
-            verbosity=0,
+            verbosity=ctx.obj.verbosity,
             header=header,
             extra_cmd_args=["--force"],
             num_processes=1,


### PR DESCRIPTION

## Description

If you run `kart upgrade` on a repo which doesn't contain a 'main'
branch, it silently adds one.

This change makes it not do that

## Related links:


## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
