### PR TITLE
Fix for kart upgrade so it handles complicated repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Please note that compatibility for 0.x releases (software or repositories) isn't
 
 _When adding new entries to the changelog, please include issue/PR numbers wherever possible._
 
+## 0.10.1
+
+#### Fix for `kart upgrade`
+Fixed `kart upgrade` so that it preserves more complicated (or yet-to-be-released) features of V2 repos as they are upgraded to V3. [#448](https://github.com/koordinates/kart/issues/448)
+
+Specifically:
+* `generated-pks.json` metadata, extra metadata found in datasets that have an automatically generated primary key and which are maintained by repeatedly importing from a primary-key-less datasource
+* attachments (which are not yet fully supported by Kart) - arbitrary files kept alongside datasets, such as license or readme files.
 
 ## 0.10.0
 

--- a/kart/dataset3.py
+++ b/kart/dataset3.py
@@ -332,6 +332,9 @@ class Dataset3(RichBaseDataset):
 
             yield full_path, content
 
+        for rel_path, content in source.attachment_items():
+            yield self.full_attachment_path(rel_path), content
+
     def iter_legend_blob_data(self):
         """
         Generates (full_path, blob_data) tuples for each legend in this dataset

--- a/kart/import_source.py
+++ b/kart/import_source.py
@@ -101,6 +101,14 @@ class ImportSource:
         """
         raise NotImplementedError()
 
+    def attachment_items(self):
+        """
+        Returns a dict of all the attachment items that need to be imported.
+        These are files that will be imported verbatim to dest_path, but not hidden inside the dataset.
+        This could be a license or a readme.
+        """
+        return {}
+
     def crs_definitions(self):
         """
         Returns an {identifier: definition} dict containing every CRS definition.

--- a/kart/init.py
+++ b/kart/init.py
@@ -326,15 +326,17 @@ def import_(
         import_sources.append(import_source)
 
     ImportSource.check_valid(import_sources, param_hint="tables")
+    replace_existing_enum = (
+        ReplaceExisting.GIVEN if replace_existing else ReplaceExisting.DONT_REPLACE
+    )
     fast_import_tables(
         repo,
         import_sources,
         verbosity=ctx.obj.verbosity + 1,
         message=message,
         max_delta_depth=max_delta_depth,
-        replace_existing=ReplaceExisting.GIVEN
-        if replace_existing
-        else ReplaceExisting.DONT_REPLACE,
+        replace_existing=replace_existing_enum,
+        from_commit=repo.head_commit,
         replace_ids=replace_ids,
         allow_empty=allow_empty,
         num_processes=num_processes or get_default_num_processes(),
@@ -458,6 +460,7 @@ def init(
         fast_import_tables(
             repo,
             sources,
+            from_commit=None,
             message=message,
             max_delta_depth=max_delta_depth,
             num_processes=num_processes or get_default_num_processes(),

--- a/kart/pk_generation.py
+++ b/kart/pk_generation.py
@@ -3,7 +3,7 @@ import pygit2
 from .import_source import ImportSource
 from .dataset2 import Dataset2
 from .dataset2 import Dataset3
-from .schema import ColumnSchema, Schema
+from .schema import ColumnSchema
 
 
 class PkGeneratingImportSource(ImportSource):

--- a/kart/rich_base_dataset.py
+++ b/kart/rich_base_dataset.py
@@ -201,9 +201,9 @@ class RichBaseDataset(BaseDataset):
         """
         feature_filter = feature_filter or UNFILTERED
 
-        params = {}
+        params = {"flags": pygit2.GIT_DIFF_SKIP_BINARY_CHECK}
         if reverse:
-            params = {"swap": True}
+            params["swap"] = True
 
         if other is None:
             diff_index = self.inner_tree.diff_to_tree(**params)

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1120,7 +1120,7 @@ def test_fast_import(data_archive, tmp_path, cli_runner, chdir):
                 data / "nz-pa-points-topo-150k.gpkg", table=table
             )
 
-            fast_import.fast_import_tables(repo, [source])
+            fast_import.fast_import_tables(repo, [source], from_commit=None)
 
             assert not repo.is_empty
             assert repo.head.name == "refs/heads/main"


### PR DESCRIPTION
Most mirrored repos are complicated - user repos, where they exist at all, are simpler.

A complicated repo might have meta-items that are non-standard eg "generated-pks.json" - these are considered "non-standard" as they don't describe the state of the data itself, or even metadata about the data such as title, description, or schema. Instead, they are extra metadata that the data-source itself maintains so that it can accurately provide the actual data / metadata. As such, they currently don't show up in diffs.

A complicated repo might have attachments, which are currently mostly hidden from users - but still need to be in the mirrors to future proof the mirrors since we can't keep changing the mirrored history, and we will eventually support them.

https://github.com/koordinates/kart/issues/448


