### PR TITLE
upgrade --in-place: prune repos better

### DIFF
--- a/kart/repo.py
+++ b/kart/repo.py
@@ -550,13 +550,16 @@ class KartRepo(pygit2.Repository):
         if key in config:
             del config[key]
 
-    def gc(self, *args):
-        """Runs git-gc on the Kart repository."""
+    def invoke_git(self, *args):
         try:
-            args = ["git", "-C", self.path, "gc", *args]
+            args = ["git", "-C", self.path, *args]
             subprocess.check_call(args, env=tool_environment())
         except subprocess.CalledProcessError as e:
             sys.exit(translate_subprocess_exit_code(e.returncode))
+
+    def gc(self, *args):
+        """Runs git-gc on the Kart repository."""
+        self.invoke_git("gc", *args)
 
     def _ensure_exists_and_empty(dir_path):
         if dir_path.exists() and any(dir_path.iterdir()):


### PR DESCRIPTION
## Description

Running `kart upgrade --in-place` doesn't expire the reflogs. This unfortunately means that all old objects are still referenced, and the `repo.gc()` call doesn't do much (it only clears objects that existed and were collectable before the upgrade)

This change makes kart expire all the reflogs that refer to upgraded commits, and then garbage collect all the old objects immediately.

The `git gc --prune=now` is safe in non-in-place upgrades because the old repo is untouched, and presumably nothing is using the new repo yet.

In `--in-place` upgrades, well - the flag is hidden, so you opted in to this by going around poking hidden flags. I added a note to the flag's `help` that states it is irreversible.


I don't think this needs a changelog entry since `--in-place` is a hidden flag.

## Related links:

none

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
