### PR TITLE
Use UTF8 as text file encoding on all platforms

### DIFF
--- a/kart/__init__.py
+++ b/kart/__init__.py
@@ -8,9 +8,19 @@ __all__ = (
 )
 
 import os
+import locale
 import logging
 import platform
 import sys
+
+# Always use UTF-8 for opening text-mode files.
+# This is the default on POSIX but not on Windows for some reason.
+# But we want consistent results across platforms, so we override it.
+# We *would* set PYTHONUTF8=1 to enable python's UTF-8 mode,
+# but that can't be changed after the interpreter
+# has started up, so it's harder for us to control.
+lang = locale.getlocale()[0]
+locale.setlocale(locale.LC_CTYPE, f"{lang}.UTF-8")
 
 L = logging.getLogger("kart.__init__")
 
@@ -106,9 +116,9 @@ if is_windows:
     # which is recommended - but we can't do anything about if they haven't done it properly.
     # But, we do need to handle CTRL-C events - the call below "restores normal processing of CTRL-C events"
     # (ie,  don't ignore them) and this is also inherited by child processes.
-    kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
     if not kernel32.SetConsoleCtrlHandler(None, False):
-        L.warn('Error calling SetConsoleCtrlHandler: ', ctypes.get_last_error())
+        L.warn("Error calling SetConsoleCtrlHandler: ", ctypes.get_last_error())
 else:
     # On non-Windows we can use os.setsid() which Windows lacks,
     # to attempt to give Kart it's own process group ID (PGID)


### PR DESCRIPTION
## Description


The test added in 6bdc2b2a190eb3df3c8a84ce399d64cbb6e80c42 fails on Windows because it seems files are opened using the `charmap` encoding there, unlikely MacOS/Linux which are using utf-8.

We want utf-8 to be the default text file encoding on _all_ platforms, otherwise we'll get inconsistent results (a file written by one user may not be readable by another)

This fix forces the locale encoding to UTF-8 without touching the locale's language, and thus hopefully fixes the test on Windows 🤞 

## Related links:

none

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
