### PR TITLE
Adds basic WC spatial filter support to kart (not yet exposed)

### DIFF
--- a/kart/base_dataset.py
+++ b/kart/base_dataset.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+import time
 
 from . import crs_util
 from .import_source import ImportSource
@@ -7,6 +8,8 @@ from . import meta_items
 from .serialise_util import json_unpack, ensure_text
 from .spatial_filters import SpatialFilter
 from .utils import ungenerator
+
+L = logging.getLogger("kart.base_dataset")
 
 
 class BaseDataset(ImportSource):
@@ -38,6 +41,8 @@ class BaseDataset(ImportSource):
     FEATURE_PATH = None  # Eg "feature/"
 
     META_ITEM_NAMES = meta_items.META_ITEM_NAMES
+
+    NUM_FEATURES_PER_PROGRESS_LOG = 10_000
 
     def __init__(self, tree, path, repo=None):
         """
@@ -263,7 +268,7 @@ class BaseDataset(ImportSource):
         geom_columns = self.schema.geometry_columns
         return geom_columns[0].name if geom_columns else None
 
-    def features(self, spatial_filter=SpatialFilter.MATCH_ALL):
+    def features(self, spatial_filter=SpatialFilter.MATCH_ALL, log_progress=False):
         """
         Yields a dict for every feature. Dicts contain key-value pairs for each feature property,
         and geometries use kart.geometry.Geometry objects, as in the following example::
@@ -277,16 +282,71 @@ class BaseDataset(ImportSource):
 
         Each dict is guaranteed to iterate in the same order as the columns are ordered in the schema,
         so that zip(schema.columns, feature.values()) matches each field with its column.
+
+        spatial_filter - restricts the features yielded to those that are in a particular geographic area.
+        log_progress - can be set to True, or to a callable logger method eg L.info, to enable logging.
         """
+        if log_progress:
+            plog = L.info if log_progress is True else log_progress
+            log_progress = bool(log_progress)
+
         if not self.geom_column_name or spatial_filter.match_all:
             matches = lambda f: True
         else:
             matches = lambda f: f[self.geom_column_name] in spatial_filter
 
+        n_read = 0
+        n_chunk = 0
+        n_matched = 0
+        n_total = self.feature_count
+        t0 = time.monotonic()
+        t0_chunk = t0
+
+        if log_progress:
+            plog("0.0%% 0/%d features... @0.0s", n_total)
+
         for blob in self.feature_blobs():
             feature = self.get_feature(path=blob.name, data=memoryview(blob))
+            n_read += 1
+            n_chunk += 1
+
             if matches(feature):
+                n_matched += 1
                 yield feature
+
+            if log_progress and n_chunk == self.NUM_FEATURES_PER_PROGRESS_LOG:
+                t = time.monotonic()
+                self._log_feature_progress(
+                    plog, n_read, n_chunk, n_matched, n_total, t0, t0_chunk, t
+                )
+                t0_chunk = t
+                n_chunk = 0
+
+        if log_progress and n_total:
+            t = time.monotonic()
+            self._log_feature_progress(
+                plog, n_read, n_chunk, n_matched, n_total, t0, t0_chunk, t
+            )
+            plog("Overall rate: %d features/s", (n_read / (t - t0 or 0.001)))
+
+    def _log_feature_progress(
+        self, plog, num_read, num_chunk, num_matched, num_total, t0, t0_chunk, t
+    ):
+        plog(
+            "%.1f%% %d/%d features... @%.1fs (+%.1fs, ~%d F/s)",
+            num_read / num_total * 100,
+            num_read,
+            num_total,
+            t - t0,
+            t - t0_chunk,
+            num_chunk / (t - t0_chunk or 0.001),
+        )
+        if num_matched != num_read:
+            plog(
+                "(of %d features read, wrote %d to the working copy that match the spatial filter)",
+                num_read,
+                num_matched,
+            )
 
     @property
     def feature_count(self):

--- a/kart/base_dataset.py
+++ b/kart/base_dataset.py
@@ -293,7 +293,7 @@ class BaseDataset(ImportSource):
         if not self.geom_column_name or spatial_filter.match_all:
             matches = lambda f: True
         else:
-            matches = lambda f: f[self.geom_column_name] in spatial_filter
+            matches = lambda f: spatial_filter.matches(f[self.geom_column_name])
 
         n_read = 0
         n_chunk = 0

--- a/kart/checkout.py
+++ b/kart/checkout.py
@@ -37,7 +37,9 @@ def reset_wc_if_needed(repo, target_tree_or_commit, *, discard_changes=False):
         click.echo(f"Creating working copy at {working_copy} ...")
         working_copy.create_and_initialise()
         datasets = list(repo.datasets(target_tree_or_commit))
-        working_copy.write_full(target_tree_or_commit, *datasets, safe=False)
+        working_copy.write_full(
+            target_tree_or_commit, *datasets, spatial_filter=repo.spatial_filter
+        )
 
     db_tree_matches = (
         working_copy.get_db_tree() == target_tree_or_commit.peel(pygit2.Tree).hex

--- a/kart/crs_util.py
+++ b/kart/crs_util.py
@@ -1,5 +1,3 @@
-import itertools
-
 from osgeo.osr import SpatialReference
 
 from .cli_util import StringFromFile

--- a/kart/dataset3.py
+++ b/kart/dataset3.py
@@ -224,8 +224,7 @@ class Dataset3(RichBaseDataset):
 
     def feature_blobs(self):
         """
-        Returns a generator that calls get_feature once per feature.
-        Each entry in the generator is the path of the feature and then the feature itself.
+        Returns a generator that yields every feature blob in turn.
         """
         if self.FEATURE_PATH not in self.inner_tree:
             return

--- a/kart/fsck.py
+++ b/kart/fsck.py
@@ -14,7 +14,7 @@ def _fsck_reset(repo, working_copy, dataset_paths):
     datasets = [repo.datasets()[p] for p in dataset_paths]
 
     working_copy.drop_table(commit, *datasets)
-    working_copy.write_full(commit, *datasets)
+    working_copy.write_full(commit, *datasets, spatial_filter=repo.spatial_filter)
 
 
 @click.command(context_settings=dict(ignore_unknown_options=True))

--- a/kart/geometry.py
+++ b/kart/geometry.py
@@ -19,27 +19,16 @@ GPKG_ENVELOPE_XYZM = 4
 # The structure of the various GPKG envelope types for reading and writing.
 GPKG_ENVELOPE_FORMATS = {
     GPKG_ENVELOPE_NONE: "",
-    GPKG_ENVELOPE_XY: "d" * 4,  # 4 doubles: XYXY
-    GPKG_ENVELOPE_XYZ: "d" * 6,  # 6 doubles: XYZXYZ
-    GPKG_ENVELOPE_XYM: "d" * 6,  # 6 doubles: XYMXYM
-    GPKG_ENVELOPE_XYZM: "d" * 8,  # 8 doubles: XYZMXYZM
+    GPKG_ENVELOPE_XY: "d" * 4,  # 4 doubles: (min-x, max-x, min-y, max-y)
+    GPKG_ENVELOPE_XYZ: "d" * 6,  # 6: standard four + (min-z, max-z)
+    GPKG_ENVELOPE_XYM: "d" * 6,  # 6: standard four + (min-m, max-m)
+    GPKG_ENVELOPE_XYZM: "d" * 8,  # 8: standard four + (min-z, max-z, min-m, max-m)
 }
 
 # The size in bytes of the various GPKG envelope types.
 GPKG_ENVELOPE_SIZES = {
     env_type: len(env_format) * 8  # 8 bytes per double
     for env_type, env_format in GPKG_ENVELOPE_FORMATS.items()
-}
-
-# Skips 8 bytes / skips a double
-x8 = "x" * 8
-
-# The 2D portion of the various GPKG envelope types, for reading.
-GPKG_READ_2D_ENVELOPE_FORMAT = {
-    GPKG_ENVELOPE_XY: "dddd",
-    GPKG_ENVELOPE_XYZ: f"dd{x8}dd{x8}",
-    GPKG_ENVELOPE_XYM: f"dd{x8}dd{x8}",
-    GPKG_ENVELOPE_XYZM: f"dd{x8}{x8}dd{x8}{x8}",
 }
 
 
@@ -120,24 +109,16 @@ class Geometry(bytes):
         )
         return geom_type
 
-    @property
-    def envelope(self):
-        """Returns the envelope as a tuple of 4, 6, or 8 values, or None if no envelope is stored."""
-        assert self.is_little_endian()
-        fmt = GPKG_ENVELOPE_FORMATS.get(self.envelope_type)
-        return struct.unpack_from(f"<{fmt}", self, 8) if fmt else None
-
-    @property
-    def envelope_2d(self):
-        """Returns the 2D envelope as a tuple of 4 values, or None if no envelope is stored."""
-        assert self.is_little_endian()
-        fmt = GPKG_READ_2D_ENVELOPE_FORMAT.get(self.envelope_type)
-        return struct.unpack_from(f"<{fmt}", self, 8) if fmt else None
-
-    def envelope_2d_as_ogr(self):
-        """Returns the 2D envelope as an OGR Polygon, for performing intersection tests etc."""
-        envelope_2d = self.envelope_2d
-        return envelope_2d_to_ogr(envelope_2d) if envelope_2d else None
+    def envelope(self, only_2d=False, calculate_if_missing=False):
+        """
+        Returns the envelope as a tuple of 4, 6, or 8 values, or None if no envelope is stored.
+        The tuple ordering is (min-x, max-x, min-y, max-y, min-z?, max-z?, min-m?, max-m?) - ? values may be missing.
+        If only_2d is True, then only (min-x, max-x, min-y, max-y) is returned, even if more values are present.
+        if calculate_if_missing is True then the entire geometry is loaded into OGR in order to calculate the envelope.
+        """
+        return geom_envelope(
+            self, only_2d=only_2d, calculate_if_missing=calculate_if_missing
+        )
 
     @classmethod
     def from_wkt(cls, wkt):
@@ -579,7 +560,7 @@ def hex_ewkb_to_gpkg_geom(hex_ewkb):
     return normalise_gpkg_geom(gpkg_geom)
 
 
-def geom_envelope(gpkg_geom):
+def geom_envelope(gpkg_geom, only_2d=False, calculate_if_missing=False):
     """
     Parse GeoPackage geometry to a 2D envelope.
     This is a shortcut to avoid instantiating a full OGR geometry if possible.
@@ -588,6 +569,11 @@ def geom_envelope(gpkg_geom):
 
     http://www.geopackage.org/spec/#gpb_format
     """
+    if calculate_if_missing and not only_2d:
+        raise NotImplementedError(
+            "calculate_if_missing is only supported for 2D envelopes - set only_2d to True also"
+        )
+
     if gpkg_geom is None:
         return None
 
@@ -608,45 +594,32 @@ def geom_envelope(gpkg_geom):
     if flags & _GPKG_EMPTY_BIT:  # Empty geometry
         return None
 
-    envelope_typ = (flags & _GPKG_ENVELOPE_BITS) >> 1
+    envelope_type = (flags & _GPKG_ENVELOPE_BITS) >> 1
     # E: envelope contents indicator code (3-bit unsigned integer)
-    # 0: no envelope (space saving slower indexing option), 0 bytes
-    # 1: envelope is [minx, maxx, miny, maxy], 32 bytes
-    # 2: envelope is [minx, maxx, miny, maxy, minz, maxz], 48 bytes
-    # 3: envelope is [minx, maxx, miny, maxy, minm, maxm], 48 bytes
-    # 4: envelope is [minx, maxx, miny, maxy, minz, maxz, minm, maxm], 64 bytes
-    # 5-7: invalid
+    # See GPKG_ENVELOPE_FORMATS above.
+    envelope_format = GPKG_ENVELOPE_FORMATS.get(envelope_type)
+    if envelope_format is None:
+        raise ValueError("Invalid envelope contents indicator")
 
-    if envelope_typ == 0:
-        # parse the full geometry then get it's envelope
+    if envelope_format == "":
+        if not calculate_if_missing:
+            return None
         ogr_geom = gpkg_geom_to_ogr(gpkg_geom)
         if ogr_geom.IsEmpty():
             # envelope is apparently (0, 0, 0, 0), thanks OGR :/
             return None
         else:
             return ogr_geom.GetEnvelope()
-    elif envelope_typ <= 4:
-        # we only care about 2D envelopes here
-        envelope = struct.unpack_from(f"{'<' if is_le else '>'}dddd", gpkg_geom, 8)
-        if any(math.isnan(c) for c in envelope):
-            return None
-        else:
-            return envelope
+
+    if only_2d:
+        # First 4 doubles are always the 2D ones.
+        envelope_format = "dddd"
+
+    envelope = struct.unpack_from(
+        f"{'<' if is_le else '>'}{envelope_format}", gpkg_geom, 8
+    )
+
+    if any(math.isnan(c) for c in envelope):
+        return None
     else:
-        raise ValueError("Invalid envelope contents indicator")
-
-
-def envelope_2d_to_ogr(envelope_2d):
-    (min_x, max_x, min_y, max_y) = envelope_2d
-
-    ogr_ring = ogr.Geometry(ogr.wkbLinearRing)
-    ogr_ring.AddPoint(min_x, min_y)
-    ogr_ring.AddPoint(max_x, min_y)
-    ogr_ring.AddPoint(max_x, max_y)
-    ogr_ring.AddPoint(min_x, max_y)
-
-    ogr_ring.AddPoint(min_x, min_y)
-
-    ogr_poly = ogr.Geometry(ogr.wkbPolygon)
-    ogr_poly.AddGeometry(ogr_ring)
-    return ogr_poly
+        return envelope

--- a/kart/init.py
+++ b/kart/init.py
@@ -61,7 +61,7 @@ def _add_datasets_to_working_copy(repo, *datasets, replace_existing=False):
 
     if replace_existing:
         wc.drop_table(commit, *datasets)
-    wc.write_full(commit, *datasets)
+    wc.write_full(commit, *datasets, spatial_filter=repo.spatial_filter)
 
 
 class GenerateIDsFromFile(StringFromFile):

--- a/kart/repo.py
+++ b/kart/repo.py
@@ -85,6 +85,7 @@ class KartConfigKeys:
     SNO_WORKINGCOPY_PATH = "sno.workingcopy.path"
 
     KART_SPATIALFILTER_GEOMETRY = "kart.spatialfilter.geometry"
+    KART_SPATIALFILTER_CRS = "kart.spatialfilter.crs"
 
     # This variable was also renamed, but when tidy-style repos were added - not during rebranding.
     CORE_BARE = "core.bare"  # Newer repos use the standard "core.bare" variable.
@@ -473,21 +474,22 @@ class KartRepo(pygit2.Repository):
     @property
     def workingcopy_location(self):
         """Return the path to the Kart working copy, if one exists."""
-        repo_cfg = self.config
-        location_key = self.WORKINGCOPY_LOCATION_KEY
-        return repo_cfg[location_key] if location_key in repo_cfg else None
+        return self._get_config_str(self.WORKINGCOPY_LOCATION_KEY)
 
     @property
     def spatial_filter(self):
         from .spatial_filters import SpatialFilter
 
-        repo_cfg = self.config
-        spec_key = KartConfigKeys.KART_SPATIALFILTER_GEOMETRY
+        geometry_spec = self._get_config_str(KartConfigKeys.KART_SPATIALFILTER_GEOMETRY)
+        crs_spec = self._get_config_str(KartConfigKeys.KART_SPATIALFILTER_CRS)
         return (
-            SpatialFilter.from_spec(repo_cfg[spec_key])
-            if spec_key in repo_cfg
+            SpatialFilter.from_spec(geometry_spec, crs_spec)
+            if geometry_spec
             else SpatialFilter.MATCH_ALL
         )
+
+    def _get_config_str(self, key):
+        return self.config[key] if key in self.config else None
 
     @property
     def is_bare(self):

--- a/kart/repo.py
+++ b/kart/repo.py
@@ -84,6 +84,8 @@ class KartConfigKeys:
     KART_WORKINGCOPY_LOCATION = "kart.workingcopy.location"
     SNO_WORKINGCOPY_PATH = "sno.workingcopy.path"
 
+    KART_SPATIALFILTER_GEOMETRY = "kart.spatialfilter.geometry"
+
     # This variable was also renamed, but when tidy-style repos were added - not during rebranding.
     CORE_BARE = "core.bare"  # Newer repos use the standard "core.bare" variable.
     SNO_WORKINGCOPY_BARE = (
@@ -474,6 +476,18 @@ class KartRepo(pygit2.Repository):
         repo_cfg = self.config
         location_key = self.WORKINGCOPY_LOCATION_KEY
         return repo_cfg[location_key] if location_key in repo_cfg else None
+
+    @property
+    def spatial_filter(self):
+        from .spatial_filters import SpatialFilter
+
+        repo_cfg = self.config
+        spec_key = KartConfigKeys.KART_SPATIALFILTER_GEOMETRY
+        return (
+            SpatialFilter.from_spec(repo_cfg[spec_key])
+            if spec_key in repo_cfg
+            else SpatialFilter.MATCH_ALL
+        )
 
     @property
     def is_bare(self):

--- a/kart/rich_base_dataset.py
+++ b/kart/rich_base_dataset.py
@@ -13,7 +13,7 @@ from .exceptions import (
     NotYetImplemented,
     PATCH_DOES_NOT_APPLY,
 )
-from .geometry import geom_envelope, make_crs
+from .geometry import make_crs
 from .key_filters import DatasetKeyFilter, FeatureKeyFilter
 from .schema import Schema
 from .spatial_filters import SpatialFilter
@@ -105,7 +105,7 @@ class RichBaseDataset(BaseDataset):
                 if geom is None:
                     continue
 
-                e = geom_envelope(geom)
+                e = geom.envelope(only_2d=True, calculate_if_missing=True)
                 yield (pk, e, None)
 
                 if c % 50000 == 0:

--- a/kart/rich_base_dataset.py
+++ b/kart/rich_base_dataset.py
@@ -39,13 +39,17 @@ class RichBaseDataset(BaseDataset):
         for blob in self.feature_blobs():
             yield self.get_feature(path=blob.name, data=memoryview(blob)), blob
 
-    def features_with_crs_ids(self, spatial_filter=SpatialFilter.MATCH_ALL):
+    def features_with_crs_ids(
+        self, spatial_filter=SpatialFilter.MATCH_ALL, log_progress=False
+    ):
         """
         Same as base_dataset.features(), but includes the CRS ID from the schema in every Geometry object.
         By contrast, the returned Geometries from base_dataset.features() all contain a CRS ID of zero,
         so the schema must be consulted separately to learn about CRS IDs.
         """
-        yield from self._add_crs_ids_to_features(self.features(spatial_filter))
+        yield from self._add_crs_ids_to_features(
+            self.features(spatial_filter, log_progress=log_progress)
+        )
 
     def get_features_with_crs_ids(self, row_pks, *, ignore_missing=False):
         """

--- a/kart/rich_base_dataset.py
+++ b/kart/rich_base_dataset.py
@@ -16,6 +16,8 @@ from .exceptions import (
 from .geometry import geom_envelope, make_crs
 from .key_filters import DatasetKeyFilter, FeatureKeyFilter
 from .schema import Schema
+from .spatial_filters import SpatialFilter
+
 
 from .base_dataset import BaseDataset
 
@@ -37,19 +39,19 @@ class RichBaseDataset(BaseDataset):
         for blob in self.feature_blobs():
             yield self.get_feature(path=blob.name, data=memoryview(blob)), blob
 
-    def features_with_crs_ids(self):
+    def features_with_crs_ids(self, spatial_filter=SpatialFilter.MATCH_ALL):
         """
         Same as base_dataset.features(), but includes the CRS ID from the schema in every Geometry object.
-        By contrast, base_dataset.features() Geometries only contain CRS IDs of zero, so the schema must
-        be consulted separately to learn about CRS IDs.
+        By contrast, the returned Geometries from base_dataset.features() all contain a CRS ID of zero,
+        so the schema must be consulted separately to learn about CRS IDs.
         """
-        yield from self._add_crs_ids_to_features(self.features())
+        yield from self._add_crs_ids_to_features(self.features(spatial_filter))
 
     def get_features_with_crs_ids(self, row_pks, *, ignore_missing=False):
         """
-        Same as base_dataset.get_features(...), but includes the CRS ID from the Schema in every Geometry object.
-        By contrast, base_dataset.get_features_with_crs_ids(...) Geometries only contain CRS IDs of zero, so the schema
-        must be consulted separately to learn about CRS IDs.
+        Same as base_dataset.get_features(...), but includes the CRS ID from the schema in every Geometry object.
+        By contrast, the returned Geometries from base_dataset.get_features(...) all contain a CRS ID of zero,
+        so the schema must be consulted separately to learn about CRS IDs.
         """
         yield from self._add_crs_ids_to_features(
             self.get_features(row_pks, ignore_missing=ignore_missing)

--- a/kart/spatial_filters.py
+++ b/kart/spatial_filters.py
@@ -1,8 +1,12 @@
+import collections
 import functools
+import logging
 
 import click
 
 from .geometry import Geometry
+
+L = logging.getLogger("kart.spatial_filters")
 
 
 class SpatialFilter:
@@ -18,9 +22,12 @@ class SpatialFilter:
 
     def __init__(self, filter_geometry, match_all=False):
         self.filter_geometry = filter_geometry
-        if filter_geometry:
-            self.filter_env = filter_geometry.envelope_2d_as_ogr()
+        if filter_geometry is not None:
             self.filter_ogr = filter_geometry.to_ogr()
+            self.filter_env = self.filter_ogr.GetEnvelope()
+        else:
+            self.filter_ogr = None
+            self.filter_env = None
 
         self.match_all = match_all
 
@@ -35,15 +42,21 @@ class SpatialFilter:
         # Quick check - envelope intersects envelope?
         if self.filter_env is not None:
             try:
-                feature_env = feature_geometry.envelope_2d_as_ogr()
-                # Envelope might be missing (for POINT geometries, or, for unknown reasons)
-                if feature_env is None:
-                    feature_env = feature_ogr = feature_geometry.to_ogr()
+                # Don't call envelope() with calculate_if_missing=True - calculating the envelope
+                # involves loading it into OGR, which we don't want to do twice (see below).
+                feature_env = feature_geometry.envelope(only_2d=True)
 
-                if not self.filter_env.Intersects(feature_env):
+                # Envelope might be missing (for POINT geometries, or, for unknown reasons).
+                # In this case, we use OGR to calculate it, but we keep the OGR geometry too.
+                if feature_env is None:
+                    feature_ogr = feature_geometry.to_ogr()
+                    feature_env = feature_ogr.GetEnvelope()
+
+                if not bbox_intersects_fast(self.filter_env, feature_env):
                     # Geometries definitely don't intersect if envelopes don't intersect.
                     return False
             except Exception as e:
+                L.warn(e)
                 err = e
 
         # Slow check - geometry intersects geometry?
@@ -52,11 +65,53 @@ class SpatialFilter:
                 feature_ogr = feature_geometry.to_ogr()
             return self.filter_ogr.Intersects(feature_ogr)
         except Exception as e:
+            L.warn(e)
             err = e
 
         # If we fail to apply the spatial filter - perhaps the geometry is corrupt? - we assume it matches.
-        click.echo(f"Error applying spatial filter to geometry:\n{err}")
+        click.echo(f"Error applying spatial filter to geometry:\n{err}", err=True)
         return True
 
 
-SpatialFilter.MATCH_ALL = SpatialFilter(None)
+SpatialFilter.MATCH_ALL = SpatialFilter(None, match_all=True)
+
+
+def _range_overlaps(range1_tuple, range2_tuple):
+    (a1, a2) = range1_tuple
+    (b1, b2) = range2_tuple
+    if a1 > a2 or b1 > b2:
+        raise ValueError(
+            "I was passed a range that didn't make sense: (%r, %r), (%r, %r)"
+            % (a1, a2, b1, b2)
+        )
+    if b1 < a1:
+        # `b` starts to the left of `a`, so they intersect if `b` finishes to the right of where `a` starts.
+        return b2 > a1
+    elif a1 < b1:
+        # `a` starts to the left of `b`, so they intersect if `a` finishes to the right of where `b` starts.
+        return a2 > b1
+    else:
+        # They both have the same left edge, so they must intersect unless one of them is zero-width.
+        return b2 != b1 and a2 != a1
+
+
+def bbox_intersects_fast(a, b):
+    """
+    Takes two four-tuples representing extents, and returns whether their interiors intersect.
+    Also handles multiboxes (two tuples each containing zero-or-more four-tuples)
+    Intended for use when doing intersections of loads of mathematically-created boxes, avoiding
+    the substantial overhead of creating geometry objects and then calling .intersects() on them.
+    Don't use this if you've already got GEOSGeometry objects - calling .extent on each and then calling
+    this is unlikely to help with performance.
+    Don't call this for global projections unless you're certain that the boxes inhabit the same world
+    (since we don't/can't wrap boxes across the antimeridian here)
+    """
+    if (not len(a)) or isinstance(a[0], collections.Iterable):
+        # a is a multi-box
+        return any(bbox_intersects_fast(a_item, b) for a_item in a)
+    if (not len(b)) or isinstance(b[0], collections.Iterable):
+        # b is a multi-box
+        return any(bbox_intersects_fast(a, b_item) for b_item in b)
+    return _range_overlaps((a[0], a[2]), (b[0], b[2])) and _range_overlaps(
+        (a[1], a[3]), (b[1], b[3])
+    )

--- a/kart/spatial_filters.py
+++ b/kart/spatial_filters.py
@@ -1,0 +1,62 @@
+import functools
+
+import click
+
+from .geometry import Geometry
+
+
+class SpatialFilter:
+    @classmethod
+    @functools.lru_cache()
+    def from_spec(cls, spec):
+        if not spec:
+            return SpatialFilter.MATCH_ALL
+
+        # Could also accept WKT here if that is useful.
+        filter_geometry = Geometry.from_hex_wkb(spec).normalise()
+        return SpatialFilter(filter_geometry)
+
+    def __init__(self, filter_geometry, match_all=False):
+        self.filter_geometry = filter_geometry
+        if filter_geometry:
+            self.filter_env = filter_geometry.envelope_2d_as_ogr()
+            self.filter_ogr = filter_geometry.to_ogr()
+
+        self.match_all = match_all
+
+    def __contains__(self, feature_geometry):
+        if self.match_all or self.filter_geometry is None or feature_geometry is None:
+            return True
+
+        err = None
+        feature_env = None
+        feature_ogr = None
+
+        # Quick check - envelope intersects envelope?
+        if self.filter_env is not None:
+            try:
+                feature_env = feature_geometry.envelope_2d_as_ogr()
+                # Envelope might be missing (for POINT geometries, or, for unknown reasons)
+                if feature_env is None:
+                    feature_env = feature_ogr = feature_geometry.to_ogr()
+
+                if not self.filter_env.Intersects(feature_env):
+                    # Geometries definitely don't intersect if envelopes don't intersect.
+                    return False
+            except Exception as e:
+                err = e
+
+        # Slow check - geometry intersects geometry?
+        try:
+            if feature_ogr is None:
+                feature_ogr = feature_geometry.to_ogr()
+            return self.filter_ogr.Intersects(feature_ogr)
+        except Exception as e:
+            err = e
+
+        # If we fail to apply the spatial filter - perhaps the geometry is corrupt? - we assume it matches.
+        click.echo(f"Error applying spatial filter to geometry:\n{err}")
+        return True
+
+
+SpatialFilter.MATCH_ALL = SpatialFilter(None)

--- a/kart/working_copy/base.py
+++ b/kart/working_copy/base.py
@@ -18,6 +18,7 @@ from kart.exceptions import (
 )
 from kart.key_filters import RepoKeyFilter, DatasetKeyFilter, FeatureKeyFilter
 from kart.schema import Schema, DefaultRoundtripContext
+from kart.spatial_filters import SpatialFilter
 from kart.sqlalchemy.upsert import Upsert as upsert
 from kart.utils import chunk
 from . import WorkingCopyStatus, WorkingCopyType
@@ -828,7 +829,7 @@ class BaseWorkingCopy:
         )
         return r.rowcount
 
-    def write_full(self, commit, *datasets, **kwargs):
+    def write_full(self, commit, *datasets, spatial_filter=SpatialFilter.MATCH_ALL):
         """
         Writes a full layer into a working-copy table
 
@@ -867,7 +868,9 @@ class BaseWorkingCopy:
 
                 CHUNK_SIZE = 10000
 
-                for row_dicts in chunk(dataset.features_with_crs_ids(), CHUNK_SIZE):
+                for row_dicts in chunk(
+                    dataset.features_with_crs_ids(spatial_filter), CHUNK_SIZE
+                ):
                     sess.execute(sql, row_dicts)
                     feat_progress += len(row_dicts)
 

--- a/kart/working_copy/base.py
+++ b/kart/working_copy/base.py
@@ -840,9 +840,8 @@ class BaseWorkingCopy:
         with self.session() as sess:
             dataset_count = len(datasets)
             for i, dataset in enumerate(datasets):
-                total_features = dataset.feature_count
                 L.info(
-                    f"Writing dataset {i+1} of {dataset_count}: {dataset.path} with {total_features} features"
+                    "Writing dataset %d of %d: %s", i + 1, dataset_count, dataset.path
                 )
 
                 try:
@@ -862,37 +861,20 @@ class BaseWorkingCopy:
 
                 L.info("Creating features...")
                 sql = self._insert_into_dataset(dataset)
-                feat_progress = 0
                 t0 = time.monotonic()
-                t0p = t0
 
                 CHUNK_SIZE = 10000
 
+                dataset_spatial_filter = spatial_filter.transform_for_dataset(dataset)
                 for row_dicts in chunk(
-                    dataset.features_with_crs_ids(spatial_filter), CHUNK_SIZE
+                    dataset.features_with_crs_ids(
+                        dataset_spatial_filter, log_progress=L.info
+                    ),
+                    CHUNK_SIZE,
                 ):
                     sess.execute(sql, row_dicts)
-                    feat_progress += len(row_dicts)
-
-                    t0a = time.monotonic()
-                    L.info(
-                        "%.1f%% %d/%d features... @%.1fs (+%.1fs, ~%d F/s)",
-                        feat_progress / total_features * 100,
-                        feat_progress,
-                        total_features,
-                        t0a - t0,
-                        t0a - t0p,
-                        CHUNK_SIZE / (t0a - t0p or 0.001),
-                    )
-                    t0p = t0a
 
                 t1 = time.monotonic()
-                L.info(
-                    "Added %d features to working copy in %.1fs", feat_progress, t1 - t0
-                )
-                L.info(
-                    "Overall rate: %d features/s", (feat_progress / (t1 - t0 or 0.001))
-                )
                 if dataset.has_geometry:
                     self._create_spatial_index_post(sess, dataset)
 
@@ -900,7 +882,11 @@ class BaseWorkingCopy:
                 self._update_last_write_time(sess, dataset, commit)
 
                 L.info(
-                    f"Wrote dataset {i+1} of {dataset_count}: {dataset.path} with {total_features} features"
+                    "Wrote dataset %d of %d in %.1fs: %s",
+                    i + 1,
+                    dataset_count,
+                    t1 - t0,
+                    dataset.path,
                 )
 
             self._insert_or_replace_state_table_tree(

--- a/kart/working_copy/gpkg.py
+++ b/kart/working_copy/gpkg.py
@@ -438,7 +438,7 @@ class WorkingCopy_GPKG(BaseWorkingCopy):
             {"table": dataset.table_name, "geom": geom_col},
         )
 
-        L.info("Created spatial index in %ss", time.monotonic() - t0)
+        L.info("Created spatial index in %.1fs", time.monotonic() - t0)
 
     def _drop_spatial_index(self, sess, dataset):
         L = logging.getLogger(f"{self.__class__.__qualname__}._drop_spatial_index")
@@ -460,7 +460,7 @@ class WorkingCopy_GPKG(BaseWorkingCopy):
             {"table_name": dataset.table_name, "column_name": geom_col},
         )
 
-        L.info("Dropped spatial index in %ss", time.monotonic() - t0)
+        L.info("Dropped spatial index in %.1fs", time.monotonic() - t0)
 
     def _sno_tracking_name(self, trigger_type, dataset):
         assert trigger_type in ("ins", "upd", "del")

--- a/kart/working_copy/mysql.py
+++ b/kart/working_copy/mysql.py
@@ -142,7 +142,7 @@ class WorkingCopy_MySql(DatabaseServer_WorkingCopy):
             f"ALTER TABLE {self.table_identifier(dataset)} ADD SPATIAL INDEX({self.quote(geom_col)})"
         )
 
-        L.info("Created spatial index in %ss", time.monotonic() - t0)
+        L.info("Created spatial index in %.1fs", time.monotonic() - t0)
 
     def _drop_spatial_index(self, sess, dataset):
         # MySQL deletes the spatial index automatically when the table is deleted.

--- a/kart/working_copy/postgis.py
+++ b/kart/working_copy/postgis.py
@@ -186,7 +186,7 @@ class WorkingCopy_Postgis(DatabaseServer_WorkingCopy):
         spatial_index.create(sess.connection())
         sess.execute(f"""ANALYZE {self.table_identifier(dataset)};""")
 
-        L.info("Created spatial index in %ss", time.monotonic() - t0)
+        L.info("Created spatial index in %.1fs", time.monotonic() - t0)
 
     def _drop_spatial_index(self, sess, dataset):
         # PostGIS deletes the spatial index automatically when the table is deleted.

--- a/kart/working_copy/sqlserver.py
+++ b/kart/working_copy/sqlserver.py
@@ -134,7 +134,7 @@ class WorkingCopy_SqlServer(DatabaseServer_WorkingCopy):
             )
         )
 
-        L.info("Created spatial index in %ss", time.monotonic() - t0)
+        L.info("Created spatial index in %.1fs", time.monotonic() - t0)
 
     def _drop_spatial_index(self, sess, dataset):
         # SQL server deletes the spatial index automatically when the table is deleted.

--- a/tests/test_spatial_filters.py
+++ b/tests/test_spatial_filters.py
@@ -1,0 +1,47 @@
+import pytest
+
+from kart.repo import KartRepo
+
+
+H = pytest.helpers.helpers()
+
+
+SPATIAL_FILTERS = {
+    "points": "0103000000010000000E0000005C94E90C569E65406777FF1A808F41C06BB6213CEFAD65407C23003250DE41C034D22DD5A8BA65402B9F88C2F51642C067EA6918BEC5654058053150C14542C039FDEDDA5CCE654016A3F10F008E42C0A11342F39FD86540D96B72D5F2E942C0DE22F65F9ADF6540917F6AADFAF242C0B128686B45E265404D5F1AA933E442C0E1FBBF3ABFCD6540D1239929B65342C0B8DAFB208FBE65406E60D0E439FA41C009BE7B726CB165400CFC0F8240CC41C0BBB3C5FBB3AC654002A68F76D8A441C07F97FFD7C59F6540E4611F18A68541C05C94E90C569E65406777FF1A808F41C0",
+    "polygons": "01060000000100000001030000000100000009000000EC21ADE020DC65403CFAB52CF3E942C0CF9F2289C0E06540F1BFAEBD38FD42C00E41DB9104E86540836341F410FD42C0130676A754EC65409196FB0A81EB42C04BB42C8C68EC6540F8BB59CA2BD242C01531A50CABE765404B7D5EBBFCBF42C0CF9F2289C0E06540DC20F1F1D4BF42C05B7E1AAA48DC6540CDED36DB64D142C0EC21ADE020DC65403CFAB52CF3E942C0",
+}
+
+
+@pytest.mark.parametrize(
+    "archive,table",
+    [
+        pytest.param("points", H.POINTS.LAYER, id="points"),
+        pytest.param("polygons", H.POLYGONS.LAYER, id="polygons"),
+        pytest.param("table", H.TABLE.LAYER, id="table"),
+    ],
+)
+def test_spatial_filtered_workingcopy(
+    archive, table, data_archive, tmp_path, cli_runner
+):
+    """ Checkout a working copy to edit """
+    with data_archive(archive) as repo_path:
+        repo = KartRepo(repo_path)
+        H.clear_working_copy()
+
+        matching_features = {
+            "points": 302,
+            "polygons": 44,
+            "table": H.TABLE.ROWCOUNT,  # All rows from table.tgz should be present, unaffected by spatial filtering.
+        }
+
+        # Use polygons spatial filter for table archive too - doesn't matter exactly what it is.
+        key = "polygons" if archive == "table" else archive
+        repo.config["kart.spatialfilter.geometry"] = SPATIAL_FILTERS[key]
+
+        r = cli_runner.invoke(["checkout"])
+        assert r.exit_code == 0, r
+        wc = repo.working_copy
+
+        with wc.session() as sess:
+            feature_count = sess.execute(f"SELECT COUNT(*) FROM {table};").scalar()
+            assert feature_count == matching_features[archive]


### PR DESCRIPTION
## Description
![](https://media4.giphy.com/media/3oKHWdZCk6zA0dPWdW/giphy.gif)


If you set a config variable - `kart.spatialfilter.geometry` - to a particular geometry, encoded in hexwkb - then Kart will only write features to your working copy that match that spatial filter.

A power user could make some use of this already, if they needed to, but there is still lots to do to make Kart fully support spatial filtering:
- Kart commands to initialise a spatially filtered repo, or to reconfigure the spatial filter on an existing repo (reconfiguring this could cause more features to be fetched and/or the WC to be rewritten)
- Kart needs to help the user avoid PK collisions when adding new features, the newly added PKs mustn't collide with the PKs of existing features that don't match the filter
- eventually, Kart shouldn't even download features that don't match the spatial filter, to save bandwidth and local disk space.

## Related links:

https://github.com/koordinates/kart/issues/456
