### PR TITLE
Configure env variables for GDAL and PROJ on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please note that compatibility for 0.x releases (software or repositories) isn't
 
 _When adding new entries to the changelog, please include issue/PR numbers wherever possible._
 
+## 0.10.3 (UNRELEASED)
+
+ * Bugfix: Set GDAL and PROJ environment variables on startup, which fixes an issue where Kart may or may not work properly depending on whether GDAL and PROJ are appropriately configured in the user's environment
+
 ## 0.10.2
 
  * Added support for the geometry `POINT EMPTY` in SQL Server working copy.

--- a/kart/__init__.py
+++ b/kart/__init__.py
@@ -63,9 +63,17 @@ else:
 os.environ["GIT_INDEX_FILE"] = os.path.join(".kart", "unlocked_index")
 
 # GDAL Data
-if not is_windows:
-    os.environ["GDAL_DATA"] = os.path.join(prefix, "share", "gdal")
-    os.environ["PROJ_LIB"] = os.path.join(prefix, "share", "proj")
+if is_windows:
+    if prefix.endswith("venv"):
+        data_prefix = os.path.join(prefix, "Lib", "site-packages", "osgeo", "data")
+    else:
+        data_prefix = os.path.join(prefix, "osgeo", "data")
+else:
+    data_prefix = os.path.join(prefix, "share")
+
+os.environ["GDAL_DATA"] = os.path.join(data_prefix, "gdal")
+os.environ["PROJ_LIB"] = os.path.join(data_prefix, "proj")
+
 
 # GPKG optimisation:
 if "OGR_SQLITE_PRAGMA" not in os.environ:


### PR DESCRIPTION
![](https://media4.giphy.com/media/l2JefhuLRZWPnxF1m/giphy.gif)

## Description

Set GDAL and PROJ data folder environment variables at Kart launch Windows. This means Kart working properly no longer depends on the global value of these variables, which other tools may also change.
The proper location of GDAL and PROJ data folder was decided empirically by searching through installed Kart folders, without referring to our changing the makefiles.
