### PR TITLE
Spatial filtering for working copies #2 - reset()

### DIFF
--- a/kart/checkout.py
+++ b/kart/checkout.py
@@ -37,9 +37,7 @@ def reset_wc_if_needed(repo, target_tree_or_commit, *, discard_changes=False):
         click.echo(f"Creating working copy at {working_copy} ...")
         working_copy.create_and_initialise()
         datasets = list(repo.datasets(target_tree_or_commit))
-        working_copy.write_full(
-            target_tree_or_commit, *datasets, spatial_filter=repo.spatial_filter
-        )
+        working_copy.write_full(target_tree_or_commit, *datasets)
 
     db_tree_matches = (
         working_copy.get_db_tree() == target_tree_or_commit.peel(pygit2.Tree).hex

--- a/kart/fsck.py
+++ b/kart/fsck.py
@@ -14,7 +14,7 @@ def _fsck_reset(repo, working_copy, dataset_paths):
     datasets = [repo.datasets()[p] for p in dataset_paths]
 
     working_copy.drop_table(commit, *datasets)
-    working_copy.write_full(commit, *datasets, spatial_filter=repo.spatial_filter)
+    working_copy.write_full(commit, *datasets)
 
 
 @click.command(context_settings=dict(ignore_unknown_options=True))

--- a/kart/init.py
+++ b/kart/init.py
@@ -61,7 +61,7 @@ def _add_datasets_to_working_copy(repo, *datasets, replace_existing=False):
 
     if replace_existing:
         wc.drop_table(commit, *datasets)
-    wc.write_full(commit, *datasets, spatial_filter=repo.spatial_filter)
+    wc.write_full(commit, *datasets)
 
 
 class GenerateIDsFromFile(StringFromFile):

--- a/kart/repo.py
+++ b/kart/repo.py
@@ -481,15 +481,17 @@ class KartRepo(pygit2.Repository):
         from .spatial_filters import SpatialFilter
 
         geometry_spec = self._get_config_str(KartConfigKeys.KART_SPATIALFILTER_GEOMETRY)
-        crs_spec = self._get_config_str(KartConfigKeys.KART_SPATIALFILTER_CRS)
+        crs_spec = self._get_config_str(
+            KartConfigKeys.KART_SPATIALFILTER_CRS, "EPSG::4326"
+        )
         return (
             SpatialFilter.from_spec(geometry_spec, crs_spec)
             if geometry_spec
             else SpatialFilter.MATCH_ALL
         )
 
-    def _get_config_str(self, key):
-        return self.config[key] if key in self.config else None
+    def _get_config_str(self, key, default=None):
+        return self.config[key] if key in self.config else default
 
     @property
     def is_bare(self):

--- a/kart/rich_base_dataset.py
+++ b/kart/rich_base_dataset.py
@@ -51,14 +51,18 @@ class RichBaseDataset(BaseDataset):
             self.features(spatial_filter, log_progress=log_progress)
         )
 
-    def get_features_with_crs_ids(self, row_pks, *, ignore_missing=False):
+    def get_features_with_crs_ids(
+        self, row_pks, *, ignore_missing=False, spatial_filter=SpatialFilter.MATCH_ALL
+    ):
         """
         Same as base_dataset.get_features(...), but includes the CRS ID from the schema in every Geometry object.
         By contrast, the returned Geometries from base_dataset.get_features(...) all contain a CRS ID of zero,
         so the schema must be consulted separately to learn about CRS IDs.
         """
         yield from self._add_crs_ids_to_features(
-            self.get_features(row_pks, ignore_missing=ignore_missing)
+            self.get_features(
+                row_pks, ignore_missing=ignore_missing, spatial_filter=spatial_filter
+            )
         )
 
     def _add_crs_ids_to_features(self, features):

--- a/kart/working_copy/base.py
+++ b/kart/working_copy/base.py
@@ -833,7 +833,7 @@ class BaseWorkingCopy:
     def write_full(self, commit, *datasets):
         """
         Writes a full layer into a working-copy table.
-        Only writes features that match the given spatial filter (defaults to the repo spatial filter.)
+        Only writes features that match the repo's spatial filter.
 
         Use for new working-copy checkouts.
         """


### PR DESCRIPTION
![](https://media4.giphy.com/media/1UU8o1EXmGSTJ8qSgS/giphy-downsized-medium.gif)

## Description

Spatial filtering (which is a not-yet-exposed kart config option) previously only worked when write_full was called - that is, when the entire dataset is rewritten to the working copy scratch. This PR makes it also work when the dataset is modified in the working copy without rewriting the entire dataset. This can happen in response to a user command like `kart checkout`, `kart restore`, or `kart reset`, depending on how different the two states are that the user is moving between.

All the TODO bullet points of the previous spatial filter PR are still required for spatial filters - this PR doesn't address them.
See https://github.com/koordinates/kart/pull/457

Tracking issue:
https://github.com/koordinates/kart/issues/456

