### PR TITLE
Filter out diff deltas that don't match the spatial filter.

### DIFF
--- a/kart/spatial_filters.py
+++ b/kart/spatial_filters.py
@@ -133,11 +133,28 @@ class SpatialFilter:
         if not ds_crs_defs:
             return self
         if len(ds_crs_defs) > 1:
-            raise NotYetImplemented(
+            raise CrsError(
                 f"Sorry, spatial filtering dataset {ds_path!r} with multiple CRS is not yet supported"
             )
         ds_crs_def = list(ds_crs_defs.values())[0]
         return result.transform_for_crs(ds_crs_def, ds_path)
+
+    def transform_for_schema_and_crs(self, schema, crs, ds_path=None):
+        """
+        Similar to transform_for_dataset above, but can also be used without a dataset object - for example,
+        to apply the spatial filter to a working copy table which might not exactly match any dataset.
+        """
+        if self.match_all:
+            return SpatialFilter.MATCH_ALL
+
+        geometry_columns = schema.geometry_columns
+        if not geometry_columns:
+            return SpatialFilter.MATCH_ALL
+        result = self.with_geom_column_name(geometry_columns[0].name)
+        if crs is None:
+            return result
+        else:
+            return result.transform_for_crs(crs, ds_path=ds_path)
 
     def with_geom_column_name(self, geom_column_name):
         if self.match_all:

--- a/kart/text_diff_writer.py
+++ b/kart/text_diff_writer.py
@@ -10,8 +10,6 @@ from .base_diff_writer import BaseDiffWriter
 
 from .output_util import format_wkt_for_output, resolve_output_path
 from .feature_output import feature_as_text, feature_field_as_text
-
-
 from .schema import Schema
 
 
@@ -64,9 +62,8 @@ class TextDiffWriter(BaseDiffWriter):
             for key, delta in ds_diff["meta"].sorted_items():
                 self.write_meta_delta(ds_path, key, delta)
 
-        if "feature" in ds_diff:
-            for key, delta in ds_diff["feature"].sorted_items():
-                self.write_feature_delta(ds_path, key, delta)
+        for key, delta in self.filtered_ds_feature_deltas(ds_path, ds_diff):
+            self.write_feature_delta(ds_path, key, delta)
 
     def write_meta_delta(self, ds_path, key, delta):
         if delta.old:


### PR DESCRIPTION
![](https://media2.giphy.com/media/aCKMaeduKfFXG/giphy.gif)

## Description

Feature deltas are only relevant to the user if either the old or the new version of the feature is inside the spatial filter. The exception to this rule is local working-copy edits, which are always relevant to the user. This PR filters out irrelevant deltas that do not match the spatial filter.

## Related links:

https://github.com/koordinates/kart/issues/456
