### PR TITLE
Add a `kart git` command

### DIFF
--- a/kart/cli.py
+++ b/kart/cli.py
@@ -215,12 +215,9 @@ def cli(ctx, repo_dir, verbose, post_mortem):
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def push(ctx, do_progress, args):
     """ Update remote refs along with associated objects """
-    execvp(
-        "git",
-        [
-            "git",
-            "-C",
-            ctx.obj.repo.path,
+    ctx.invoke(
+        git,
+        args=[
             "push",
             "--progress" if do_progress else "--quiet",
             *args,
@@ -240,12 +237,9 @@ def push(ctx, do_progress, args):
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def fetch(ctx, do_progress, args):
     """ Download objects and refs from another repository """
-    execvp(
-        "git",
-        [
-            "git",
-            "-C",
-            ctx.obj.repo.path,
+    ctx.invoke(
+        git,
+        args=[
             "fetch",
             "--progress" if do_progress else "--quiet",
             *args,
@@ -258,7 +252,7 @@ def fetch(ctx, do_progress, args):
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def remote(ctx, args):
     """ Manage set of tracked repositories """
-    execvp("git", ["git", "-C", ctx.obj.repo.path, "remote"] + list(args))
+    ctx.invoke(git, args=["remote", *args])
 
 
 @cli.command(context_settings=dict(ignore_unknown_options=True))
@@ -266,7 +260,7 @@ def remote(ctx, args):
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def tag(ctx, args):
     """ Create, list, delete or verify a tag object signed with GPG """
-    execvp("git", ["git", "-C", ctx.obj.repo.path, "tag"] + list(args))
+    ctx.invoke(git, args=["tag", *args])
 
 
 @cli.command(context_settings=dict(ignore_unknown_options=True))
@@ -274,7 +268,7 @@ def tag(ctx, args):
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def reflog(ctx, args):
     """ Manage reflog information """
-    execvp("git", ["git", "-C", ctx.obj.repo.path, "reflog"] + list(args))
+    ctx.invoke(git, args=["reflog", *args])
 
 
 @cli.command(context_settings=dict(ignore_unknown_options=True))
@@ -282,10 +276,7 @@ def reflog(ctx, args):
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def config(ctx, args):
     """ Get and set repository or global options """
-    params = ["git", "config"]
-    if ctx.obj.user_repo_path:
-        params[1:1] = ["-C", ctx.obj.user_repo_path]
-    execvp("git", params + list(args))
+    ctx.invoke(git, args=["config", *args])
 
 
 @cli.command(context_settings=dict(ignore_unknown_options=True))
@@ -293,10 +284,20 @@ def config(ctx, args):
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def gc(ctx, args):
     """ Cleanup unnecessary files and optimize the local repository """
-    params = ["git", "gc"]
+    ctx.invoke(git, args=["gc", *args])
+
+
+@cli.command(context_settings=dict(ignore_unknown_options=True), hidden=True)
+@click.pass_context
+@click.argument("args", nargs=-1, type=click.UNPROCESSED)
+def git(ctx, args):
+    """
+    Run an arbitrary git command, using kart's packaged git
+    """
+    params = ["git"]
     if ctx.obj.user_repo_path:
-        params[1:1] = ["-C", ctx.obj.user_repo_path]
-    execvp("git", params + list(args))
+        params += ["-C", ctx.obj.user_repo_path]
+    execvp("git", [*params, *args])
 
 
 def _hackily_parse_command(args):


### PR DESCRIPTION
## Description

This adds a command which just runs kart's packaged `git` with arbitrary arguments. git is invoked however kart normally invokes git, so it has kart's default config vars and any environment overrides:

```
$ kart config init.defaultBranch
main

$ git config init.defaultBranch

$ kart git config init.defaultBranch
main
```

The main reason I want this is so that in our hosting app I can run `git` on kart repos to do advanced things, and know that the config discrepancies aren't going to introduce subtle bugs in the repos.

However it might also be useful as a way for us to suggest commands for triaging bugs. We won't know if the user has git installed separately, but if `kart xyz` isn't working we can suggest an alternative `kart git ...` command that might shed some light on whatever problem they're having.

## Related links:

none

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
