### PR TITLE
Feature-count estimate improvements for string-PK datasets

### DIFF
--- a/kart/diff_estimation.py
+++ b/kart/diff_estimation.py
@@ -1,7 +1,10 @@
 import logging
+import math
 import statistics
 import subprocess
 import time
+
+import pygit2
 
 from kart.exceptions import SubprocessError
 
@@ -110,7 +113,7 @@ def get_approximate_diff_blob_count(
 
     if path_encoder.DISTRIBUTED_FEATURES:
 
-        diff_count, samples_taken = _recursive_distributed_diff_count(
+        diff_count, samples_taken = _recursive_distributed_diff_estimate(
             repo, tree1, tree2, path_encoder.branches, 16
         )
         return int(round(diff_count))
@@ -197,14 +200,25 @@ def _nonrecursive_diff(tree_a, tree_b):
     return {k: (a.get(k), b.get(k)) for k in all_names if a.get(k) != b.get(k)}
 
 
-def _recursive_distributed_diff_count(
+def _num_expected_distributed_tree_blobs(num_samples, branch_factor):
+    """
+    Returns the expected number of children in a tree of the given size.
+
+    """
+    # https://docs.google.com/document/d/11CeJKbiNQoLmhDcYIM68cJSA_nKBHW7kYVybh2N-Lww/edit#heading=h.7z95y6hc62gn
+    return math.log(1 - num_samples / branch_factor) / math.log(1 - 1 / branch_factor)
+
+
+def _recursive_distributed_diff_estimate(
     repo, tree1, tree2, branch_count, total_samples_to_take
 ):
     diff = _nonrecursive_diff(tree1, tree2)
+
     diff_size = len(diff)
     if diff_size < branch_count / 2:
-        L.debug(f"Found {diff_size} diffs.")
-        return diff_size, 1
+        estimated_blobs = _num_expected_distributed_tree_blobs(diff_size, branch_count)
+        L.debug(f"Found {diff_size} diffs for an estimate of {estimated_blobs} blobs.")
+        return estimated_blobs, 1
 
     L.debug(f"Found {diff_size} diffs, checking next level:")
 
@@ -212,9 +226,13 @@ def _recursive_distributed_diff_count(
     total_subsamples_taken = 0
     total_samples_taken = 0
     for tree1, tree2 in diff.values():
-        subsample_size, samples_taken = _recursive_distributed_diff_count(
-            repo, tree1, tree2, branch_count, total_samples_to_take
-        )
+        if isinstance(tree1, pygit2.Blob) or isinstance(tree2, pygit2.Blob):
+            subsample_size = 1
+            samples_taken = 1
+        else:
+            subsample_size, samples_taken = _recursive_distributed_diff_estimate(
+                repo, tree1, tree2, branch_count, total_samples_to_take
+            )
         total_subsample_size += subsample_size
         total_subsamples_taken += 1
         total_samples_taken += samples_taken

--- a/tests/test_diff_feature_count.py
+++ b/tests/test_diff_feature_count.py
@@ -76,15 +76,27 @@ def test_feature_count_commits_fast(data_archive, cli_runner):
         ]
 
 
-def test_feature_count_commits_string_pks(data_archive, cli_runner):
+def test_feature_count_fast_for_string_pks(data_archive, cli_runner):
     with data_archive("string-pks"):
         r = cli_runner.invoke(["diff", "--only-feature-count=fast", "HEAD^?...HEAD"])
         assert r.exit_code == 0, r.stderr
 
         assert r.stdout.splitlines() == [
             "nz_waca_adjustments:",
-            # there's actually 228, but this is a 'fast' estimate
+            # there's actually 228
             "\t213 features changed",
+        ]
+
+
+def test_feature_count_good_for_string_pks(data_archive, cli_runner):
+    with data_archive("string-pks"):
+        r = cli_runner.invoke(["diff", "--only-feature-count=good", "HEAD^?...HEAD"])
+        assert r.exit_code == 0, r.stderr
+
+        assert r.stdout.splitlines() == [
+            "nz_waca_adjustments:",
+            # there's actually 228
+            "\t229 features changed",
         ]
 
 

--- a/tests/test_diff_feature_count.py
+++ b/tests/test_diff_feature_count.py
@@ -83,7 +83,8 @@ def test_feature_count_commits_string_pks(data_archive, cli_runner):
 
         assert r.stdout.splitlines() == [
             "nz_waca_adjustments:",
-            "\t208 features changed",
+            # there's actually 228, but this is a 'fast' estimate
+            "\t213 features changed",
         ]
 
 


### PR DESCRIPTION
## Description

This is part I of a two part series to rework the feature-count estimates to be more performant, more accurate and more reliable.

Datasets with string PKs already use quite a nice algorithm for generating feature-count estimates. This PR has two incremental improvements:

1. actually take the supplied accuracy into account (`fast` vs `good` etc) by sampling more trees when higher accuracy is desired
2. When we find 30 children in a tree with a branching factor of 64, (and the children are also trees, not blobs) the current code was just returning 30 for the number of estimated features. This is subtly incorrect since features are assigned to trees randomly and thus multiple features sometimes collide into the same tree. This makes the correct result closer to 40, which can be given by this formula:

```python
>>>  log(1 - 30/64) / log(1-1/64)
40.164352384390334
```
[(derivation is in this google doc)](https://docs.google.com/document/d/11CeJKbiNQoLmhDcYIM68cJSA_nKBHW7kYVybh2N-Lww/edit#heading=h.7z95y6hc62gn)

## Related links:

none

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
