### PR TITLE
Faster, better feature count estimates for intPKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
  * Bugfix: Set GDAL and PROJ environment variables on startup, which fixes an issue where Kart may or may not work properly depending on whether GDAL and PROJ are appropriately configured in the user's environment
  * Bugfix: `kart restore` now simply discards all working copy changes, as it is intended to - previously it would complain if there were "structural" schema differences between the working copy and HEAD.
+ * Feature-count estimates are now more accurate and generally also faster [#467](https://github.com/koordinates/kart/issues/467)
 
 ## 0.10.2
 

--- a/kart/diff_estimation.py
+++ b/kart/diff_estimation.py
@@ -1,37 +1,10 @@
-import logging
-import math
-import statistics
 import subprocess
-import time
-
-import pygit2
 
 from kart.exceptions import SubprocessError
 
-L = logging.getLogger("kart.diff_estimation")
 
-# required_confidence -> z_score
-Z_SCORES = {
-    0.50: 0.0,
-    0.60: 0.26,
-    0.70: 0.53,
-    0.75: 0.68,
-    0.80: 0.85,
-    0.85: 1.04,
-    0.90: 1.29,
-    0.95: 1.65,
-    0.99: 2.33,
-}
-
-# accuracy -> (sample_size, required_confidence, z_score)
-ACCURACY_PARAMS = {
-    "veryfast": (2, 0.00001, 0.0),
-    "fast": (2, 0.60, Z_SCORES[0.60]),
-    "medium": (8, 0.80, Z_SCORES[0.80]),
-    "good": (16, 0.95, Z_SCORES[0.95]),
-}
 ACCURACY_SUBTREE_SAMPLES = {
-    "veryfast": 8,
+    "veryfast": 2,
     "fast": 16,
     "medium": 32,
     "good": 64,
@@ -109,145 +82,12 @@ def get_approximate_diff_blob_count(
     as long as both Trees are either feature trees with features arranged according to the given path_encoder,
     or the empty tree.
     """
-
-    # TODO(craigds) - write some more comments explaining how it works.
     if tree1 == tree2:
         return 0
 
-    git_rev_spec = f"{tree1.id}..{tree2.id}"
-
-    if path_encoder.DISTRIBUTED_FEATURES:
-        total_samples_to_take = ACCURACY_SUBTREE_SAMPLES[accuracy]
-        diff_count, samples_taken = _recursive_distributed_diff_estimate(
-            repo, tree1, tree2, path_encoder.branches, total_samples_to_take
-        )
-        return int(round(diff_count))
-
-    # integer PK encoder. First, find what range of trees we have
-    max_tree_id = path_encoder.max_tree_id(repo, tree1, tree2)
-    max_trees = max_tree_id + 1
-    sample_size, required_confidence, z_score = ACCURACY_PARAMS[accuracy]
-
-    if sample_size >= max_trees:
-        return get_exact_diff_blob_count(repo, tree1, tree2)
-
-    sample_mean = 0
-    while sample_size <= max_trees:
-        L.debug(
-            "sampling %d trees for dataset %s",
-            sample_size,
-            dataset_path,
-        )
-        t1 = time.monotonic()
-        # Now take a sample of all trees present
-        sample_tree_paths = list(
-            path_encoder.sample_subtrees(sample_size, max_tree_id=max_tree_id)
-        )
-        samples = _feature_count_sample_trees(
-            repo, git_rev_spec, sample_tree_paths, sample_size
-        )
-        sample_mean = statistics.mean(samples)
-        sample_stdev = statistics.stdev(samples)
-        t2 = time.monotonic()
-        if accuracy == "veryfast":
-            # Even if no features were found in the two trees, call it done.
-            # This will be Good Enough if all you need to know is something like
-            # "is the diff size probably less than 100K features?"
-            break
-        if sample_mean == 0:
-            # No features were encountered in the sample.
-            # This is likely quite a small diff.
-            # Let's just sample a lot more trees.
-            new_sample_size = min(max_trees, sample_size * 1024)
-            L.debug(
-                "sampled %s trees in %.3fs, found 0 features; increased sample size to %d",
-                sample_size,
-                t2 - t1,
-                new_sample_size,
-            )
-            sample_size = new_sample_size
-            continue
-        # Try and get within 10% of the real mean.
-        margin_of_error = 0.10 * sample_mean
-        required_sample_size = min(
-            max_trees,
-            (z_score * sample_stdev / margin_of_error) ** 2,
-        )
-        L.debug(
-            "sampled %s trees in %.3fs (ƛ=%.3f, s=%.3f). required: %.1f (margin: %.1f; confidence: %d%%)",
-            sample_size,
-            t2 - t1,
-            sample_mean,
-            sample_stdev,
-            required_sample_size,
-            margin_of_error * max_trees,
-            required_confidence * 100,
-        )
-        if sample_size >= required_sample_size:
-            break
-        if sample_size == max_trees:
-            break
-        while sample_size < required_sample_size:
-            sample_size *= 2
-        sample_size = min(max_trees, sample_size)
-    return int(round(sample_mean * max_trees))
-
-
-def _nonrecursive_diff(tree_a, tree_b):
-    """
-    Returns a dict mapping names to OIDs which differ between the trees.
-    (either the key is present in both, and the OID is different,
-    or the key is only present in one of the trees)
-    """
-    a = {obj.name: obj for obj in tree_a} if tree_a else {}
-    b = {obj.name: obj for obj in tree_b} if tree_b else {}
-    all_names = sorted(list(set(a.keys() | b.keys())))
-
-    return {k: (a.get(k), b.get(k)) for k in all_names if a.get(k) != b.get(k)}
-
-
-def _num_expected_distributed_tree_blobs(num_samples, branch_factor):
-    """
-    Returns the expected number of children in a tree of the given size.
-
-    """
-    # https://docs.google.com/document/d/11CeJKbiNQoLmhDcYIM68cJSA_nKBHW7kYVybh2N-Lww/edit#heading=h.7z95y6hc62gn
-    return math.log(1 - num_samples / branch_factor) / math.log(1 - 1 / branch_factor)
-
-
-def _recursive_distributed_diff_estimate(
-    repo, tree1, tree2, branch_count, total_samples_to_take
-):
-    diff = _nonrecursive_diff(tree1, tree2)
-
-    diff_size = len(diff)
-    if diff_size < branch_count / 2:
-        estimated_blobs = _num_expected_distributed_tree_blobs(diff_size, branch_count)
-        L.debug(f"Found {diff_size} diffs for an estimate of {estimated_blobs} blobs.")
-        return estimated_blobs, 1
-
-    L.debug(f"Found {diff_size} diffs, checking next level:")
-
-    total_subsample_size = 0
-    total_subsamples_taken = 0
-    total_samples_taken = 0
-    for tree1, tree2 in diff.values():
-        if isinstance(tree1, pygit2.Blob) or isinstance(tree2, pygit2.Blob):
-            subsample_size = 1
-            samples_taken = 1
-        else:
-            subsample_size, samples_taken = _recursive_distributed_diff_estimate(
-                repo, tree1, tree2, branch_count, total_samples_to_take
-            )
-        total_subsample_size += subsample_size
-        total_subsamples_taken += 1
-        total_samples_taken += samples_taken
-        if total_samples_taken >= total_samples_to_take:
-            break
-
-    return (
-        1.0 * diff_size * total_subsample_size / total_subsamples_taken,
-        total_samples_taken,
+    total_samples_to_take = ACCURACY_SUBTREE_SAMPLES[accuracy]
+    return path_encoder.diff_estimate(
+        tree1, tree2, path_encoder.branches, total_samples_to_take
     )
 
 

--- a/tests/test_diff_feature_count.py
+++ b/tests/test_diff_feature_count.py
@@ -59,9 +59,9 @@ def test_feature_count_commits_veryfast(data_archive, cli_runner):
         r = cli_runner.invoke(["diff", "--only-feature-count=veryfast", "HEAD^...HEAD"])
         assert r.exit_code == 0, r.stderr
 
-        # we get "0 features changed" because veryfast only ever samples 1/65536 trees.
         assert r.stdout.splitlines() == [
-            "0 features changed",
+            "nz_pa_points_topo_150k:",
+            "\t5 features changed",
         ]
 
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -131,6 +131,18 @@ def test_log_with_feature_count(data_archive, cli_runner):
         result = json.loads(r.stdout)
         result = [c["featureChanges"] for c in result]
         assert result == [
+            # in fact these are exactly right (!)
             {"nz_pa_points_topo_150k": 5},
-            {"nz_pa_points_topo_150k": 2174},
+            {"nz_pa_points_topo_150k": 2143},
+        ]
+        r = cli_runner.invoke(
+            ["log", "--output-format=json", "--with-feature-count=veryfast"]
+        )
+        assert r.exit_code == 0, r
+        result = json.loads(r.stdout)
+        result = [c["featureChanges"] for c in result]
+        assert result == [
+            # not quite so accurate, but veryfast
+            {"nz_pa_points_topo_150k": 5},
+            {"nz_pa_points_topo_150k": 2176},
         ]


### PR DESCRIPTION
![](https://media2.giphy.com/media/sPtPHvqyANbuo/giphy.gif)

## Description

feature-count estimates for integer PK datasets have been:
* doing a lot of unnecessary work, especially for sparse trees
* pretty slow, due to often running `git diff-tree` multiple times
* crashing on some large datasets while trying to sample millions(!) of trees

This change rewrites int-PK estimates to use a similar algorithm as we're already using for string-PK datasets.


## Estimates for string PKs

String-PK algorithm is to dive from the root down through the tree, until the number of child trees is less than half the branch factor. Then, sample a number of trees at that level, and average their blob count to produce an estimate.

With the string PK algorithm, we only need to dive down one tree path from the root, since we are assured of an even distribution of blobs.

## Differences for int PKs

Like string-PK datasets, we can sample a number of trees from the root, and give up once we've sampled enough. We don't need to run a git subprocess.
Unlike string-PK datsets, int-PKs have no particular distribution, and in fact may often have a very uneven distribution. For example, a fairly typical commit might delete or modify 100 evenly-distributed features, and then insert 100 features with tightly-packed PKs.

For int PKs, we instead take a number of samples at the deepest level of trees, acquired by diving through *random* trees along the way.

This is intended to mitigate the effect of having both distributed updates and tightly-packed inserts in the same commit. It will be slower than the equivalent string-PK estimate, because more non-leaf trees will be traversed along the way to achieve the same sample size.

## note

This doesn't fully avoid the problem of updates and inserts in the same commit. For instance a commit is likely to contain 999 leaf trees containing exactly one change, and 1 leaf tree containing 50 changes. So the algorithm sampling 16 trees might:

* sample 15 trees containing 1 change and 1 tree containing 50 changes, and produce an estimate of `(1/16 * 1000 * 50) + (15/16 * 1000 * 1)`
  --> 4063 features, with 1.6% probability 

* sample 16 trees containing 1 change, and produce an estimate of `(16/16 * 1000 * 1)`
  --> 1000 features, with 98.4% probability


## Related links:

none

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
