### PR TITLE
Enable auto-incrementing PKs for all WC types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## 0.10.3 (UNRELEASED)
 
+### Major changes
+
+ * Added basic support for spatial filters - the spatial filter can be updated during an `init`, `clone` or `checkout` by supplying the option `--spatial-filter=CRS;GEOMETRY` where CRS is a string such as `EPSG:4326` and GEOMETRY is a polygon or multigon specified using WKT or hex-encoded WKB. When a spatial filter is set, the working copy will only contain features that intersect the spatial filter, and changes that happened outside the working copy are not shown to the user unless specifically required. [#456](https://github.com/koordinates/kart/issues/456)
+
+### Other changes
+ * Auto-incrementing integer PKs: When the working copy is written, Kart now sets up a sequence which supplies the next unassigned PK value and sets it as the default value for the PK column. This helps the user find the next unassigned PK, which can be non-obvious in particular when a spatial filter has been applied and not all features are present in the working copy. [#468](https://github.com/koordinates/kart/pull/468)
  * Bugfix: Set GDAL and PROJ environment variables on startup, which fixes an issue where Kart may or may not work properly depending on whether GDAL and PROJ are appropriately configured in the user's environment
  * Bugfix: `kart restore` now simply discards all working copy changes, as it is intended to - previously it would complain if there were "structural" schema differences between the working copy and HEAD.
  * Feature-count estimates are now more accurate and generally also faster [#467](https://github.com/koordinates/kart/issues/467)

--- a/docs/SQL_SERVER_WC.md
+++ b/docs/SQL_SERVER_WC.md
@@ -1,7 +1,7 @@
 SQL Server Working Copy
 -----------------------
 
-In order to use a [Microsoft SQL Server](https://docs.microsoft.com/sql/sql-server/) working copy, you need to have a SQL Server running. SQL Server 2016 and later is officially supported by Kart (SQL Server 2008 and later are largely compatible but not officially supported).
+In order to use a [Microsoft SQL Server](https://docs.microsoft.com/sql/sql-server/) working copy, you need to have a SQL Server running. SQL Server 2016 and later is officially supported by Kart (SQL Server 2012 and later are largely compatible but not officially supported).
 
 You also need to have the [Microsoft ODBC Driver for SQL Server](https://docs.microsoft.com/sql/connect/odbc/microsoft-odbc-driver-for-sql-server) installed on your system.
 

--- a/kart/sqlalchemy/adapter/mysql.py
+++ b/kart/sqlalchemy/adapter/mysql.py
@@ -91,6 +91,16 @@ class KartAdapter_MySql(BaseKartAdapter, Db_MySql):
     }
 
     @classmethod
+    def v2_column_schema_to_sql_spec(cls, col, v2_obj=None, has_int_pk=False):
+        result = super().v2_column_schema_to_sql_spec(col, v2_obj)
+
+        # Make int PKs auto-increment.
+        if has_int_pk and col.pk_index is not None:
+            result += " AUTO_INCREMENT"
+
+        return result
+
+    @classmethod
     def v2_type_to_sql_type(cls, col, v2_obj=None):
         sql_type = super().v2_type_to_sql_type(col, v2_obj)
 

--- a/kart/sqlalchemy/adapter/postgis.py
+++ b/kart/sqlalchemy/adapter/postgis.py
@@ -72,6 +72,17 @@ class KartAdapter_Postgis(BaseKartAdapter, Db_Postgis):
     ZM_FLAG_TO_STRING = {0: "", 1: "M", 2: "Z", 3: "ZM"}
 
     @classmethod
+    def v2_column_schema_to_sql_spec(cls, col, v2_obj=None, has_int_pk=False):
+        col_name = cls.quote(col.name)
+        sql_type = cls.v2_type_to_sql_type(col, v2_obj)
+
+        # Make int PKs auto-increment.
+        if has_int_pk and col.pk_index is not None:
+            sql_type = sql_type.replace("INT", "SERIAL")
+
+        return f"{col_name} {sql_type}"
+
+    @classmethod
     def v2_type_to_sql_type(cls, col, v2_obj=None):
         sql_type = super().v2_type_to_sql_type(col, v2_obj)
 

--- a/kart/sqlalchemy/adapter/postgis.py
+++ b/kart/sqlalchemy/adapter/postgis.py
@@ -1,4 +1,5 @@
 import decimal
+import re
 
 from osgeo.osr import SpatialReference
 from psycopg2.extensions import Binary
@@ -78,7 +79,8 @@ class KartAdapter_Postgis(BaseKartAdapter, Db_Postgis):
 
         # Make int PKs auto-increment.
         if has_int_pk and col.pk_index is not None:
-            sql_type = sql_type.replace("INT", "SERIAL")
+            # SMALLINT, INTEGER, BIGINT -> SMALLSERIAL, SERIAL, BIGSERIAL
+            sql_type = re.sub("INT(EGER)?", "SERIAL", sql_type)
 
         return f"{col_name} {sql_type}"
 

--- a/kart/sqlalchemy/adapter/sqlserver.py
+++ b/kart/sqlalchemy/adapter/sqlserver.py
@@ -123,7 +123,7 @@ class KartAdapter_SqlServer(BaseKartAdapter, Db_SqlServer):
     )
 
     @classmethod
-    def v2_column_schema_to_sql_spec(cls, col, v2_obj=None):
+    def v2_column_schema_to_sql_spec(cls, col, v2_obj=None, has_int_pk=False):
         result = super().v2_column_schema_to_sql_spec(col, v2_obj)
         constraints = cls.get_sql_type_constraints(col, v2_obj)
         return f"{result} {constraints}" if constraints else result

--- a/kart/sqlalchemy/mysql.py
+++ b/kart/sqlalchemy/mysql.py
@@ -60,3 +60,9 @@ class Db_MySql(BaseDb):
                 )
             )
             return {f"{row['TABLE_SCHEMA']}.{row['TABLE_NAME']}": None for row in r}
+
+    @classmethod
+    def drop_all_in_schema(cls, sess, db_schema):
+        """Drops all tables and routines in schema db_schema."""
+        for thing in ("table", "routine"):
+            cls._drop_things_in_schema(cls, sess, db_schema, thing)

--- a/kart/working_copy/base.py
+++ b/kart/working_copy/base.py
@@ -983,7 +983,7 @@ class BaseWorkingCopy:
 
     def _initialise_sequence(self, sess, dataset):
         """Sets up an auto-increment integer PK sequence so that a useful default PK value is provided."""
-        raise NotImplementedError()
+        pass
 
     def _drop_sequence(self, sess, dataset):
         """Drop the PK auto-increment sequence associated with this dataset."""
@@ -1254,6 +1254,10 @@ class BaseWorkingCopy:
             self._apply_feature_diff(
                 sess, base_ds, target_ds, feature_filter, track_changes_as_dirty
             )
+
+        if not target_ds.feature_path_encoder.DISTRIBUTED_FEATURES:
+            # Set up a sequence so that the user doesn't have to supply the next int PK.
+            self._initialise_sequence(sess, target_ds)
 
         self._update_last_write_time(sess, target_ds, commit)
 

--- a/kart/working_copy/base.py
+++ b/kart/working_copy/base.py
@@ -916,13 +916,17 @@ class BaseWorkingCopy:
                 ):
                     sess.execute(sql, row_dicts)
 
-                t1 = time.monotonic()
                 if dataset.has_geometry:
                     self._create_spatial_index_post(sess, dataset)
+
+                if not dataset.feature_path_encoder.DISTRIBUTED_FEATURES:
+                    # Set up a sequence so that the user doesn't have to supply the next int PK.
+                    self._initialise_sequence(sess, dataset)
 
                 self._create_triggers(sess, dataset)
                 self._update_last_write_time(sess, dataset, commit)
 
+                t1 = time.monotonic()
                 L.info(
                     "Wrote dataset %d of %d in %.1fs: %s",
                     i + 1,
@@ -975,6 +979,15 @@ class BaseWorkingCopy:
 
     def _drop_spatial_index(self, sess, dataset):
         """Inverse of _create_spatial_index_* - deletes the spatial index."""
+        pass
+
+    def _initialise_sequence(self, sess, dataset):
+        """Sets up an auto-increment integer PK sequence so that a useful default PK value is provided."""
+        raise NotImplementedError()
+
+    def _drop_sequence(self, sess, dataset):
+        """Drop the PK auto-increment sequence associated with this dataset."""
+        # Subclasses only need to override if the sequence is not automatically cleaned up by dropping the table.
         pass
 
     def _update_last_write_time(self, sess, dataset, commit=None):
@@ -1034,6 +1047,7 @@ class BaseWorkingCopy:
                         kart_track.c.table_name == dataset.table_name
                     )
                 )
+                self._drop_sequence(sess, dataset)
 
     def _delete_meta(self, sess, dataset):
         """

--- a/kart/working_copy/gpkg.py
+++ b/kart/working_copy/gpkg.py
@@ -462,6 +462,14 @@ class WorkingCopy_GPKG(BaseWorkingCopy):
 
         L.info("Dropped spatial index in %.1fs", time.monotonic() - t0)
 
+    def _initialise_sequence(self, sess, dataset):
+        start = dataset.feature_path_encoder.find_start_of_unassigned_range(dataset)
+        if start:
+            sess.execute(
+                "INSERT OR REPLACE INTO sqlite_sequence (name, seq) VALUES (:table_name, :seq)",
+                {"table_name": dataset.table_name, "seq": start - 1},
+            )
+
     def _sno_tracking_name(self, trigger_type, dataset):
         assert trigger_type in ("ins", "upd", "del")
         assert dataset is not None

--- a/kart/working_copy/mysql.py
+++ b/kart/working_copy/mysql.py
@@ -148,6 +148,14 @@ class WorkingCopy_MySql(DatabaseServer_WorkingCopy):
         # MySQL deletes the spatial index automatically when the table is deleted.
         pass
 
+    def _initialise_sequence(self, sess, dataset):
+        start = dataset.feature_path_encoder.find_start_of_unassigned_range(dataset)
+        if start:
+            sess.execute(
+                f"ALTER TABLE {self.table_identifier(dataset)} AUTO_INCREMENT = :start;",
+                {"start": start},
+            )
+
     def _sno_tracking_name(self, trigger_type, dataset=None):
         """Returns the sno-branded name of the trigger reponsible for populating the sno_track table."""
         return f"_sno_track_{trigger_type}"

--- a/kart/working_copy/sqlserver.py
+++ b/kart/working_copy/sqlserver.py
@@ -140,6 +140,32 @@ class WorkingCopy_SqlServer(DatabaseServer_WorkingCopy):
         # SQL server deletes the spatial index automatically when the table is deleted.
         pass
 
+    def _initialise_sequence(self, sess, dataset):
+        start = dataset.feature_path_encoder.find_start_of_unassigned_range(dataset)
+        if start:
+            seq_name = f"{dataset.table_name}_{dataset.primary_key}_seq"
+            sess.execute(
+                f"CREATE SEQUENCE {self.table_identifier(seq_name)} START WITH {start};",
+            )
+            constraint_name = f"{dataset.table_name}_{dataset.primary_key}_dflt"
+            sess.execute(
+                f"""
+                ALTER TABLE {self.table_identifier(dataset)}
+                ADD CONSTRAINT {self.quote(constraint_name)}
+                DEFAULT NEXT VALUE FOR {self.table_identifier(seq_name)}
+                FOR {self.quote(dataset.primary_key)};
+                """
+            )
+
+    def _drop_sequence(self, sess, dataset):
+        seq_name = f"{dataset.table_name}_{dataset.primary_key}_seq"
+        seq_exists = sess.scalar(
+            "SELECT COUNT(*) FROM sys.sequences WHERE object_id = object_id(:full_seq_name)",
+            {"full_seq_name": f"{self.db_schema}.{seq_name}"},
+        )
+        if seq_exists:
+            sess.execute(f"DROP SEQUENCE {self.table_identifier(seq_name)};")
+
     def _sno_tracking_name(self, trigger_type, dataset):
         assert trigger_type == "trigger"
         assert dataset is not None

--- a/tests/test_working_copy_gpkg.py
+++ b/tests/test_working_copy_gpkg.py
@@ -875,6 +875,21 @@ def test_delete_branch(data_working_copy, cli_runner):
         assert r.exit_code == 0, r
 
 
+def test_auto_increment_pk(data_working_copy):
+    with data_working_copy("polygons") as (repo_path, wc):
+        repo = KartRepo(repo_path)
+        with repo.working_copy.session() as sess:
+            count = sess.scalar(
+                f"SELECT COUNT(*) FROM {H.POLYGONS.LAYER} WHERE id = {H.POLYGONS.NEXT_UNASSIGNED_PK};"
+            )
+            assert count == 0
+            sess.execute(f"INSERT INTO {H.POLYGONS.LAYER} (geom) VALUES (NULL);")
+            count = sess.scalar(
+                f"SELECT COUNT(*) FROM {H.POLYGONS.LAYER} WHERE id = {H.POLYGONS.NEXT_UNASSIGNED_PK};"
+            )
+            assert count == 1
+
+
 def test_approximated_types():
     assert KartAdapter_GPKG.APPROXIMATED_TYPES == compute_approximated_types(
         KartAdapter_GPKG.V2_TYPE_TO_SQL_TYPE, KartAdapter_GPKG.SQL_TYPE_TO_V2_TYPE

--- a/tests/test_working_copy_mysql.py
+++ b/tests/test_working_copy_mysql.py
@@ -301,6 +301,27 @@ def test_edit_schema(data_archive, cli_runner, new_mysql_db_schema):
             assert repo.head.peel(pygit2.Commit).hex == orig_head
 
 
+def test_auto_increment_pk(data_archive, cli_runner, new_mysql_db_schema):
+    with data_archive("polygons") as repo_path:
+        H.clear_working_copy()
+        with new_mysql_db_schema() as (mysql_url, mysql_schema):
+            r = cli_runner.invoke(["create-workingcopy", mysql_url])
+            assert r.exit_code == 0, r.stderr
+
+            repo = KartRepo(repo_path)
+            with repo.working_copy.session() as sess:
+                t = f"{mysql_schema}.{H.POLYGONS.LAYER}"
+                count = sess.scalar(
+                    f"SELECT COUNT(*) FROM {t} WHERE id = {H.POLYGONS.NEXT_UNASSIGNED_PK};"
+                )
+                assert count == 0
+                sess.execute(f"INSERT INTO {t} (geom) VALUES (NULL);")
+                count = sess.scalar(
+                    f"SELECT COUNT(*) FROM {t} WHERE id = {H.POLYGONS.NEXT_UNASSIGNED_PK};"
+                )
+                assert count == 1
+
+
 def test_approximated_types():
     assert KartAdapter_MySql.APPROXIMATED_TYPES == compute_approximated_types(
         KartAdapter_MySql.V2_TYPE_TO_SQL_TYPE, KartAdapter_MySql.SQL_TYPE_TO_V2_TYPE


### PR DESCRIPTION
![](https://media4.giphy.com/media/H46Dtwtwo1FDO/giphy.gif)

When the working copy is written, Kart now sets up a sequence which supplies the next unassigned PK value and sets it as the default value for the PK column.

This is normally simply a convenience for the user - the user doesn't have to think of a new PK, the next unassigned one is
automatically supplied for them.

However, it serves another purpose when a spatial filter is active. The PK that is automatically supplied is guaranteed not to clash with any feature inside OR outside of the spatial filter - the user may have no other easy way of providing such a PK themselves without disabling the spatial filter.

## Related links:

https://github.com/koordinates/kart/issues/456

