### PR TITLE
Improve performance of cached estimates in logs

### DIFF
--- a/kart/annotations/cli.py
+++ b/kart/annotations/cli.py
@@ -61,10 +61,9 @@ def build_annotations(ctx, all_reachable):
                     f"({i+1}/{len(commits)}): {commit.short_id} {commit.message.splitlines()[0]}"
                 )
                 estimate_diff_feature_counts(
-                    repo.structure(
-                        commit.parent_ids[0] if commit.parent_ids else EMPTY_TREE_SHA
-                    ),
-                    repo.structure(commit),
+                    repo,
+                    commit.parents[0] if commit.parents else repo.empty_tree,
+                    commit,
                     accuracy="exact",
                 )
     click.echo("done.")

--- a/kart/base_diff_writer.py
+++ b/kart/base_diff_writer.py
@@ -80,7 +80,7 @@ class BaseDiffWriter:
     ):
         self.repo = repo
         self.commit_spec = commit_spec
-        self.base_rs, self.target_rs, self.working_copy = self._parse_diff_commit_spec(
+        self.base_rs, self.target_rs, self.working_copy = self.parse_diff_commit_spec(
             repo, commit_spec
         )
 
@@ -135,7 +135,7 @@ class BaseDiffWriter:
         return output_path
 
     @classmethod
-    def _parse_diff_commit_spec(cls, repo, commit_spec):
+    def parse_diff_commit_spec(cls, repo, commit_spec):
         # Parse <commit> or <commit>...<commit>
         commit_spec = commit_spec or "HEAD"
         commit_parts = re.split(r"(\.{2,3})", commit_spec)

--- a/kart/diff.py
+++ b/kart/diff.py
@@ -24,12 +24,16 @@ def feature_count_diff(
     repo = ctx.obj.repo
     from .base_diff_writer import BaseDiffWriter
 
-    base_rs, target_rs, working_copy = BaseDiffWriter._parse_diff_commit_spec(
+    base_rs, target_rs, working_copy = BaseDiffWriter.parse_diff_commit_spec(
         repo, commit_spec
     )
 
     dataset_change_counts = diff_estimation.estimate_diff_feature_counts(
-        base_rs, target_rs, working_copy=working_copy, accuracy=accuracy
+        repo,
+        base_rs.tree,
+        target_rs.tree,
+        working_copy=working_copy,
+        accuracy=accuracy,
     )
 
     if output_format == "text":

--- a/kart/diff_estimation.py
+++ b/kart/diff_estimation.py
@@ -114,14 +114,15 @@ def estimate_diff_feature_counts(
 
     assert accuracy in ACCURACY_CHOICES
 
-    annotation_type = f"feature-change-counts-{accuracy}"
-    annotation = repo.diff_annotations.get(
-        base=base,
-        target=target,
-        annotation_type=annotation_type,
-    )
-    if annotation is not None:
-        return annotation
+    if not working_copy:
+        annotation_type = f"feature-change-counts-{accuracy}"
+        annotation = repo.diff_annotations.get(
+            base=base,
+            target=target,
+            annotation_type=annotation_type,
+        )
+        if annotation is not None:
+            return annotation
 
     base_rs = repo.structure(base)
     target_rs = repo.structure(target)

--- a/kart/log.py
+++ b/kart/log.py
@@ -101,9 +101,6 @@ def _parse_git_log_output(lines):
         yield commit_id, [r.strip() for r in refs]
 
 
-EMPTY_TREE_SHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
-
-
 def commit_obj_to_json(
     commit,
     repo=None,
@@ -154,13 +151,15 @@ def commit_obj_to_json(
                 parent_commit = commit.parents[0]
             except (KeyError, IndexError):
                 # shallow clone (parent not present) or initial commit (no parents)
-                base_rs = repo.structure(EMPTY_TREE_SHA)
+                base = repo.empty_tree
             else:
-                base_rs = repo.structure(parent_commit)
+                base = parent_commit
 
-            target_rs = repo.structure(commit)
             result["featureChanges"] = diff_estimation.estimate_diff_feature_counts(
-                base_rs, target_rs, accuracy=with_feature_count
+                repo,
+                base=base,
+                target=commit,
+                accuracy=with_feature_count,
             )
         else:
             result["featureChanges"] = {}


### PR DESCRIPTION


## Description

This avoids instantiating two RepoStructure objects for each commit in a
log, when we're fetching cached estimates (stored in annotations.db) with `--with-feature-count=...`

This shaves a bit off processing each commit.
For a repo with 492 commits, the difference is ~0.43s:

Before:
```
$ hyperfine 'kart log --with-feature-count=medium -o json > /dev/null'
Benchmark #1: kart log --with-feature-count=medium -o json > /dev/null
  Time (mean ± σ):      2.861 s ±  0.034 s    [User: 2.078 s, System: 0.769 s]
  Range (min … max):    2.813 s …  2.919 s    10 runs
```

After:
```
$ hyperfine 'kart log --with-feature-count=medium -o json > /dev/null'
Benchmark #1: kart log --with-feature-count=medium -o json > /dev/null
  Time (mean ± σ):      2.429 s ±  0.043 s    [User: 1.851 s, System: 0.571 s]
  Range (min … max):    2.371 s …  2.494 s    10 runs
```

## Related links:

none

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
