### PR TITLE
log: Add `--output-format=json-lines`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
  * Bugfix: Set GDAL and PROJ environment variables on startup, which fixes an issue where Kart may or may not work properly depending on whether GDAL and PROJ are appropriately configured in the user's environment
  * Bugfix: `kart restore` now simply discards all working copy changes, as it is intended to - previously it would complain if there were "structural" schema differences between the working copy and HEAD.
  * Feature-count estimates are now more accurate and generally also faster [#467](https://github.com/koordinates/kart/issues/467)
+ * `kart log` now supports output in JSON-lines format, so that large logs can be streamed before being entirely generated.
 
 ## 0.10.2
 

--- a/kart/output_util.py
+++ b/kart/output_util.py
@@ -190,7 +190,7 @@ def dump_json_output(
 
     fp = resolve_output_path(output_path)
 
-    highlit = json_style == "pretty" and can_output_colour(fp)
+    highlit = can_output_colour(fp)
     json_encoder = encoder_class(**JSON_PARAMS[json_style], **encoder_kwargs)
     if highlit:
         json_lexer = JsonLexer()

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -5,11 +5,11 @@ import pytest
 H = pytest.helpers.helpers()
 
 
-@pytest.mark.parametrize("output_format", ["text", "json"])
+@pytest.mark.parametrize("output_format", ["text", "json", "json-lines"])
 def test_log(output_format, data_archive_readonly, cli_runner):
     """ review commit history """
     with data_archive_readonly("points"):
-        extra_args = ["--dataset-changes"] if output_format == "json" else []
+        extra_args = ["--dataset-changes"] if output_format.startswith("json") else []
         r = cli_runner.invoke(["log", f"--output-format={output_format}"] + extra_args)
         assert r.exit_code == 0, r
         if output_format == "text":
@@ -26,7 +26,7 @@ def test_log(output_format, data_archive_readonly, cli_runner):
                 "",
                 "    Import from nz-pa-points-topo-150k.gpkg",
             ]
-        else:
+        elif output_format == "json":
             assert json.loads(r.stdout) == [
                 {
                     "commit": H.POINTS.HEAD_SHA,
@@ -63,6 +63,24 @@ def test_log(output_format, data_archive_readonly, cli_runner):
                     "datasetChanges": ["nz_pa_points_topo_150k"],
                 },
             ]
+        else:
+            assert json.loads(r.stdout.splitlines()[1]) == {
+                "commit": H.POINTS.HEAD1_SHA,
+                "abbrevCommit": H.POINTS.HEAD1_SHA[:7],
+                "message": "Import from nz-pa-points-topo-150k.gpkg",
+                "refs": [],
+                "authorEmail": "robert@coup.net.nz",
+                "authorName": "Robert Coup",
+                "authorTime": "2019-06-11T11:03:58Z",
+                "authorTimeOffset": "+01:00",
+                "commitTime": "2019-06-11T11:03:58Z",
+                "commitTimeOffset": "+01:00",
+                "committerEmail": "robert@coup.net.nz",
+                "committerName": "Robert Coup",
+                "parents": [],
+                "abbrevParents": [],
+                "datasetChanges": ["nz_pa_points_topo_150k"],
+            }
 
 
 @pytest.mark.parametrize("output_format", ["text", "json"])


### PR DESCRIPTION
## Description

Adds the `json-lines` output format to the `log` command (already exists for `diff`, `show`)

Just outputs the same stuff as the `json` output, but with each item on its own line for easy stream consumption.

## Related links:

none

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
