### PR TITLE
Fix GeoJSON diff regressions in v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## 0.10.5 (UNRELEASED)
 
+ * Fixed regressions in `diff -o geojson` since Kart 0.10.1 [#487](https://github.com/koordinates/kart/issues/487)
+ * Removed `kart show -o geojson` [#487](https://github.com/koordinates/kart/issues/487#issuecomment-933561924)
  * Fix for [#478](https://github.com/koordinates/kart/issues/478) `merge --dry-run` raises error
  * Fix for [#483](https://github.com/koordinates/kart/issues/483) `diff` error with Z/M geometries
 

--- a/kart/show.py
+++ b/kart/show.py
@@ -10,9 +10,8 @@ from . import diff_estimation
 @click.option(
     "--output-format",
     "-o",
-    type=click.Choice(
-        ["text", "json", "geojson", "quiet", "feature-count", "html", "json-lines"]
-    ),
+    # note: geojson was removed from here because it doesn't work with multiple datasets.
+    type=click.Choice(["text", "json", "quiet", "feature-count", "html", "json-lines"]),
     default="text",
     help=(
         "Output format. 'quiet' disables all output and implies --exit-code.\n"
@@ -39,7 +38,7 @@ from . import diff_estimation
     "--json-style",
     type=click.Choice(["extracompact", "compact", "pretty"]),
     default="pretty",
-    help="How to format the output. Only used with -o json or -o geojson",
+    help="How to format the output. Only used with -o json",
 )
 @click.option(
     "--only-feature-count",


### PR DESCRIPTION


## Description
* Revert `kart diff --output-format=geojson` output handling to the
  pre-0.10.1 behaviour. That is:
  - by default, output goes to stdout
  - if output goes to stdout and there are more than one dataset,
    a usage error occurs (exit code 2) with an error message.
  - `--output=mydirectory` can be used to set a directory into which to
    write output files; one file per dataset.
  - if an existing directory is given, any `*.geojson` files in the
    directory are deleted before creating output files
  - if a path to an existing regular file is given, a usage error
    occurs.

* Remove `kart show --output-format=geojson`. This doesn't work well
  with multiple-dataset commits and was added rather coincidentally
  between 0.10.0 and 0.10.1. We'll remove it for simplicity as it isn't
  very usable; if multiple datasets end up in a single commit, then this
  shows all features together in one FeatureCollection, even if their
  feature schemas are different.

## Related links:

Fixes #487


## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
