### PR TITLE
dataset paths: Forbid certain chars & components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## 0.10.6 (UNRELEASED)
 
- * New `kart data rm` command to simply delete datasets and commit the result [#490](https://github.com/koordinates/kart/issues/491)
- * Fix for [#491](https://github.com/koordinates/kart/issues/491) - make Kart more robust to manual edits to the GPKG working copy that don't leave the metadata exactly as Kart would leave it (such as by leaving unneeded table rows in `gpkg_contents`)
-* `kart create-patch` now supports `--patch-type minimal`, which creates a much-smaller patch; relying on the patch recipient having the HEAD commit in their repository [#482](https://github.com/koordinates/kart/issues/482)
-* `kart apply` now applies both types of patch.
+* Added a specification for allowed characters & path components in dataset names - see [Valid Dataset Names](https://github.com/koordinates/kart/blob/master/docs/DATASETS_v3.md#valid-dataset-names).
+* New `kart data rm` command to simply delete datasets and commit the result [#490](https://github.com/koordinates/kart/issues/491)
+* Fix for [#491](https://github.com/koordinates/kart/issues/491) - make Kart more robust to manual edits to the GPKG working copy that don't leave the metadata exactly as Kart would leave it (such as by leaving unneeded table rows in `gpkg_contents`)
+* Added minimal patches:
+  - `kart create-patch` now supports `--patch-type minimal`, which creates a much-smaller patch; relying on the patch recipient having the HEAD commit in their repository [#482](https://github.com/koordinates/kart/issues/482)
+  - `kart apply` now applies both types of patch.
 * `kart log` now accepts a `--` marker to signal that all remaining arguments are dataset names. [#498](https://github.com/koordinates/kart/issues/498)
 * Bugfix: Diffing between an old commit and the current working copy no longer fails when datasets have been deleted in the intervening commits.
 * Bugfix: Existing auto-incrementing integer PK sequences are now overwritten properly in GPKG working copies. [#468](https://github.com/koordinates/kart/pull/468)

--- a/docs/DATASETS_v3.md
+++ b/docs/DATASETS_v3.md
@@ -386,4 +386,6 @@ Datasets have names, which can actually be hierarchical paths, e.g. `hydro/sound
 * Path components may not be any of these [reserved Windows filenames](https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN#naming-conventions): `CON`, `PRN`, `AUX`, `NUL`, `COM1`, `COM2`, `COM3`, `COM4`, `COM5`, `COM6`, `COM7`, `COM8`, `COM9`, `LPT1`, `LPT2`, `LPT3`, `LPT4`, `LPT5`, `LPT6`, `LPT7`, `LPT8`, `LPT9`.
 * Repositories may not contain more than one dataset with names that differ only by case.
 
+Additionally, backslashes (`\`) in dataset paths are converted to forward slashes (`/`) when imported.
+
 These rules exist to help ensure that Kart repositories can be checked out on a range of operating systems and filesystems.

--- a/docs/DATASETS_v3.md
+++ b/docs/DATASETS_v3.md
@@ -381,7 +381,7 @@ Datasets have names, which can actually be hierarchical paths, e.g. `hydro/sound
 
 * Paths may contain most unicode characters
 * Paths must not contain any ASCII control characters (codepoints 00 to 1F), or any of the characters `:`, `<`, `>`, `"`, `|`, `?`, or `*`
-* Paths must begin with a letter.
+* Paths must begin with a letter or an underscore (`_`).
 * No path component may end with a `.` or a ` ` (space)
 * Path components may not be any of these [reserved Windows filenames](https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN#naming-conventions): `CON`, `PRN`, `AUX`, `NUL`, `COM1`, `COM2`, `COM3`, `COM4`, `COM5`, `COM6`, `COM7`, `COM8`, `COM9`, `LPT1`, `LPT2`, `LPT3`, `LPT4`, `LPT5`, `LPT6`, `LPT7`, `LPT8`, `LPT9`.
 * Repositories may not contain more than one dataset with names that differ only by case.

--- a/docs/DATASETS_v3.md
+++ b/docs/DATASETS_v3.md
@@ -293,7 +293,7 @@ A feature path might look like this:
 
 `A/A/A/B/kU0=`
 
-There are two parts to this: the path to the file - `A/A/A/B` - and the filename itself - `kU0=`. 
+There are two parts to this: the path to the file - `A/A/A/B` - and the filename itself - `kU0=`.
 
 #### Feature path filename
 
@@ -374,3 +374,16 @@ Datasets V2 only supports a single path structure, which is not stored in the da
 ```
 
 See [DATASETS_v2](DATASETS_v2.md).
+
+### Valid Dataset Names
+
+Datasets have names, which can actually be hierarchical paths, e.g. `hydro/soundings`. Kart enforces the following rules about these paths:
+
+* Paths may contain most unicode characters
+* Paths must not contain any ASCII control characters (codepoints 00 to 1F), or any of the characters `:`, `<`, `>`, `"`, `|`, `?`, or `*`
+* Paths must begin with a letter.
+* No path component may end with a `.` or a ` ` (space)
+* Path components may not be any of these [reserved Windows filenames](https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN#naming-conventions): `CON`, `PRN`, `AUX`, `NUL`, `COM1`, `COM2`, `COM3`, `COM4`, `COM5`, `COM6`, `COM7`, `COM8`, `COM9`, `LPT1`, `LPT2`, `LPT3`, `LPT4`, `LPT5`, `LPT6`, `LPT7`, `LPT8`, `LPT9`.
+* Repositories may not contain more than one dataset with names that differ only by case.
+
+These rules exist to help ensure that Kart repositories can be checked out on a range of operating systems and filesystems.

--- a/kart/base_dataset.py
+++ b/kart/base_dataset.py
@@ -119,8 +119,10 @@ class BaseDataset(ImportSource):
         if not path_bytes:
             raise InvalidOperation(f"Dataset path {path!r} may not be empty")
 
-        if not unicodedata.category(path[0]).startswith("L"):
-            raise InvalidOperation(f"Dataset path {path!r} must begin with a letter")
+        if not (path[0] == "_" or unicodedata.category(path[0]).startswith("L")):
+            raise InvalidOperation(
+                f"Dataset path {path!r} must begin with a letter or an underscore"
+            )
 
         if path_bytes.intersection(control_chars):
             raise InvalidOperation(

--- a/kart/base_dataset.py
+++ b/kart/base_dataset.py
@@ -132,6 +132,11 @@ class BaseDataset(ImportSource):
                 f"Dataset path {path!r} may not contain any of these characters: {other}"
             )
         components = path.upper().split("/")
+        if any(not c for c in components):
+            raise InvalidOperation(
+                f"Dataset path {path!r} may not contain empty components"
+            )
+
         bad_parts = sorted(cls._RESERVED_WINDOWS_FILENAMES.intersection(components))
         if bad_parts:
             raise InvalidOperation(

--- a/kart/base_dataset.py
+++ b/kart/base_dataset.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
 import functools
 import logging
 import time
+import unicodedata
 
 from . import crs_util
 from .import_source import ImportSource
 from . import meta_items
+from .exceptions import InvalidOperation
 from .serialise_util import json_unpack, ensure_text
 from .spatial_filters import SpatialFilter
 from .utils import ungenerator
@@ -70,6 +73,92 @@ class BaseDataset(ImportSource):
         self.L = logging.getLogger(self.__class__.__qualname__)
 
         self.repo = repo
+
+    _RESERVED_WINDOWS_FILENAMES = frozenset(
+        {
+            "CON",
+            "PRN",
+            "AUX",
+            "NUL",
+            "COM1",
+            "COM2",
+            "COM3",
+            "COM4",
+            "COM5",
+            "COM6",
+            "COM7",
+            "COM8",
+            "COM9",
+            "LPT1",
+            "LPT2",
+            "LPT3",
+            "LPT4",
+            "LPT5",
+            "LPT6",
+            "LPT7",
+            "LPT8",
+            "LPT9",
+        }
+    )
+
+    @classmethod
+    def _validate_dataset_path(cls, path: str) -> None:
+        """
+        Checks that the given dataset path has no disallowed characters or path components.
+        """
+        # disallow ASCII control characters as well as a few printable characters
+        # (mostly because they're disallowed in Windows filenames)
+        # but also because allowing ':' would make filter-spec parsing ambiguous in the Kart CLI.
+        control_chars = set(range(0, 0x20))
+        try:
+            path_bytes = set(path.encode("utf8"))
+        except UnicodeEncodeError:
+            raise InvalidOperation(
+                f"Dataset path {path!r} cannot be encoded using UTF-8"
+            )
+        if not path_bytes:
+            raise InvalidOperation(f"Dataset path {path!r} may not be empty")
+
+        if not unicodedata.category(path[0]).startswith("L"):
+            raise InvalidOperation(f"Dataset path {path!r} must begin with a letter")
+
+        if path_bytes.intersection(control_chars):
+            raise InvalidOperation(
+                f"Dataset path {path!r} may not contain ASCII control characters"
+            )
+        other = ':<>"|?*'
+        if set(path_bytes).intersection(other.encode()):
+            raise InvalidOperation(
+                f"Dataset path {path!r} may not contain any of these characters: {other}"
+            )
+        components = path.upper().split("/")
+        bad_parts = sorted(cls._RESERVED_WINDOWS_FILENAMES.intersection(components))
+        if bad_parts:
+            raise InvalidOperation(
+                f"Dataset path {path!r} may not contain a component called {bad_parts[0]}"
+            )
+
+        if any(comp.startswith(".") or comp.endswith(".") for comp in components):
+            raise InvalidOperation(
+                f"Dataset path {path!r} may not contain a component starting or ending with a '.'"
+            )
+        if any(comp.endswith(" ") for comp in components):
+            raise InvalidOperation(
+                f"Dataset path {path!r} may not contain a component ending with a ' '"
+            )
+
+    @classmethod
+    def validate_dataset_paths(cls, paths: list[str]) -> None:
+        existing_paths_lower = {}
+        for path in paths:
+            cls._validate_dataset_path(path)
+            path_lower = path.casefold()
+            if path_lower in existing_paths_lower:
+                existing_path = existing_paths_lower[path_lower]
+                raise InvalidOperation(
+                    f"Dataset path {path!r} conflicts with existing path {existing_path!r}"
+                )
+            existing_paths_lower[path_lower] = path
 
     @classmethod
     def new_dataset_for_writing(cls, path, schema, repo=None):

--- a/kart/import_source.py
+++ b/kart/import_source.py
@@ -71,9 +71,15 @@ class ImportSource:
             return self._dest_path
         return self.default_dest_path()
 
+    @classmethod
+    def _normalise_dataset_path(cls, path):
+        # we treat back-slash and forward-slash as equivalent at import time.
+        # (but we only ever import forward-slashes)
+        return path.strip("/").replace("\\", "/")
+
     @dest_path.setter
     def dest_path(self, dest_path):
-        self._dest_path = dest_path.strip("/")
+        self._dest_path = self._normalise_dataset_path(dest_path)
 
     def default_dest_path(self):
         """

--- a/kart/ogr_import_source.py
+++ b/kart/ogr_import_source.py
@@ -200,7 +200,7 @@ class OgrImportSource(ImportSource):
         }
 
     def default_dest_path(self):
-        return self.table
+        return self._normalise_dataset_path(self.table)
 
     def import_source_desc(self):
         return f"Import from {self.source_name}:{self.table} to {self.dest_path}/"

--- a/kart/sqlalchemy_import_source.py
+++ b/kart/sqlalchemy_import_source.py
@@ -152,7 +152,9 @@ class SqlAlchemyImportSource(ImportSource):
         return desc
 
     def default_dest_path(self):
-        return self.table_location_within_source or self.table
+        return self._normalise_dataset_path(
+            self.table_location_within_source or self.table
+        )
 
     @functools.lru_cache(maxsize=1)
     def get_tables(self):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1067,6 +1067,7 @@ def test_import_list_formats(data_archive_readonly, cli_runner):
         pytest.param((r"a\b\c",), True, id="backslash-separated"),
         pytest.param(("1a",), False, id="leading-numeral"),
         pytest.param(("a1",), True, id="trailing-numeral"),
+        pytest.param(("_1",), True, id="leading-underscore"),
         pytest.param((".a",), False, id="leading-dot"),
         pytest.param(("a.",), False, id="trailing-dot"),
         pytest.param(("a.b",), True, id="contains-dot"),


### PR DESCRIPTION
## Description

Background: There's existing ambiguity caused by the use of `:` in dataset names, when you use either:

* `kart import file.gpkg oldname:something:newname`
* `kart diff --filter=datasetname:something:primarykeyvalue`

This PR enforces a fairly conservative spec for dataset names to avoid problems with `:` as well as future databases, OSes and filesystems we might want to play nicely with.

## Related links:

Fixes #497

## Checklist:

- [ ] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
