### PR TITLE
log: Fix a bug with parsing of ranges in args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## 0.10.7 (UNRELEASED)
 
-* Bugfix: Auto-incrementing PK sequences now work in PostGIS working copies for table names containing the `.` character. [#468](https://github.com/koordinates/kart/pull/468)
+### Bugs fixed
+
+* `log`: Fixed a regression in 0.10.6 involving range arguments (`x..y` or `x...y`) being handled incorrectly. [#504](https://github.com/koordinates/kart/pull/504)
+* Auto-incrementing PK sequences now work in PostGIS working copies for table names containing the `.` character. [#468](https://github.com/koordinates/kart/pull/468)
 
 ## 0.10.6
 

--- a/kart/log.py
+++ b/kart/log.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone, timedelta
+import re
 import subprocess
 import sys
 import warnings
@@ -74,8 +75,17 @@ def parse_extra_args(repo, args):
                 # to disambiguate, and they haven't done so here.
                 other_args.append(arg)
                 continue
+
+            range_parts = re.split(r"\.\.\.?", arg)
+            if len(range_parts) > 2:
+                # not a valid range or ref, must be a path
+                # Treat remaining args as paths
+                paths = args[i:]
+                break
+
             try:
-                repo.resolve_refish(arg)
+                for part in range_parts:
+                    repo.resolve_refish(part or "HEAD")
             except (KeyError, pygit2.InvalidSpecError):
                 # not a commit-ish.
                 # Treat remaining args as paths

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -84,6 +84,22 @@ def test_log(output_format, data_archive_readonly, cli_runner):
             }
 
 
+def test_log_arg_parsing_with_range(data_archive_readonly, cli_runner):
+    with data_archive_readonly("points"):
+        EMPTY_TREE_SHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+        r = cli_runner.invoke(
+            [
+                "log",
+                f"--output-format=json",
+                f"{EMPTY_TREE_SHA}..{H.POINTS.HEAD1_SHA}",
+            ]
+        )
+        assert r.exit_code == 0, r.stderr
+        commits = json.loads(r.stdout)
+        assert len(commits) == 1
+        assert commits[0]["commit"] == H.POINTS.HEAD1_SHA
+
+
 @pytest.mark.parametrize("output_format", ["text", "json"])
 def test_log_shallow_clone(
     output_format, data_archive_readonly, cli_runner, tmp_path, chdir


### PR DESCRIPTION


## Description

Range arguments were being interpreted as paths, and then passed to
`git log` as paths, causing incorrect output

## Related links:

<!-- If you have links to [issues](https://github.com/koordinates/kart/issues) etc, link them here. -->

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
