### PR TITLE
log: Fix limit options not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ### Bugs fixed
 
-* `log`: Fixed a regression in 0.10.6 involving range arguments (`x..y` or `x...y`) being handled incorrectly. [#504](https://github.com/koordinates/kart/pull/504)
+* `log`: Fixed two regressions in 0.10.6 involving argument parsing:
+  - range arguments (`x..y` or `x...y`) were handled incorrectly. [#504](https://github.com/koordinates/kart/pull/504)
+  - `-n INTEGER` caused an error [#507](https://github.com/koordinates/kart/pull/507)
 * Auto-incrementing PK sequences now work in PostGIS working copies for table names containing the `.` character. [#468](https://github.com/koordinates/kart/pull/468)
 
 ## 0.10.6

--- a/kart/log.py
+++ b/kart/log.py
@@ -93,7 +93,7 @@ def parse_extra_args(repo, args):
                 break
             else:
                 other_args.append(arg)
-    return other_args, paths
+    return list(other_args), list(paths)
 
 
 @click.command(
@@ -132,12 +132,93 @@ def parse_extra_args(repo, args):
         "Otherwise, the feature count will be approximated with varying levels of accuracy."
     ),
 )
+# Some standard git options
+@click.option(
+    "-n",
+    "--max-count",
+    type=int,
+    nargs=1,
+    help="Limit the number of commits to output.",
+)
+@click.option(
+    "--skip",
+    type=int,
+    nargs=1,
+    metavar="INTEGER",
+    help="Skip INTEGER commits before starting to show the commit output.",
+)
+@click.option(
+    "--since",
+    "--after",
+    nargs=1,
+    metavar="DATE",
+    help="Show commits more recent than a specific date.",
+)
+@click.option(
+    "--until",
+    "--before",
+    nargs=1,
+    metavar="DATE",
+    help="Show commits older than a specific date.",
+)
+@click.option(
+    "--author",
+    nargs=1,
+    metavar="PATTERN",
+    multiple=True,
+    help="Limit the commits output to ones with author matching the specified pattern (regular expression)",
+)
+@click.option(
+    "--committer",
+    nargs=1,
+    metavar="PATTERN",
+    multiple=True,
+    help="Limit the commits output to ones with committer matching the specified pattern (regular expression)",
+)
+@click.option(
+    "--grep",
+    nargs=1,
+    metavar="PATTERN",
+    multiple=True,
+    help="Limit the commits output to ones with log message matching the specified pattern (regular expression)",
+)
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
-def log(ctx, output_format, json_style, do_dataset_changes, with_feature_count, args):
-    """ Show commit logs """
+def log(
+    ctx,
+    output_format,
+    json_style,
+    do_dataset_changes,
+    with_feature_count,
+    max_count,
+    skip,
+    since,
+    until,
+    author,
+    committer,
+    grep,
+    args,
+):
+    """
+    Show commit logs
+    """
     repo = ctx.obj.get_repo(allowed_states=KartRepoState.ALL_STATES)
 
     other_args, paths = parse_extra_args(repo, args)
+    if max_count is not None:
+        other_args.append(f"--max-count={max_count}")
+    if skip is not None:
+        other_args.append(f"--skip={skip}")
+    if since is not None:
+        other_args.append(f"--since={since}")
+    if until is not None:
+        other_args.append(f"--until={until}")
+    # These ones can be specified more than once
+    if author:
+        other_args.extend(f"--author={a}" for a in author)
+    if committer:
+        other_args.extend(f"--committer={c}" for c in committer)
+    if grep:
+        other_args.extend(f"--grep={g}" for g in grep)
 
     # TODO: should we check paths exist here? git doesn't!
     if output_format == "text":


### PR DESCRIPTION
## Description

In #498 I added some code to pre-parse arguments that we're going to pass to `git log`, to figure out
which of the arguments were paths. This was necessary for future work (#496).

Unfortunately I failed to account for git's options that take an argument, notably `-n 1`, and the `1` got treated as a path.

This change fixes the bug for:
* `-n / --max-limit`
* `--after / --since / --until / --before`
* `--skip`
* `--author / --committer`
* `--grep`

And incidentally adds those options to the `--help` output:

```
  -n, --max-count INTEGER         Limit the number of commits to output.
  --skip INTEGER                  Skip INTEGER commits before starting to show
                                  the commit output.

  --since, --after DATE           Show commits more recent than a specific
                                  date.

  --until, --before DATE          Show commits older than a specific date.
  --author PATTERN                Limit the commits output to ones with author
                                  matching the specified pattern (regular
                                  expression)

  --committer PATTERN             Limit the commits output to ones with
                                  committer matching the specified pattern
                                  (regular expression)

  --grep PATTERN                  Limit the commits output to ones with log
                                  message matching the specified pattern
                                  (regular expression)
```

Since we currently pass all unknown arguments on to `git log`, there could be other options that fail. Browsing `git log --help` shows these options that take positional arguments:

I'd like to take a pragmatic approach to fixing these and so have categorised them below:

### these ones make no sense in a kart context

(so no need to support/fix them)

* `-L<start>,<end>:<file>, -L:<funcname>:<file>`

### these ones don't actually accept a separate arg

These ones take an _optional_ argument, so to keep parsing simple, git seems to have required that they be supplied as `--opt=value` rather than `--opt value`. Which means they don't actually break in 0.10.6 at all, and don't need fixing.

* `--no-decorate, --decorate[=short|full|auto|no]`
* `--branches[=<pattern>] / --tags[=<pattern>] / --remotes[=<pattern>]`
* `--pretty[=<format>], --format=<format>`
* `--expand-tabs=<n>, --expand-tabs, --no-expand-tabs`
* `--notes[=<ref>]`
* `--show-linear-break[=<barrier>]`

### obscure opts that are unlikely to be used

pragmatically it's unlikely anyone's using these, and our rough plan is to stop forwarding unknown options to git log in a near-future release (0.11 or 0.12); ref https://github.com/koordinates/kart/issues/493#issuecomment-973330636 - which will break these options anyway. Let's just not re-add them now.

* `--decorate-refs=<pattern>, --decorate-refs-exclude=<pattern>`
* `--grep-reflog=<pattern>`
* `--min-parents=<number>, --max-parents=<number>, --no-min-parents, --no-max-parents`
* `--glob=<glob-pattern>`
* `--exclude=<glob-pattern>`
* `--no-walk[=(sorted|unsorted)]`
* `--encoding=<encoding>`
* `--date=<format>`


## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
