### PR TITLE
Fix `kart log @` not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ### Bugs fixed
 
-* `log`: Fixed two regressions in 0.10.6 involving argument parsing:
+* `log`: Fixed some regressions in 0.10.6 involving argument parsing:
   - range arguments (`x..y` or `x...y`) were handled incorrectly. [#504](https://github.com/koordinates/kart/pull/504)
   - `-n INTEGER` caused an error [#507](https://github.com/koordinates/kart/pull/507)
+  - `kart log @` was empty (`@` is supposed to be handled as a synonym for `HEAD`) [#510](https://github.com/koordinates/kart/pull/510)
 * Auto-incrementing PK sequences now work in PostGIS working copies for table names containing the `.` character. [#468](https://github.com/koordinates/kart/pull/468)
 
 ## 0.10.6

--- a/kart/repo.py
+++ b/kart/repo.py
@@ -715,6 +715,18 @@ class KartRepo(pygit2.Repository):
             return
         path.unlink()
 
+    def revparse_single(self, revision):
+        # FIXME: Overridden to work around https://github.com/libgit2/libgit2/issues/6123
+        if revision == "@":
+            revision = "HEAD"
+        return super().revparse_single(revision)
+
+    def revparse_ext(self, revision):
+        # FIXME: Overridden to work around https://github.com/libgit2/libgit2/issues/6123
+        if revision == "@":
+            revision = "HEAD"
+        return super().revparse_ext(revision)
+
     KART_COMMON_README = [
         "",
         "kart status",

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -309,6 +309,9 @@ def test_log_arg_handling(data_archive, cli_runner, output_format):
         ),
         pytest.param(["--committer", "Telemachus"], [], id="committer-no-match"),
         pytest.param(["--grep", "Coromandel.*coast"], [H.POINTS.HEAD_SHA], id="grep"),
+        pytest.param(["HEAD"], [H.POINTS.HEAD_SHA, H.POINTS.HEAD1_SHA], id="HEAD"),
+        pytest.param(["@"], [H.POINTS.HEAD_SHA, H.POINTS.HEAD1_SHA], id="@"),
+        pytest.param(["@{0}"], [H.POINTS.HEAD_SHA, H.POINTS.HEAD1_SHA], id="@{0}"),
     ],
 )
 def test_extra_git_log_options(data_archive, cli_runner, args, expected_commits):


### PR DESCRIPTION
## Description

`kart log @` output was empty since kart 0.10.6 (it worked in 0.10.5)

## Related links:

upstream ticket at libgit2/libgit2#6123

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
