### PR TITLE
Fix dependabot builds on MacOS (skip signing)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -669,7 +669,7 @@ jobs:
       - name: "package: setup app signing certificate"
         id: keychain
         uses: apple-actions/import-codesign-certs@v1
-        if: "steps.version.outputs.is_fork == 0"
+        if: "steps.version.outputs.is_fork == 0 && github.actor != 'dependabot[bot]'"
         with:
           p12-file-base64: ${{ secrets.MACOS_APP_CERT }}
           p12-password: ${{ secrets.MACOS_CERT_PW }}


### PR DESCRIPTION

## Description

Dependabot's builds always fail on MacOS while trying to set up signing certs

Dependabot doesn't have access to secrets:
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#responding-to-events

So I skipped the signing step for dependabot.

## Related links:

https://github.com/koordinates/kart/runs/4346703672?check_suite_focus=true

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
