### PR TITLE
Fix for #521 - no replace-ids when PK changes type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 * Simpler developer builds using CMake, see the [contributing notes](./CONTRIBUTING.md).
 * `kart log`: can now output the history of individual features using syntax `kart log -- <dataset-name>:feature:<feature-primary-key>`. [#496](https://github.com/koordinates/kart/issues/496)
 * Bugfix: fixed the error when merging a commit where every feature in a dataset is deleted. [#506](https://github.com/koordinates/kart/pull/506)
+* Bugfix: Don't allow `--replace-ids` to be specified during an import where the primary key is changing type. [#521](https://github.com/koordinates/kart/issues/521)
 
 ## 0.10.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 * Simpler developer builds using CMake, see the [contributing notes](./CONTRIBUTING.md).
 * `kart log`: can now output the history of individual features using syntax `kart log -- <dataset-name>:feature:<feature-primary-key>`. [#496](https://github.com/koordinates/kart/issues/496)
 * Bugfix: fixed the error when merging a commit where every feature in a dataset is deleted. [#506](https://github.com/koordinates/kart/pull/506)
-* Bugfix: Don't allow `--replace-ids` to be specified during an import where the primary key is changing type. [#521](https://github.com/koordinates/kart/issues/521)
+* Bugfix: Don't allow `--replace-ids` to be specified during an import where the primary key is changing. [#521](https://github.com/koordinates/kart/issues/521)
 
 ## 0.10.7
 


### PR DESCRIPTION
<img src="https://media3.giphy.com/media/tKIt3zenrB7CgdRlI2/giphy.gif"/>

See https://github.com/koordinates/kart/issues/521 for details

## Description

`--replace-ids` option isn't useful when a primary key type is being changed, and right now if you try to use it anyway, it corrupts your dataset. (If this has happened, you can put the dataset back to an earlier state using `kart reset`). See issue link for more details.
Lower impact than it sounds since very few users are using --replace-ids at this early stage...

## Related links:

https://github.com/koordinates/kart/issues/521

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
