### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Download the .msi installer from the [release page](https://github.com/koordinat
 
 Download the .pkg installer from the [release page](https://github.com/koordinates/kart/releases/tag/v0.10.7);
 
-Or use [Homebrew](https://brew.sh) to install: `brew cask install koordinates/kart/kart`
+Or use [Homebrew](https://brew.sh) to install: `brew install koordinates/kart/kart`
 
 ### Linux
 


### PR DESCRIPTION
Syntax for installing from a cask is now just ```brew install```.

## Description

Brew cask changed a while ago to no longer require the ```cask``` keyword.

## Related links:

Discussion here: https://github.com/Homebrew/discussions/discussions/902

## Checklist:

- [ ] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
