### PR TITLE
Support wildcards and meta items in diff/commit filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## 0.10.8 (UNRELEASED)
 
+* More advanced filters for `log`, `diff` and `commit`: All of these now work:
+  - Wildcard (`*`) filters for dataset names, e.g. `kart diff -- *parcel*:meta:schema.json` will show only schema changes for all datasets with `parcel` in their names. `*` by itself matches all datasets. [#532](https://github.com/koordinates/kart/issues/532)
+  - You can now output the history of individual features: `kart log -- <dataset-name>:feature:<feature-primary-key>`. [#496](https://github.com/koordinates/kart/issues/496)
 * Simpler developer builds using CMake, see the [contributing notes](./CONTRIBUTING.md).
-* `kart log`: can now output the history of individual features using syntax `kart log -- <dataset-name>:feature:<feature-primary-key>`. [#496](https://github.com/koordinates/kart/issues/496)
 * Bugfix: fixed the error when merging a commit where every feature in a dataset is deleted. [#506](https://github.com/koordinates/kart/pull/506)
 * Bugfix: Don't allow `--replace-ids` to be specified during an import where the primary key is changing. [#521](https://github.com/koordinates/kart/issues/521)
 

--- a/kart/base_diff_writer.py
+++ b/kart/base_diff_writer.py
@@ -86,10 +86,7 @@ class BaseDiffWriter:
         )
 
         self.user_key_filters = user_key_filters
-        self.repo_key_filter = RepoKeyFilter.build_from_user_patterns(
-            user_key_filters,
-            implicit_meta=False,
-        )
+        self.repo_key_filter = RepoKeyFilter.build_from_user_patterns(user_key_filters)
 
         self.spatial_filter = repo.spatial_filter
 

--- a/kart/base_diff_writer.py
+++ b/kart/base_diff_writer.py
@@ -86,7 +86,10 @@ class BaseDiffWriter:
         )
 
         self.user_key_filters = user_key_filters
-        self.repo_key_filter = RepoKeyFilter.build_from_user_patterns(user_key_filters)
+        self.repo_key_filter = RepoKeyFilter.build_from_user_patterns(
+            user_key_filters,
+            implicit_meta=False,
+        )
 
         self.spatial_filter = repo.spatial_filter
 

--- a/kart/diff_util.py
+++ b/kart/diff_util.py
@@ -19,7 +19,7 @@ def get_all_ds_paths(base_rs, target_rs, repo_key_filter=RepoKeyFilter.MATCH_ALL
     all_ds_paths = base_ds_paths | target_ds_paths
 
     if not repo_key_filter.match_all:
-        all_ds_paths = all_ds_paths & repo_key_filter.keys()
+        all_ds_paths = repo_key_filter.filter_keys(all_ds_paths)
 
     return sorted(list(all_ds_paths))
 

--- a/kart/key_filters.py
+++ b/kart/key_filters.py
@@ -150,34 +150,30 @@ class RepoKeyFilter(KeyFilterDict):
         return groups["dataset_glob"], subdataset, groups["rest"] or None
 
     @classmethod
-    def build_from_user_patterns(cls, user_patterns, implicit_meta=True):
+    def build_from_user_patterns(cls, user_patterns):
         """
         Given a list of strings like ["datasetA:1", "datasetA:2", "datasetB"],
         builds a RepoKeyFilter with the appropriate entries for "datasetA" and "datasetB".
         If no patterns are specified, returns RepoKeyFilter.MATCH_ALL.
-        If implicit_meta is True, then all meta changes are matched as soon as any feature changes are requested.
         """
         result = cls()
         for user_pattern in user_patterns:
-            result.add_user_pattern(user_pattern, implicit_meta=implicit_meta)
+            result.add_user_pattern(user_pattern)
         return result if result else cls.MATCH_ALL
 
-    def add_user_pattern(self, user_pattern, implicit_meta=True):
+    def add_user_pattern(self, user_pattern):
         dataset_glob, subdataset, rest = self._parse_user_pattern(user_pattern)
 
         if subdataset is None:
             # whole dataset
             self[dataset_glob] = DatasetKeyFilter.MATCH_ALL
             return
-        # meta or feature filter
+        # Either a meta or feature filter
         ds_filter = self.get(dataset_glob)
         if not ds_filter:
             ds_filter = DatasetKeyFilter()
-            # TODO: remove this? what is it for?
-            # if implicit_meta:
-            #     ds_filter["meta"] = UserStringKeyFilter.MATCH_ALL
             if rest:
-                # Specific feature or specific meta item
+                # Specific feature or meta item
                 ds_filter[subdataset] = UserStringKeyFilter()
             else:
                 # All features, or all meta items

--- a/kart/log.py
+++ b/kart/log.py
@@ -208,9 +208,7 @@ def convert_user_patterns_to_raw_paths(paths, repo, commits):
     # Specially handle raw paths, because we can and it's nice for Kart developers
     result = [p for p in paths if "/.table-dataset/" in p]
     normal_paths = [p for p in paths if "/.table-dataset/" not in p]
-    repo_filter = RepoKeyFilter.build_from_user_patterns(
-        normal_paths, implicit_meta=False
-    )
+    repo_filter = RepoKeyFilter.build_from_user_patterns(normal_paths)
     if repo_filter.match_all:
         return result
     for ds_path, ds_filter in repo_filter.items():

--- a/kart/log.py
+++ b/kart/log.py
@@ -205,10 +205,14 @@ def convert_user_patterns_to_raw_paths(paths, repo, commits):
     finds the path encoding for the dataset they apply to and converts them to the feature's path, eg:
     path/to/dataset/.table-dataset/feature/F/9/o/6/kc4F9o6L
     """
-    repo_filter = RepoKeyFilter.build_from_user_patterns(paths, implicit_meta=False)
+    # Specially handle raw paths, because we can and it's nice for Kart developers
+    result = [p for p in paths if "/.table-dataset/" in p]
+    normal_paths = [p for p in paths if "/.table-dataset/" not in p]
+    repo_filter = RepoKeyFilter.build_from_user_patterns(
+        normal_paths, implicit_meta=False
+    )
     if repo_filter.match_all:
-        return []
-    result = []
+        return result
     for ds_path, ds_filter in repo_filter.items():
         if ds_filter.match_all:
             result.append(ds_path)

--- a/kart/log.py
+++ b/kart/log.py
@@ -10,7 +10,7 @@ import pygit2
 
 from .cli_util import tool_environment
 from .exec import execvp
-from .exceptions import SubprocessError
+from .exceptions import NotYetImplemented, SubprocessError
 from .key_filters import RepoKeyFilter
 from .output_util import dump_json_output
 from .repo import KartRepoState
@@ -205,9 +205,10 @@ def convert_user_patterns_to_raw_paths(paths, repo, commits):
     finds the path encoding for the dataset they apply to and converts them to the feature's path, eg:
     path/to/dataset/.table-dataset/feature/F/9/o/6/kc4F9o6L
     """
+    DATASET_DIRNAME = repo.dataset_class.DATASET_DIRNAME
     # Specially handle raw paths, because we can and it's nice for Kart developers
-    result = [p for p in paths if "/.table-dataset/" in p]
-    normal_paths = [p for p in paths if "/.table-dataset/" not in p]
+    result = [p for p in paths if f"/{DATASET_DIRNAME}/" in p]
+    normal_paths = [p for p in paths if f"/{DATASET_DIRNAME}/" not in p]
     repo_filter = RepoKeyFilter.build_from_user_patterns(normal_paths)
     if repo_filter.match_all:
         return result
@@ -215,22 +216,40 @@ def convert_user_patterns_to_raw_paths(paths, repo, commits):
         if ds_filter.match_all:
             result.append(ds_path)
             continue
-        ds = find_dataset(ds_path, repo, commits)
-        if not ds:
-            result.append(ds_path)
-            continue
-        for ds_part, part_filter in ds_filter.items():
-            if part_filter.match_all:
-                result.append(f"{ds.inner_path}/{ds_part}")
-                continue
 
-            for item_key in part_filter:
-                if ds_part == "feature":
-                    result.append(
-                        ds.encode_pks_to_path(ds.schema.sanitise_pks(item_key))
-                    )
-                else:
-                    result.append(f"{ds.inner_path}/{ds_part}/{item_key}")
+        for char in "?[]":
+            # git pathspecs actually treat '*?[]' specially but we only want to support '*' for now
+            ds_path = ds_path.replace(char, f"[{char}]")
+
+        # NOTE: git's interpretation of '*' is pretty loose.
+        # It matches all characters in a path *including slashes*, so '*abc' will match 'foo/bar/abc'
+        # This is pretty much what we want though 👍
+        if ds_filter.match_all:
+            result.append(f"{ds_path}/*")
+        else:
+            for ds_part, part_filter in ds_filter.items():
+                if part_filter.match_all:
+                    result.append(f"{ds_path}/{DATASET_DIRNAME}/{ds_part}/*")
+                    continue
+
+                for item_key in part_filter:
+                    if ds_part == "feature":
+                        if "*" in ds_path:
+                            raise NotYetImplemented(
+                                "`kart log` doesn't currently support filters with both wildcards and feature IDs"
+                            )
+                        else:
+                            ds = find_dataset(ds_path, repo, commits)
+                            if not ds:
+                                result.append(ds_path)
+                                continue
+                            result.append(
+                                ds.encode_pks_to_path(ds.schema.sanitise_pks(item_key))
+                            )
+                    else:
+                        result.append(
+                            f"{ds_path}/{DATASET_DIRNAME}/{ds_part}/{item_key}"
+                        )
     return result
 
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -288,7 +288,7 @@ def test_path_handling(data_archive, cli_runner, output_format):
         )
         assert r.exit_code == 0, r.stderr
         assert num_commits(r) == 1
-        # Path syntax still works:
+        # Raw path syntax still works:
         PK_1_PATH = "nz_pa_points_topo_150k/.table-dataset/feature/A/A/A/A/kQ0="
         r = cli_runner.invoke(["log", "-o", output_format, "--", PK_1_PATH])
         assert r.exit_code == 0, r.stderr


### PR DESCRIPTION
## Description

This PR adds support for the following filter styles:

* `kart diff HEAD^ datasetname:meta:title` - diff a meta item
* `kart diff HEAD^ datasetname:meta` - diff all meta items from datasetname
* `kart diff HEAD^ *:meta` - diff all meta items from all datasets
* `kart diff HEAD^ *:feature` - diff all features from all datasets
* `kart diff HEAD^ *abc*:feature` - diff all features from datasets whose names contain `abc`

In addition specific-feature filters no longer also show meta items.

### Todo:

- ~~[ ] Prevent user from committing a feature without an associated schema change (`kart commit '*:feature'` when a schema change is also present, as mentioned in #219 )~~
- [x] implement or disable wildcard filters for `log` (it's hard)

## Related links:

* #219 
* #514

## Checklist:


- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
