### PR TITLE
clone: Strip trailing '.git' from dir names for non-bare repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 * More advanced filters for `log`, `diff` and `commit`: All of these now work:
   - Wildcard (`*`) filters for dataset names, e.g. `kart diff -- *parcel*:meta:schema.json` will show only schema changes for all datasets with `parcel` in their names. `*` by itself matches all datasets. [#532](https://github.com/koordinates/kart/issues/532)
   - You can now output the history of individual features: `kart log -- <dataset-name>:feature:<feature-primary-key>`. [#496](https://github.com/koordinates/kart/issues/496)
+* `kart clone` now strips `.git` off the end of automatically-generated repo paths, if `--bare` is not specified. [#540](https://github.com/koordinates/kart/issues/540)
 * Simpler developer builds using CMake, see the [contributing notes](./CONTRIBUTING.md).
 * Bugfix: fixed the error when merging a commit where every feature in a dataset is deleted. [#506](https://github.com/koordinates/kart/pull/506)
 * Bugfix: Don't allow `--replace-ids` to be specified during an import where the primary key is changing. [#521](https://github.com/koordinates/kart/issues/521)

--- a/kart/clone.py
+++ b/kart/clone.py
@@ -32,7 +32,12 @@ def get_directory_from_url(url):
         path = PurePath(path)
 
     # Return the directory name.
-    return str(path.name or path.parent.name)
+    name = str(path.name or path.parent.name)
+
+    # Strip trailing ".git". Some hosts (notably github) add this to the end of URLs
+    if name.endswith(".git"):
+        name = name[:-4]
+    return name
 
 
 @click.command()

--- a/kart/clone.py
+++ b/kart/clone.py
@@ -11,7 +11,7 @@ from .repo import KartRepo, PotentialRepo
 from .spatial_filter import SpatialFilterString, spatial_filter_help_text
 
 
-def get_directory_from_url(url):
+def get_directory_from_url(url, is_bare):
     if isinstance(url, PurePath):
         path = url
     elif "://" in str(url):
@@ -37,6 +37,8 @@ def get_directory_from_url(url):
     # Strip trailing ".git". Some hosts (notably github) add this to the end of URLs
     if name.endswith(".git"):
         name = name[:-4]
+    if is_bare:
+        name += ".git"
     return name
 
 
@@ -124,7 +126,7 @@ def clone(
     directory,
 ):
     """ Clone a repository into a new directory """
-    repo_path = Path(directory or get_directory_from_url(url)).resolve()
+    repo_path = Path(directory or get_directory_from_url(url, is_bare=bare)).resolve()
 
     if repo_path.exists() and any(repo_path.iterdir()):
         raise InvalidOperation(f'"{repo_path}" isn\'t empty', param_hint="directory")

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -20,45 +20,62 @@ def test_clone_empty_repo(tmp_path, cli_runner, chdir):
 
 
 def test_get_directory_from_url():
-    assert get_directory_from_url("kart@example.com:def/abc") == "abc"
-    assert get_directory_from_url("kart@example.com:abc") == "abc"
-    assert get_directory_from_url("kart@example.com:def/abc.git") == "abc"
-    assert get_directory_from_url("kart@example.com:def/abc.d") == "abc.d"
-    assert get_directory_from_url("https://example.com/def/abc") == "abc"
-    assert get_directory_from_url("https://example.com/abc") == "abc"
-    assert get_directory_from_url("https://example.com/abc.git") == "abc"
-    assert get_directory_from_url("https://example.com/abc.d") == "abc.d"
-    assert get_directory_from_url("abc") == "abc"
-    assert get_directory_from_url("abc/") == "abc"
-    assert get_directory_from_url("def/abc") == "abc"
-    assert get_directory_from_url("def/abc/") == "abc"
-    assert get_directory_from_url("/def/abc") == "abc"
-    assert get_directory_from_url("/def/abc/") == "abc"
-    assert get_directory_from_url("file:/def/abc") == "abc"
-    assert get_directory_from_url("file:/def/abc/") == "abc"
-    assert get_directory_from_url("file://def/abc") == "abc"
-    assert get_directory_from_url("file://def/abc/") == "abc"
-    assert get_directory_from_url("file:///def/abc") == "abc"
-    assert get_directory_from_url("file:///def/abc/") == "abc"
+    assert get_directory_from_url("kart@example.com:def/abc", is_bare=False) == "abc"
+    assert get_directory_from_url("kart@example.com:abc", is_bare=False) == "abc"
+    assert (
+        get_directory_from_url("kart@example.com:def/abc.git", is_bare=False) == "abc"
+    )
+    assert (
+        get_directory_from_url("kart@example.com:def/abc.d", is_bare=False) == "abc.d"
+    )
+    assert get_directory_from_url("https://example.com/def/abc", is_bare=False) == "abc"
+    assert get_directory_from_url("https://example.com/abc", is_bare=False) == "abc"
+    assert get_directory_from_url("https://example.com/abc.git", is_bare=False) == "abc"
+    assert get_directory_from_url("https://example.com/abc.d", is_bare=False) == "abc.d"
+    assert get_directory_from_url("abc", is_bare=False) == "abc"
+    assert get_directory_from_url("abc/", is_bare=False) == "abc"
+    assert get_directory_from_url("def/abc", is_bare=False) == "abc"
+    assert get_directory_from_url("def/abc/", is_bare=False) == "abc"
+    assert get_directory_from_url("/def/abc", is_bare=False) == "abc"
+    assert get_directory_from_url("/def/abc/", is_bare=False) == "abc"
+    assert get_directory_from_url("file:/def/abc", is_bare=False) == "abc"
+    assert get_directory_from_url("file:/def/abc/", is_bare=False) == "abc"
+    assert get_directory_from_url("file://def/abc", is_bare=False) == "abc"
+    assert get_directory_from_url("file://def/abc/", is_bare=False) == "abc"
+    assert get_directory_from_url("file:///def/abc", is_bare=False) == "abc"
+    assert get_directory_from_url("file:///def/abc/", is_bare=False) == "abc"
 
-    assert get_directory_from_url(PureWindowsPath("C:/def/abc")) == "abc"
-    assert get_directory_from_url(PureWindowsPath("C:\\def\\abc")) == "abc"
-    assert get_directory_from_url(PureWindowsPath("C:\\def\\abc\\")) == "abc"
-    assert get_directory_from_url(PureWindowsPath("C:\\def\\abc/")) == "abc"
+    assert get_directory_from_url(PureWindowsPath("C:/def/abc"), is_bare=False) == "abc"
+    assert (
+        get_directory_from_url(PureWindowsPath("C:\\def\\abc"), is_bare=False) == "abc"
+    )
+    assert (
+        get_directory_from_url(PureWindowsPath("C:\\def\\abc\\"), is_bare=False)
+        == "abc"
+    )
+    assert (
+        get_directory_from_url(PureWindowsPath("C:\\def\\abc/"), is_bare=False) == "abc"
+    )
 
     if is_windows:
-        assert get_directory_from_url("C:/def/abc") == "abc"
-        assert get_directory_from_url("C:/def/abc/") == "abc"
-        assert get_directory_from_url("C:\\def\\abc") == "abc"
-        assert get_directory_from_url("C:\\def\\abc\\") == "abc"
-        assert get_directory_from_url("file:/C:/def/abc") == "abc"
-        assert get_directory_from_url("file:/C:/def/abc/") == "abc"
-        assert get_directory_from_url("file:/C:\\def\\abc") == "abc"
-        assert get_directory_from_url("file:/C:\\def\\abc\\") == "abc"
-        assert get_directory_from_url("file://C:\\def\\abc") == "abc"
-        assert get_directory_from_url("file://C:\\def\\abc\\") == "abc"
-        assert get_directory_from_url("file:///C:\\def\\abc") == "abc"
-        assert get_directory_from_url("file:///C:\\def\\abc\\") == "abc"
+        assert get_directory_from_url("C:/def/abc", is_bare=False) == "abc"
+        assert get_directory_from_url("C:/def/abc/", is_bare=False) == "abc"
+        assert get_directory_from_url("C:\\def\\abc", is_bare=False) == "abc"
+        assert get_directory_from_url("C:\\def\\abc\\", is_bare=False) == "abc"
+        assert get_directory_from_url("file:/C:/def/abc", is_bare=False) == "abc"
+        assert get_directory_from_url("file:/C:/def/abc/", is_bare=False) == "abc"
+        assert get_directory_from_url("file:/C:\\def\\abc", is_bare=False) == "abc"
+        assert get_directory_from_url("file:/C:\\def\\abc\\", is_bare=False) == "abc"
+        assert get_directory_from_url("file://C:\\def\\abc", is_bare=False) == "abc"
+        assert get_directory_from_url("file://C:\\def\\abc\\", is_bare=False) == "abc"
+        assert get_directory_from_url("file:///C:\\def\\abc", is_bare=False) == "abc"
+        assert get_directory_from_url("file:///C:\\def\\abc\\", is_bare=False) == "abc"
+
+    assert get_directory_from_url("kart@example.com:def/abc", is_bare=True) == "abc.git"
+    assert (
+        get_directory_from_url("kart@example.com:def/abc.git", is_bare=True)
+        == "abc.git"
+    )
 
 
 @pytest.mark.parametrize(
@@ -162,7 +179,7 @@ def test_clone_filter(
             r = cli_runner.invoke(args)
             assert r.exit_code == 0, r.stderr
 
-            repo_path = tmp_path / "points"
+            repo_path = tmp_path / "points.git"
             assert repo_path.is_dir()
 
             # it's kind of hard to tell if `--filter` succeeded tbh.

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -22,8 +22,12 @@ def test_clone_empty_repo(tmp_path, cli_runner, chdir):
 def test_get_directory_from_url():
     assert get_directory_from_url("kart@example.com:def/abc") == "abc"
     assert get_directory_from_url("kart@example.com:abc") == "abc"
+    assert get_directory_from_url("kart@example.com:def/abc.git") == "abc"
+    assert get_directory_from_url("kart@example.com:def/abc.d") == "abc.d"
     assert get_directory_from_url("https://example.com/def/abc") == "abc"
     assert get_directory_from_url("https://example.com/abc") == "abc"
+    assert get_directory_from_url("https://example.com/abc.git") == "abc"
+    assert get_directory_from_url("https://example.com/abc.d") == "abc.d"
     assert get_directory_from_url("abc") == "abc"
     assert get_directory_from_url("abc/") == "abc"
     assert get_directory_from_url("def/abc") == "abc"


### PR DESCRIPTION
## Description
Github adds '.git' to its repository names. [Git strips this automatically](https://github.com/git/git/blob/90d242d36e248acfae0033274b524bfa55a947fd/dir.c#L3066) for non-bare repos, and it seems reasonable for kart to do the same.

## Related links:

re #533

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
