### PR TITLE
Avoid cert verify issues via https clone on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
   - You can now output the history of individual features: `kart log -- <dataset-name>:feature:<feature-primary-key>`. [#496](https://github.com/koordinates/kart/issues/496)
 * `kart clone` now strips `.git` off the end of automatically-generated repo paths, if `--bare` is not specified. [#540](https://github.com/koordinates/kart/issues/540)
 * Simpler developer builds using CMake, see the [contributing notes](./CONTRIBUTING.md).
+* Bugfix: fixed certificate verification errors when cloning HTTPS repositories on some Linux distributions. [#541](https://github.com/koordinates/kart/pull/541)
 * Bugfix: fixed the error when merging a commit where every feature in a dataset is deleted. [#506](https://github.com/koordinates/kart/pull/506)
 * Bugfix: Don't allow `--replace-ids` to be specified during an import where the primary key is changing. [#521](https://github.com/koordinates/kart/issues/521)
 

--- a/kart/__init__.py
+++ b/kart/__init__.py
@@ -71,9 +71,7 @@ else:
     path_extras.append(os.path.join(prefix, "bin"))
 
 os.environ["GIT_EXEC_PATH"] = os.path.join(prefix, "libexec", "git-core")
-os.environ["GIT_TEMPLATE_DIR"] = os.path.join(
-    prefix, "share", "git-core", "templates"
-)
+os.environ["GIT_TEMPLATE_DIR"] = os.path.join(prefix, "share", "git-core", "templates")
 # See locked_git_index in.repo.py:
 os.environ["GIT_INDEX_FILE"] = os.path.join(".kart", "unlocked_index")
 
@@ -102,7 +100,9 @@ if "OGR_SQLITE_PRAGMA" not in os.environ:
     os.environ["OGR_SQLITE_PRAGMA"] = "page_size=65536"
 
 # Write our various additions to $PATH
-os.environ['PATH'] = os.pathsep.join(path_extras) + os.pathsep + os.environ.get("PATH", "")
+os.environ["PATH"] = (
+    os.pathsep.join(path_extras) + os.pathsep + os.environ.get("PATH", "")
+)
 
 # GDAL Error Handling
 from osgeo import gdal, ogr, osr
@@ -128,6 +128,7 @@ pygit2.option(pygit2.GIT_OPT_SET_CACHE_OBJECT_LIMIT, 2, 100000)
 if is_linux:
     import certifi
 
+    # note: cli_util.py also sets this in git's `http.sslCAInfo` config var
     pygit2.settings.ssl_cert_file = certifi.where()
 
 

--- a/kart/cli_util.py
+++ b/kart/cli_util.py
@@ -44,6 +44,11 @@ GIT_CONFIG_DEFAULT_OVERRIDES = {
     "pack.depth": 0,
     "pack.window": 0,
 }
+if platform.system() == "Linux":
+    import certifi
+
+    GIT_CONFIG_DEFAULT_OVERRIDES["http.sslCAInfo"] = certifi.where()
+
 # These are the settings that Kart always *overrides* in git config.
 # i.e. regardless of your local git settings, kart will use these settings instead.
 GIT_CONFIG_FORCE_OVERRIDES = {

--- a/tests/scripts/e2e-1.sh
+++ b/tests/scripts/e2e-1.sh
@@ -53,4 +53,7 @@ kart status
 kart merge edit-1 --no-ff -m merge-1
 kart log
 
+# Briefly try a remote to ensure the CA cert bundle is working
+kart git ls-remote https://github.com/koordinates/kart.git HEAD
+
 { echo -e "\n✅ E2E: Success"; } 2>/dev/null


### PR DESCRIPTION


## Description

On a fresh Ubuntu install (tested with 21.04) `kart clone` wasn't using the certificate bundle included with it, and thus produced this error when cloning things:

```
root@a0cd8d48a21e:/downloads# kart clone https://github.com/Georepublic/kart-repo.git
Cloning into '/downloads/kart-repo.git/.clone'...
fatal: unable to access 'https://github.com/Georepublic/kart-repo.git/': error setting certificate verify locations:
  CAfile: /etc/pki/tls/certs/ca-bundle.crt
  CApath: none
```

## Todo

* [x] Actually test the deb build on ubuntu to make sure the issue goes away
* [x] figure out why this isn't happening in the e2e test in github actions?

## Related links:

fixes #533

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
