### PR TITLE
`diff -o json-lines`: Add feature count estimate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 ### Major changes
 Support for spatial filters - the spatial filter can be updated during an `init`, `clone` or `checkout` by supplying the option `--spatial-filter=CRS;GEOMETRY` where CRS is a string such as `EPSG:4326` and GEOMETRY is a polygon or multigon specified using WKT or hex-encoded WKB. When a spatial filter is set, the working copy will only contain features that intersect the spatial filter, and changes that happened outside the working copy are not shown to the user unless specifically required. Starting with Kart 0.11.0, only the features that are inside the specified spatial filter are downloaded during a clone. [Spatial filter docs](docs/SPATIAL_FILTERS.md) | [#456](https://github.com/koordinates/kart/issues/456)
 ### Other changes
+
+* diff: Added `--add-feature-count-estimate=<accuracy>` to `json-lines` diffs. This lazily inserts an estimate of the total number of features into the output stream. [#543](https://github.com/koordinates/kart/issues/543)
 * Bugfix: fixed errors with Postgres working copies when one or more datasets have no CRS defined. [#529](https://github.com/koordinates/kart/issues/529)
 * Bugfix: better error message when `kart import` fails due to multiple XML metadata files for a single dataset, which Kart does not support [#547](https://github.com/koordinates/kart/issues/547)
-* When there are two pieces of XML metadata for a single dataset, but one is simply a GDALMultiDomainMetadata wrapping the other, the wrapped version is ignored. [#547](https://github.com/koordinates/kart/issues/547)
+* When there are two pieces of XML metadata for a single dataset, but one is simply a `GDALMultiDomainMetadata` wrapping the other, the wrapped version is ignored. [#547](https://github.com/koordinates/kart/issues/547)
 
 ## 0.10.8
 

--- a/kart/base_diff_writer.py
+++ b/kart/base_diff_writer.py
@@ -78,6 +78,8 @@ class BaseDiffWriter:
         *,
         json_style="pretty",
         target_crs=None,
+        # used by json-lines diffs only
+        diff_estimate_accuracy=None,
     ):
         self.repo = repo
         self.commit_spec = commit_spec

--- a/kart/diff.py
+++ b/kart/diff.py
@@ -95,6 +95,16 @@ def feature_count_diff(
         "Otherwise, the feature count will be approximated with varying levels of accuracy."
     ),
 )
+@click.option(
+    "--add-feature-count-estimate",
+    default=None,
+    type=click.Choice(diff_estimation.ACCURACY_CHOICES),
+    help=(
+        "Adds a feature count estimate to this diff (used with `--output-format json-lines` only.) "
+        "The estimate will be calculated while the diff is being generated, and will be added to "
+        "the stream when it is ready. If the estimate is not ready before the process exits, it will not be added."
+    ),
+)
 @click.argument("commit_spec", required=False, nargs=1)
 @click.argument("filters", nargs=-1)
 def diff(
@@ -107,6 +117,7 @@ def diff(
     only_feature_count,
     commit_spec,
     filters,
+    add_feature_count_estimate,
 ):
     """
     Show changes between two commits, or between a commit and the working copy.
@@ -140,7 +151,13 @@ def diff(
     repo = ctx.obj.get_repo(allowed_states=KartRepoState.ALL_STATES)
     diff_writer_class = BaseDiffWriter.get_diff_writer_class(output_format)
     diff_writer = diff_writer_class(
-        repo, commit_spec, filters, output_path, json_style=json_style, target_crs=crs
+        repo,
+        commit_spec,
+        filters,
+        output_path,
+        json_style=json_style,
+        target_crs=crs,
+        diff_estimate_accuracy=add_feature_count_estimate,
     )
     diff_writer.write_diff()
 

--- a/kart/json_diff_writers.py
+++ b/kart/json_diff_writers.py
@@ -236,7 +236,6 @@ class JsonLinesDiffWriter(BaseDiffWriter):
             }
         )
         if self._diff_estimate_accuracy is not None:
-
             t = threading.Thread(
                 target=self._calculate_and_feature_count_estimate,
             )

--- a/kart/sqlalchemy/gpkg.py
+++ b/kart/sqlalchemy/gpkg.py
@@ -16,7 +16,7 @@ class Db_GPKG(BaseDb):
     preparer = SQLiteIdentifierPreparer(SQLiteDialect())
 
     @classmethod
-    def create_engine(cls, path):
+    def create_engine(cls, path, **kwargs):
         def _on_connect(pysqlite_conn, connection_record):
             pysqlite_conn.isolation_level = None
             pysqlite_conn.enable_load_extension(True)
@@ -28,7 +28,7 @@ class Db_GPKG(BaseDb):
             dbcur.execute(f"PRAGMA cache_size = -{cls.GPKG_CACHE_SIZE_MiB * 1024};")
 
         path = os.path.expanduser(path)
-        engine = sqlalchemy.create_engine(f"sqlite:///{path}", module=sqlite)
+        engine = sqlalchemy.create_engine(f"sqlite:///{path}", module=sqlite, **kwargs)
         sqlalchemy.event.listen(engine, "connect", _on_connect)
         return engine
 
@@ -50,7 +50,7 @@ class Db_GPKG(BaseDb):
                 ORDER BY SM.name;
                 """
             )
-            return {row['name']: row['identifier'] for row in r}
+            return {row["name"]: row["identifier"] for row in r}
 
         r = sess.execute(
             """
@@ -59,7 +59,7 @@ class Db_GPKG(BaseDb):
             ORDER BY name;
             """
         )
-        return {row['name']: None for row in r}
+        return {row["name"]: None for row in r}
 
     @classmethod
     def pk_name(cls, sess, db_schema=None, table=None):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ import sqlalchemy
 # Pytest sets up its own keyboard interrupt handler - don't mess with that.
 os.environ["NO_CONFIGURE_PROCESS_CLEANUP"] = "1"  # noqa
 
+from kart.diff_estimation import terminate_estimate_thread
 from kart.geometry import Geometry  # noqa: E402
 from kart.repo import KartRepo  # noqa: E402
 from kart.sqlalchemy.postgis import Db_Postgis  # noqa: E402
@@ -389,6 +390,9 @@ class KartCliRunner(CliRunner):
         params.update(kwargs)
 
         load_commands_from_args(args)
+
+        terminate_estimate_thread.clear()
+
         r = super().invoke(cli, args=args, **params)
 
         L.debug("Command result: %s (%s)", r.exit_code, repr(r))


### PR DESCRIPTION


## Description

With new `--add-feature-count-estimate=<accuracy>` option, adds a line
to the output stating the number of features expected to be in
the diff. This should be useful for showing a progress bar when the diff is
large.

For small diffs it may never appear, as the estimate can easily take
longer to calculate than the whole diff anyway.

## Related links:




## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
