### PR TITLE
Log formatting options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 ### Major changes
 Support for spatial filters - the spatial filter can be updated during an `init`, `clone` or `checkout` by supplying the option `--spatial-filter=CRS;GEOMETRY` where CRS is a string such as `EPSG:4326` and GEOMETRY is a polygon or multigon specified using WKT or hex-encoded WKB. When a spatial filter is set, the working copy will only contain features that intersect the spatial filter, and changes that happened outside the working copy are not shown to the user unless specifically required. Starting with Kart 0.11.0, only the features that are inside the specified spatial filter are downloaded during a clone. [Spatial filter docs](docs/SPATIAL_FILTERS.md) | [#456](https://github.com/koordinates/kart/issues/456)
 ### Other changes
+* Expanded `--output-format`/`-o` to accept format specifiers; e.g. `-o json:compact`. `kart log` now accepts text formatstrings, e.g. `-o text:%H` [#544](https://github.com/koordinates/kart/issues/544)
+* Deprecated `--json-style` in favour of `-o json:{style}`
 * Bugfix: fixed errors with Postgres working copies when one or more datasets have no CRS defined. [#529](https://github.com/koordinates/kart/issues/529)
 * Bugfix: better error message when `kart import` fails due to multiple XML metadata files for a single dataset, which Kart does not support [#547](https://github.com/koordinates/kart/issues/547)
 * When there are two pieces of XML metadata for a single dataset, but one is simply a GDALMultiDomainMetadata wrapping the other, the wrapped version is ignored. [#547](https://github.com/koordinates/kart/issues/547)

--- a/kart/diff.py
+++ b/kart/diff.py
@@ -2,6 +2,7 @@ import sys
 
 import click
 
+from .cli_util import OutputFormatType, parse_output_format
 from .crs_util import CoordinateReferenceString
 
 from .output_util import dump_json_output
@@ -54,8 +55,17 @@ def feature_count_diff(
 @click.option(
     "--output-format",
     "-o",
-    type=click.Choice(
-        ["text", "json", "geojson", "quiet", "feature-count", "html", "json-lines"]
+    type=OutputFormatType(
+        output_types=[
+            "text",
+            "json",
+            "geojson",
+            "quiet",
+            "feature-count",
+            "html",
+            "json-lines",
+        ],
+        allow_text_formatstring=False,
     ),
     default="text",
     help=(
@@ -82,8 +92,7 @@ def feature_count_diff(
 @click.option(
     "--json-style",
     type=click.Choice(["extracompact", "compact", "pretty"]),
-    default="pretty",
-    help="How to format the output. Only used with -o json or -o geojson",
+    help="[deprecated] How to format the output. Only used with -o json or -o geojson",
 )
 @click.option(
     "--only-feature-count",
@@ -124,25 +133,27 @@ def diff(
 
     To list only particular conflicts, supply one or more FILTERS of the form [DATASET[:PRIMARY_KEY]]
     """
+    output_type, fmt = parse_output_format(output_format, json_style)
+
     if only_feature_count:
         return feature_count_diff(
             ctx,
-            output_format,
+            output_type,
             commit_spec,
             output_path,
             exit_code,
-            json_style,
+            fmt,
             only_feature_count,
         )
 
     from .base_diff_writer import BaseDiffWriter
 
     repo = ctx.obj.get_repo(allowed_states=KartRepoState.ALL_STATES)
-    diff_writer_class = BaseDiffWriter.get_diff_writer_class(output_format)
+    diff_writer_class = BaseDiffWriter.get_diff_writer_class(output_type)
     diff_writer = diff_writer_class(
-        repo, commit_spec, filters, output_path, json_style=json_style, target_crs=crs
+        repo, commit_spec, filters, output_path, json_style=fmt, target_crs=crs
     )
     diff_writer.write_diff()
 
-    if exit_code or output_format == "quiet":
+    if exit_code or output_type == "quiet":
         diff_writer.exit_with_code()

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1700,7 +1700,7 @@ def test_show_polygons_initial(output_format, data_archive_readonly, cli_runner)
 
 def test_show_json_format(data_archive_readonly, cli_runner):
     with data_archive_readonly("points"):
-        r = cli_runner.invoke(["show", f"-o", "json", "--json-style=compact", "HEAD"])
+        r = cli_runner.invoke(["show", f"-o", "json:compact", "HEAD"])
 
         assert r.exit_code == 0, r.stderr
         # output is compact, no indentation
@@ -1712,7 +1712,7 @@ def test_show_json_coloured(data_archive_readonly, cli_runner, monkeypatch):
     monkeypatch.setattr(kart.output_util, "can_output_colour", always_output_colour)
 
     with data_archive_readonly("points"):
-        r = cli_runner.invoke(["show", f"-o", "json", "--json-style=pretty", "HEAD"])
+        r = cli_runner.invoke(["show", f"-o", "json:pretty", "HEAD"])
         assert r.exit_code == 0, r.stderr
         # No asserts about colour codes - that would be system specific. Just a basic check:
         assert '"kart.diff/v1+hexwkb"' in r.stdout

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -209,7 +209,7 @@ def test_commit_files_remove_empty(data_archive, cli_runner):
 
 def test_commit_files_amend(data_archive, cli_runner):
     with data_archive("points"):
-        r = cli_runner.invoke(["log", "--pretty=%s"])
+        r = cli_runner.invoke(["log", "--output-format=text:%s"])
         assert r.exit_code == 0, r.stderr
         assert r.stdout.splitlines() == [
             "Improve naming on Coromandel East coast",
@@ -228,7 +228,7 @@ def test_commit_files_amend(data_archive, cli_runner):
         )
         assert r.exit_code == 0, r.stderr
 
-        r = cli_runner.invoke(["log", "--pretty=%t"])
+        r = cli_runner.invoke(["log", "--output-format=text:%t"])
         assert r.exit_code == 0, r.stderr
         actual_tree_contents = r.stdout.splitlines()
 
@@ -243,7 +243,7 @@ def test_commit_files_amend(data_archive, cli_runner):
             ]
         )
 
-        r = cli_runner.invoke(["log", "--pretty=%s"])
+        r = cli_runner.invoke(["log", "--output-format=text:%s"])
         assert r.exit_code == 0, r.stderr
         assert r.stdout.splitlines() == [
             "A more informative commit message",
@@ -254,13 +254,13 @@ def test_commit_files_amend(data_archive, cli_runner):
         )
         assert myfile == "myfile"
 
-        r = cli_runner.invoke(["log", "--pretty=%t"])
+        r = cli_runner.invoke(["log", "--output-format=text:%t"])
         assert r.exit_code == 0, r.stderr
         assert r.stdout.splitlines() == actual_tree_contents
 
         # --amend without a message just uses the same message as previous commit
         r = cli_runner.invoke(["commit-files", "--amend", "x=y"])
-        r = cli_runner.invoke(["log", "--pretty=%s"])
+        r = cli_runner.invoke(["log", "--output-format=text:%s"])
         assert r.exit_code == 0, r.stderr
         assert r.stdout.splitlines() == [
             "A more informative commit message",


### PR DESCRIPTION
## Description

Expands the `--output-format / -o` flag to handle format/style modifiers, and deprecates `--json-style=compact` which was used for JSON output specifically.

e.g. these are now supported:
* `--output-format=text` (same as default)
* `--output-format=text:%H`
* `--output-format=text:oneline`
* `--output-format=json:compact`
* `--output-format=json:pretty`
* `--output-format=json` (same as pretty)

the `text` modifiers are only available in `log` at present (todo: we should add them to `show` at some point) but the `json` ones are available in all commands that json is accepted

## Related links:

* Fixes #542 (this is solution 3)
## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
