### PR TITLE
Two fixes for GPKGs with more than 1 XML metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 ## 0.10.9 (UNRELEASED)
 
 * Bugfix: fixed errors with Postgres working copies when one or more datasets have no CRS defined. [#529](https://github.com/koordinates/kart/issues/529)
+* Bugfix: better error message when `kart import` fails due to multiple XML metadata files for a single dataset, which Kart does not support [#547](https://github.com/koordinates/kart/issues/547)
+* When there are two pieces of XML metadata for a single dataset, but one is simply a GDALMultiDomainMetadata wrapping the other, the wrapped version is ignored. [#547](https://github.com/koordinates/kart/issues/547)
 
 ## 0.10.8
 

--- a/kart/dataset3.py
+++ b/kart/dataset3.py
@@ -439,6 +439,16 @@ class Dataset3(RichBaseDataset):
                 "Sorry, committing more than one XML metadata file is not supported"
             )
 
+    @classmethod
+    def check_source_is_importable(cls, source):
+        # This is currently the only case where we sometimes generate meta items we cannot import -
+        # if there is more than one XML metadata blob attached to a single dataset.
+        metadata_xml = source.meta_items().get("metadata.xml")
+        if isinstance(metadata_xml, list):
+            raise NotYetImplemented(
+                f"Sorry, importing more than one XML metadata file for a single dataset ({source.dest_path}) is not supported"
+            )
+
     def _apply_meta_deltas_to_tree(
         self,
         deltas,

--- a/kart/fast_import.py
+++ b/kart/fast_import.py
@@ -254,7 +254,7 @@ def fast_import_tables(
     assert repo.version in SUPPORTED_REPO_VERSIONS
     extra_blobs = extra_blobs_for_version(repo.version) if not from_commit else []
 
-    ImportSource.check_valid(sources)
+    ImportSource.check_valid(sources, dataset_class_for_version(repo.version))
 
     if replace_existing == ReplaceExisting.DONT_REPLACE:
         for source in sources:

--- a/kart/import_source.py
+++ b/kart/import_source.py
@@ -39,11 +39,13 @@ class ImportSource:
             return OgrImportSource.open(full_spec, table=table)
 
     @classmethod
-    def check_valid(cls, import_sources, param_hint=None):
+    def check_valid(cls, import_sources, dataset_class=None, param_hint=None):
         """Given an iterable of ImportSources, checks that all are fully specified and none of their dest_paths collide."""
         dest_paths = {}
         for s1 in import_sources:
             s1.check_fully_specified()
+            if dataset_class is not None:
+                dataset_class.check_source_is_importable(s1)
             dest_path = s1.dest_path
             if dest_path not in dest_paths:
                 dest_paths[dest_path] = s1


### PR DESCRIPTION
<img src="https://media2.giphy.com/media/xULW8INGrA62E85Wdq/giphy.gif"/>

Firstly, output a proper error message instead of
TypeError: a bytes-like object is required, not 'list'

Secondly, automatically discard one piece of XML metadata in the case
that both pieces of XML metadata are functionally identical, but one
is original and the other wraps the original in the following manner:

```xml
<GDALMultiDomainMetadata>
  <Metadata>
    <MDI key="some_key">
	[ESCAPED_ORIGINAL_XML]
    </MDI>
  </Metadata>
</GDALMultiDomainMetadata>
```

## Description

<!-- Thanks for your contribution! Describe your changes in a few sentences. Try to include discussion of tradeoffs or alternatives you considered when writing this code. -->

## Related links:

<!-- If you have links to [issues](https://github.com/koordinates/kart/issues) etc, link them here. -->

## Checklist:

- [ ] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
