### PR TITLE
Fix for #555 - issues with merge + shallow clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Support for spatial filters - the spatial filter can be updated during an `init`
 * Bugfix: better error message when `kart import` fails due to multiple XML metadata files for a single dataset, which Kart does not support [#547](https://github.com/koordinates/kart/issues/547)
 * When there are two pieces of XML metadata for a single dataset, but one is simply a `GDALMultiDomainMetadata` wrapping the other, the wrapped version is ignored. [#547](https://github.com/koordinates/kart/issues/547)
 * Bugfix: fixed a bug preventing `checkout -b NEW_BRANCH HEAD^` and similar commands from working
+* Bugfix: fixed a bug where `kart merge` would fail in a shallow clone, in certain circumstances. [#555](https://github.com/koordinates/kart/issues/555)
 
 ## 0.10.8
 

--- a/kart/repo.py
+++ b/kart/repo.py
@@ -780,6 +780,18 @@ class KartRepo(pygit2.Repository):
             revision = "HEAD"
         return super().revparse_ext(revision)
 
+    def merge_base(self, oid1, oid2):
+        # FIXME: Overridden to work around https://github.com/koordinates/kart/issues/555
+        # Caused by https://github.com/libgit2/libgit2/issues/6123
+        try:
+            args = ["git", "-C", self.path, "merge-base", str(oid1), str(oid2)]
+            output = subprocess.check_output(
+                args, encoding="utf8", env=tool_environment()
+            )
+            return pygit2.Oid(hex=output.strip())
+        except subprocess.CalledProcessError:
+            return None
+
     KART_COMMON_README = [
         "",
         "kart status",


### PR DESCRIPTION
<img src="https://media1.giphy.com/media/JMoyE48gJqivS/giphy.gif"/>

libgit2 doesn't support shallow clones, and so operations that involve
walking back through the commits like `git_merge_base` can fail
(depending on the exact circumstances).
This workaround simply switches to using `git merge-base` instead - the
same functionality, but from within git, which *does* support shallow clones.

Adds a test case to show it is fixed.

Fixes https://github.com/koordinates/kart/issues/555

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
