### PR TITLE
Start of point cloud import

### DIFF
--- a/kart/cli.py
+++ b/kart/cli.py
@@ -294,11 +294,26 @@ def gc(ctx, args):
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def git(ctx, args):
     """
-    Run an arbitrary git command, using kart's packaged git
+    Run an arbitrary Git command, using kart's packaged Git
     """
     params = ["git"]
     if ctx.obj.user_repo_path:
         params += ["-C", ctx.obj.user_repo_path]
+    execvp("git", [*params, *args])
+
+
+@cli.command(context_settings=dict(ignore_unknown_options=True), hidden=True)
+@click.pass_context
+@click.argument("args", nargs=-1, type=click.UNPROCESSED)
+def lfs(ctx, args):
+    """
+    Run an arbitrary Git LFS command, using Kart's packaged Git.
+    Git LFS is not yet packaged with Kart so this will not work unless your Kart environment has Git LFS installed.
+    """
+    params = ["git"]
+    if ctx.obj.user_repo_path:
+        params += ["-C", ctx.obj.user_repo_path]
+    params += ["lfs"]
     execvp("git", [*params, *args])
 
 

--- a/kart/point_cloud/import_.py
+++ b/kart/point_cloud/import_.py
@@ -1,16 +1,34 @@
 import json
+import hashlib
+import os
 from pathlib import Path
+import uuid
+import subprocess
 import sys
 
 import click
+from osgeo import osr
 
+from kart.crs_util import make_crs
 from kart.exceptions import (
     InvalidOperation,
     NotFound,
     NO_IMPORT_SOURCE,
     INVALID_FILE_FORMAT,
 )
+from kart.fast_import import (
+    FastImportSettings,
+    git_fast_import,
+    generate_header,
+    write_blob_to_stream,
+    write_blobs_to_stream,
+)
+from kart.serialise_util import hexhash
 from kart.output_util import format_wkt_for_output
+from kart.repo_version import (
+    SUPPORTED_REPO_VERSIONS,
+    extra_blobs_for_version,
+)
 
 
 @click.command("point-cloud-import", hidden=True)
@@ -25,14 +43,20 @@ def point_cloud_import(ctx, sources):
     """
     import pdal
 
+    repo = ctx.obj.repo
+
     for source in sources:
         if not (Path() / source).is_file():
             raise NotFound(f"No data found at {source}", exit_code=NO_IMPORT_SOURCE)
 
+    compressed_set = ListBasedSet()
     version_set = ListBasedSet()
     copc_version_set = ListBasedSet()
     pdrf_set = ListBasedSet()
     crs_set = ListBasedSet()
+    transform = None
+
+    per_source_info = {}
 
     for source in sources:
         click.echo(f"Checking {source}...          \r", nl=False)
@@ -53,10 +77,14 @@ def point_cloud_import(ctx, sources):
 
         info = json.loads(pipeline.metadata)["metadata"]["readers.las"]
 
+        compressed_set.add(info["compressed"])
+        if len(compressed_set) > 1:
+            raise _non_homogenous_error("filetype", "LAS vs LAZ")
+
         version = f"{info['major_version']}.{info['minor_version']}"
         version_set.add(version)
         if len(version_set) > 1:
-            raise _non_homogenous_error("ersion", version_set)
+            raise _non_homogenous_error("version", version_set)
 
         copc_version_set.add(get_copc_version(info))
         if len(copc_version_set) > 1:
@@ -75,19 +103,118 @@ def point_cloud_import(ctx, sources):
                 ),
             )
 
-    click.secho("\nVersion:", bold=True)
-    click.echo(version_set[0])
+        if transform is None:
+            src_crs = make_crs(crs_set[0])
+            target_crs = make_crs("EPSG:4326")
+            transform = osr.CoordinateTransformation(src_crs, target_crs)
 
-    click.secho("\nCOPC Version:", bold=True)
-    click.echo(copc_version_set[0])
+        native_envelope = get_native_envelope(info)
+        crs84_envelope = _transform_3d_envelope(transform, native_envelope)
+        per_source_info[source] = {
+            "count": info["count"],
+            "native_envelope": native_envelope,
+            "crs84_envelope": crs84_envelope,
+        }
 
-    click.secho("\nPoint Data Record Format:", bold=True)
-    click.echo(pdrf_set[0])
+    click.echo()
 
-    click.secho("\nCRS:", bold=True)
-    click.echo(format_wkt_for_output(crs_set[0], sys.stdout))
+    # Set up LFS hooks.
+    # TODO: This could eventually be moved to `kart init`.
+    r = subprocess.check_call(
+        ["git", "-C", str(repo.gitdir_path), "lfs", "install", "hooks"]
+    )
 
-    # TODO - actually import these files.
+    # TODO: Find a proper dataset name or let the user supply it:
+    if len(sources) == 1:
+        ds_path = os.path.basename(os.path.splitext(sources[0])[0])
+    else:
+        ds_path = os.path.basename(os.path.commonprefix(sources)).rstrip("-_.")
+
+    # We still need to write .kart.repostructure.version unfortunately, even though it's only relevant to tabular datasets.
+    assert repo.version in SUPPORTED_REPO_VERSIONS
+    extra_blobs = extra_blobs_for_version(repo.version) if not repo.head_commit else []
+
+    header = generate_header(
+        repo,
+        None,
+        f"Importing {len(sources)} point-cloud tiles as {ds_path}",
+        repo.head_branch,
+        repo.head_commit,
+    )
+
+    # TODO: Don't accept all possible versions of everything / maybe convert everything to COPC-1.0
+    copc_version = copc_version_set[0]
+    if copc_version == 1:
+        kart_format = "pc:v1/copc-1.0"
+    elif copc_version != NOT_COPC:
+        kart_format = f"pc:DEV/copc-{copc_version}"
+    else:
+        filetype = "laz" if compressed_set[0] is True else "las"
+        kart_format = f"pc:DEV/{filetype}-{version_set[0]}"
+
+    lfs_objects_path = repo.gitdir_path / "lfs" / "objects"
+    lfs_tmp_import_path = lfs_objects_path / "import"
+    lfs_tmp_import_path.mkdir(parents=True, exist_ok=True)
+
+    with git_fast_import(repo, *FastImportSettings().as_args(), "--quiet") as proc:
+        proc.stdin.write(header.encode("utf8"))
+
+        for i, blob_path in write_blobs_to_stream(proc.stdin, extra_blobs):
+            pass
+
+        for source in sources:
+            click.echo(f"Writing {source}...          \r", nl=False)
+
+            tmp_object_path = lfs_tmp_import_path / str(uuid.uuid4())
+            oid, size = _copy_and_get_sha256_and_size(source, tmp_object_path)
+            actual_object_path = lfs_objects_path / oid[0:2] / oid[2:4] / oid
+            actual_object_path.parents[0].mkdir(parents=True, exist_ok=True)
+            tmp_object_path.rename(actual_object_path)
+
+            # TODO - is this the right prefix and name?
+            tilename = os.path.basename(source)
+            tile_prefix = hexhash(tilename)[0:2]
+            blob_path = (
+                f"{ds_path}/.point-cloud-dataset.v1/tiles/{tile_prefix}/{tilename}"
+            )
+            info = per_source_info[source]
+            pointer_dict = {
+                "version": "https://git-lfs.github.com/spec/v1",
+                # TODO - available.<URL-IDX> <URL>
+                "kart.extent.crs84": _format_array(info["crs84_envelope"]),
+                "kart.extent.native": _format_array(info["native_envelope"]),
+                "kart.format": kart_format,
+                "kart.pc.count": info["count"],
+                "oid": f"sha256:{oid}",
+                "size": size,
+            }
+            write_pointer_file_to_stream(proc.stdin, blob_path, pointer_dict)
+
+    click.echo()
+
+
+def _format_array(array):
+    return json.dumps(array, separators=(",", ":"))[1:-1]
+
+
+def write_pointer_file_to_stream(stream, blob_path, pointer_dict):
+    def sort_key(key_value):
+        key, value = key_value
+        if key == "version":
+            return ""
+        return key
+
+    blob = bytearray()
+    for key, value in sorted(pointer_dict.items(), key=sort_key):
+        # TODO - LFS doesn't support our fancy pointer files yet. Hopefully fix this in LFS.
+        if key not in ("version", "oid", "size"):
+            continue
+        blob += key.encode("utf8")
+        blob += b" "
+        blob += str(value).encode("utf8")
+        blob += b"\n"
+
+    write_blob_to_stream(stream, blob_path, blob)
 
 
 # The COPC version number we use for any LAZ / LAS file that is not actually COPC.
@@ -103,6 +230,22 @@ def get_copc_version(info):
     return NOT_COPC
 
 
+def get_native_envelope(info):
+    def _get_native_envelope_for_coord(coord):
+        min_coord = (
+            info[f"min{coord}"] * info[f"scale_{coord}"] + info[f"offset_{coord}"]
+        )
+        max_coord = (
+            info[f"max{coord}"] * info[f"scale_{coord}"] + info[f"offset_{coord}"]
+        )
+        return min_coord, max_coord
+
+    min_x, max_x = _get_native_envelope_for_coord("x")
+    min_y, max_y = _get_native_envelope_for_coord("y")
+    min_z, max_z = _get_native_envelope_for_coord("z")
+    return min_x, max_x, min_y, max_y, min_z, max_z
+
+
 def _non_homogenous_error(attribute_name, detail):
     if not isinstance(detail, str):
         detail = " vs ".join(str(d) for d in detail)
@@ -114,6 +257,27 @@ def _non_homogenous_error(attribute_name, detail):
     raise InvalidOperation(
         "Non-homogenous dataset supplied", exit_code=INVALID_FILE_FORMAT
     )
+
+
+def _transform_3d_envelope(transform, envelope):
+    x0, y0, z0 = transform.TransformPoint(*envelope[0::2])
+    x1, y1, z1 = transform.TransformPoint(*envelope[1::2])
+    return min(x0, x1), max(x0, x1), min(y0, y1), max(y0, y1), min(z0, z1), max(z0, z1)
+
+
+def _copy_and_get_sha256_and_size(src, dest):
+    BUF_SIZE = 65536
+    sha256 = hashlib.sha256()
+    size = Path(src).stat().st_size
+    with open(str(src), "rb") as input:
+        with open(str(dest), "wb") as output:
+            while True:
+                data = input.read(BUF_SIZE)
+                if not data:
+                    break
+                sha256.update(data)
+                output.write(data)
+    return sha256.hexdigest(), size
 
 
 class ListBasedSet:

--- a/kart/repo.py
+++ b/kart/repo.py
@@ -441,6 +441,9 @@ class KartRepo(pygit2.Repository):
         (self.gitdir_path / "info").mkdir(exist_ok=True)
         with (self.gitdir_path / "info" / "attributes").open("a+") as f:
             f.write("**/.table-dataset/feature/** merge=binary\n")
+            f.write(
+                "**/.point-cloud-dataset*/tiles/** filter=lfs diff=lfs merge=lfs -text\n"
+            )
 
     def write_readme(self):
         readme_filename = f"{self.branding.upper()}_README.txt"

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -1,8 +1,11 @@
 from glob import glob
+import subprocess
 import pytest
 
 from kart.exceptions import INVALID_FILE_FORMAT
+from kart.repo import KartRepo
 
+DUMMY_REPO = "git@example.com/example.git"
 
 # using a fixture instead of a skipif decorator means we get one aggregated skip
 # message rather than one per test
@@ -22,36 +25,87 @@ def requires_pdal():
     )
 
 
+@pytest.fixture(scope="session")
+def requires_git_lfs():
+    r = subprocess.run(["git", "lfs", "--version"])
+    has_git_lfs = r.returncode == 0
+
+    pytest.helpers.feature_assert_or_skip(
+        "Git LFS installed", "KART_EXPECT_GIT_LFS", has_git_lfs, ci_require=False
+    )
+
+
 def test_import_single_las(
-    tmp_path, chdir, cli_runner, data_archive_readonly, requires_pdal
+    tmp_path, chdir, cli_runner, data_archive_readonly, requires_pdal, requires_git_lfs
 ):
     # Using postgres here because it has the best type preservation
     with data_archive_readonly("point-cloud/autzen.tgz") as autzen:
         repo_path = tmp_path / "point-cloud-repo"
         r = cli_runner.invoke(["init", repo_path])
         assert r.exit_code == 0, r.stderr
+
+        repo = KartRepo(repo_path)
         with chdir(repo_path):
             r = cli_runner.invoke(["point-cloud-import", f"{autzen}/autzen.las"])
             assert r.exit_code == 0, r.stderr
 
+            r = cli_runner.invoke(["remote", "add", "origin", DUMMY_REPO])
+            assert r.exit_code == 0, r.stderr
+            repo.config[f"lfs.{DUMMY_REPO}/info/lfs.locksverify"] = False
+
+            stdout = subprocess.check_output(
+                ["kart", "lfs", "push", "origin", "--all", "--dry-run"], encoding="utf8"
+            )
+            assert stdout.splitlines() == [
+                "push 068a349959a45957184606a0442f8dd69aef24543e11963bc63835301df532f5 => autzen/.point-cloud-dataset.v1/tiles/0d/autzen.las"
+            ]
+
 
 def test_import_several_las(
-    tmp_path, chdir, cli_runner, data_archive_readonly, requires_pdal
+    tmp_path, chdir, cli_runner, data_archive_readonly, requires_pdal, requires_git_lfs
 ):
     # Using postgres here because it has the best type preservation
     with data_archive_readonly("point-cloud/auckland.tgz") as auckland:
         repo_path = tmp_path / "point-cloud-repo"
         r = cli_runner.invoke(["init", repo_path])
         assert r.exit_code == 0
+
+        repo = KartRepo(repo_path)
         with chdir(repo_path):
             r = cli_runner.invoke(
                 ["point-cloud-import", *glob(f"{auckland}/auckland_*.laz")]
             )
             assert r.exit_code == 0, r.stderr
 
+            r = cli_runner.invoke(["remote", "add", "origin", DUMMY_REPO])
+            assert r.exit_code == 0, r.stderr
+            repo.config[f"lfs.{DUMMY_REPO}/info/lfs.locksverify"] = False
+
+            stdout = subprocess.check_output(
+                ["kart", "lfs", "push", "origin", "--all", "--dry-run"], encoding="utf8"
+            )
+            assert stdout.splitlines() == [
+                "push 6b980ce4d7f4978afd3b01e39670e2071a792fba441aca45be69be81cb48b08c => auckland/.point-cloud-dataset.v1/tiles/14/auckland_0_0.laz",
+                "push 46d84ea32dddeb29e4189febb2d2ab22b285e568fb8179ee96d17615502a7f3b => auckland/.point-cloud-dataset.v1/tiles/23/auckland_2_1.laz",
+                "push 1a4b8ac69123725e705657b9fd8000cd0ad33cc92f57992cc5902081700a697d => auckland/.point-cloud-dataset.v1/tiles/35/auckland_1_0.laz",
+                "push 06bd15fbb6616cf63a4a410c5ba4666dab76177a58cb99c3fa2afb46c9dd6379 => auckland/.point-cloud-dataset.v1/tiles/35/auckland_1_3.laz",
+                "push 09701813661e369395d088a9a44f1201200155e652a8b6e291e71904f45e32a6 => auckland/.point-cloud-dataset.v1/tiles/44/auckland_3_0.laz",
+                "push 2b54321de47d48c399a679c647cba20798399d604f3b350e6dcd1ce395d61031 => auckland/.point-cloud-dataset.v1/tiles/4c/auckland_0_1.laz",
+                "push 111579edfe022ebfd3388cc47d911c16c72c7ebd84c32a7a0c1dab6ed9ec896a => auckland/.point-cloud-dataset.v1/tiles/52/auckland_0_2.laz",
+                "push d89966fb10b30d6987955ae1b97c752ba875de89da1881e2b05820878d17eab9 => auckland/.point-cloud-dataset.v1/tiles/69/auckland_1_1.laz",
+                "push 74f144617acd46b95c02b3e4f3030fd2029476fab795b5a9a99a13c1ee184e36 => auckland/.point-cloud-dataset.v1/tiles/8b/auckland_2_3.laz",
+                "push 82563ccbbc55ba4b063ef6e8a41c031e8af508a6be6fec400565b88096dd1501 => auckland/.point-cloud-dataset.v1/tiles/96/auckland_2_0.laz",
+                "push a4acd08ca3763823df67fc0d4e45ce0e39525b49e31d8f20babc74d208e481a5 => auckland/.point-cloud-dataset.v1/tiles/9d/auckland_0_3.laz",
+                "push 1ca14275bbd4b74fedc00b64687f85776e6ebd32aceda413566ab7d6694ccff7 => auckland/.point-cloud-dataset.v1/tiles/b5/auckland_3_1.laz",
+                "push 4190c9056b732fadd6e86500e93047a787d88812f7a4af21c7759d92d1d48954 => auckland/.point-cloud-dataset.v1/tiles/ba/auckland_3_3.laz",
+                "push d47dad83c4259e4ff2b6efbb8f1262dbd903c70794d928c43e98c45edbcd927c => auckland/.point-cloud-dataset.v1/tiles/d5/auckland_1_2.laz",
+                "push 03e3d4dc6fc8e75c65ffdb39b630ffe26e4b95982b9765c919e34fb940e66fc0 => auckland/.point-cloud-dataset.v1/tiles/d5/auckland_3_2.laz",
+                "push 7fdde415acb376f5dcad93fcb6a9ef9cb9b1378edeb7f0c5ec6fd8beacdabedd => auckland/.point-cloud-dataset.v1/tiles/fc/auckland_2_2.laz",
+            ]
+
 
 def test_import_mismatched_las(
-    tmp_path, chdir, cli_runner, data_archive_readonly, requires_pdal
+    tmp_path, chdir, cli_runner, data_archive_readonly, requires_pdal, requires_git_lfs
 ):
     # Using postgres here because it has the best type preservation
     with data_archive_readonly("point-cloud/auckland.tgz") as auckland:


### PR DESCRIPTION
<img src="https://media3.giphy.com/media/12EkClXW5dt9PW/giphy.gif"/>

Imports individual point cloud tiles by writing pointer files and
putting the tiles in the LFS cache.
This is sufficient so that running `git push` or `kart push` will
cause the tiles to be written to the remote's LFS server (if LFS is
installed).

Lots more things to be done in subsequent changes:
- No point-cloud dataset metadata is written
- Point cloud working copy is not checked out
- Although we generate the necessary tile metadata, we don't yet write
  it to the pointer files since Git LFS doesn't currently allow this

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?

