### PR TITLE
PC: Convert LAS/LAZ files to COPC.LAZ on import

### DIFF
--- a/kart/dataset_util.py
+++ b/kart/dataset_util.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from .exceptions import InvalidOperation
+
+_RESERVED_WINDOWS_FILENAMES = frozenset(
+    {
+        "CON",
+        "PRN",
+        "AUX",
+        "NUL",
+        "COM1",
+        "COM2",
+        "COM3",
+        "COM4",
+        "COM5",
+        "COM6",
+        "COM7",
+        "COM8",
+        "COM9",
+        "LPT1",
+        "LPT2",
+        "LPT3",
+        "LPT4",
+        "LPT5",
+        "LPT6",
+        "LPT7",
+        "LPT8",
+        "LPT9",
+    }
+)
+
+
+def _validate_dataset_path(path: str) -> None:
+    """
+    Checks that the given dataset path has no disallowed characters or path components.
+    """
+    # disallow ASCII control characters as well as a few printable characters
+    # (mostly because they're disallowed in Windows filenames)
+    # but also because allowing ':' would make filter-spec parsing ambiguous in the Kart CLI.
+    control_chars = set(range(0, 0x20))
+    try:
+        path_bytes = set(path.encode("utf8"))
+    except UnicodeEncodeError:
+        raise InvalidOperation(f"Dataset path {path!r} cannot be encoded using UTF-8")
+    if not path_bytes:
+        raise InvalidOperation(f"Dataset path {path!r} may not be empty")
+
+    if path_bytes.intersection(control_chars):
+        raise InvalidOperation(
+            f"Dataset path {path!r} may not contain ASCII control characters"
+        )
+    other = ':<>"|?*'
+    if set(path_bytes).intersection(other.encode()):
+        raise InvalidOperation(
+            f"Dataset path {path!r} may not contain any of these characters: {other}"
+        )
+
+    if path.startswith("/"):
+        raise InvalidOperation(f"Dataset path {path!r} may not start with a '/'")
+
+    components = path.upper().split("/")
+    if any(not c for c in components):
+        raise InvalidOperation(
+            f"Dataset path {path!r} may not contain empty components"
+        )
+
+    bad_parts = sorted(_RESERVED_WINDOWS_FILENAMES.intersection(components))
+    if bad_parts:
+        raise InvalidOperation(
+            f"Dataset path {path!r} may not contain a component called {bad_parts[0]}"
+        )
+
+    if any(comp.startswith(".") or comp.endswith(".") for comp in components):
+        raise InvalidOperation(
+            f"Dataset path {path!r} may not contain a component starting or ending with a '.'"
+        )
+    if any(comp.endswith(" ") for comp in components):
+        raise InvalidOperation(
+            f"Dataset path {path!r} may not contain a component ending with a ' '"
+        )
+
+
+def validate_dataset_paths(paths: list[str]) -> None:
+    existing_paths_lower = {}
+    for path in paths:
+        _validate_dataset_path(path)
+        path_lower = path.casefold()
+        if path_lower in existing_paths_lower:
+            existing_path = existing_paths_lower[path_lower]
+            raise InvalidOperation(
+                f"Dataset path {path!r} conflicts with existing path {existing_path!r}"
+            )
+        existing_paths_lower[path_lower] = path

--- a/kart/init.py
+++ b/kart/init.py
@@ -9,11 +9,11 @@ from kart import is_windows
 from . import checkout
 from .cli_util import JsonFromFile, MutexOption, StringFromFile, call_and_exit_flag
 from .core import check_git_user
+from .dataset_util import validate_dataset_paths
 from .exceptions import InvalidOperation
 from .fast_import import FastImportSettings, ReplaceExisting, fast_import_tables
 from .repo import KartRepo, PotentialRepo
 from .spatial_filter import SpatialFilterString, spatial_filter_help_text
-from .tabular.base_dataset import BaseDataset
 from .tabular.import_source import ImportSource
 from .tabular.ogr_import_source import FORMAT_TO_OGR_MAP
 from .tabular.pk_generation import PkGeneratingImportSource
@@ -341,7 +341,7 @@ def import_(
     all_ds_paths = [s.dest_path for s in import_sources]
     if not replace_existing:
         all_ds_paths[:0] = [ds.path for ds in repo.datasets()]
-    BaseDataset.validate_dataset_paths(all_ds_paths)
+    validate_dataset_paths(all_ds_paths)
 
     replace_existing_enum = (
         ReplaceExisting.GIVEN if replace_existing else ReplaceExisting.DONT_REPLACE
@@ -485,7 +485,7 @@ def init(
     )
 
     if import_from:
-        BaseDataset.validate_dataset_paths([s.dest_path for s in sources])
+        validate_dataset_paths([s.dest_path for s in sources])
         fast_import_tables(
             repo,
             sources,

--- a/kart/point_cloud/import_.py
+++ b/kart/point_cloud/import_.py
@@ -10,6 +10,7 @@ import click
 from osgeo import osr
 
 from kart.crs_util import make_crs
+from kart.dataset_util import validate_dataset_paths
 from kart.exceptions import (
     InvalidOperation,
     NotFound,
@@ -33,8 +34,11 @@ from kart.repo_version import (
 
 @click.command("point-cloud-import", hidden=True)
 @click.pass_context
+@click.option(
+    "--dataset-path", "ds_path", help="The dataset's path once imported", required=True
+)
 @click.argument("sources", metavar="SOURCES", nargs=-1, required=True)
-def point_cloud_import(ctx, sources):
+def point_cloud_import(ctx, ds_path, sources):
     """
     Experimental command for importing point cloud datasets. Work-in-progress.
     Will eventually be merged with the main `import` command.
@@ -44,6 +48,10 @@ def point_cloud_import(ctx, sources):
     import pdal
 
     repo = ctx.obj.repo
+
+    # TODO - improve path validation to make sure datasets of any type don't collide with each other
+    # or with attachments.
+    validate_dataset_paths([ds_path])
 
     for source in sources:
         if not (Path() / source).is_file():
@@ -116,19 +124,14 @@ def point_cloud_import(ctx, sources):
             "crs84_envelope": crs84_envelope,
         }
 
-    click.echo()
+    click.echo(copc_version_set[0])
 
     # Set up LFS hooks.
     # TODO: This could eventually be moved to `kart init`.
-    r = subprocess.check_call(
-        ["git", "-C", str(repo.gitdir_path), "lfs", "install", "hooks"]
-    )
-
-    # TODO: Find a proper dataset name or let the user supply it:
-    if len(sources) == 1:
-        ds_path = os.path.basename(os.path.splitext(sources[0])[0])
-    else:
-        ds_path = os.path.basename(os.path.commonprefix(sources)).rstrip("-_.")
+    if not (repo.gitdir_path / "hooks" / "pre-push").is_file():
+        subprocess.check_call(
+            ["git", "-C", str(repo.gitdir_path), "lfs", "install", "hooks"]
+        )
 
     # We still need to write .kart.repostructure.version unfortunately, even though it's only relevant to tabular datasets.
     assert repo.version in SUPPORTED_REPO_VERSIONS
@@ -142,15 +145,14 @@ def point_cloud_import(ctx, sources):
         repo.head_commit,
     )
 
-    # TODO: Don't accept all possible versions of everything / maybe convert everything to COPC-1.0
-    copc_version = copc_version_set[0]
-    if copc_version == 1:
-        kart_format = "pc:v1/copc-1.0"
-    elif copc_version != NOT_COPC:
-        kart_format = f"pc:DEV/copc-{copc_version}"
-    else:
-        filetype = "laz" if compressed_set[0] is True else "las"
-        kart_format = f"pc:DEV/{filetype}-{version_set[0]}"
+    is_copc = (
+        compressed_set[0] is True
+        and version_set[0] == "1.4"
+        and copc_version_set[0] == 1
+    )
+    import_func = (
+        _copy_tile_to_copc_lfs_blob if is_copc else _convert_tile_to_copc_lfs_blob
+    )
 
     lfs_objects_path = repo.gitdir_path / "lfs" / "objects"
     lfs_tmp_import_path = lfs_objects_path / "import"
@@ -163,16 +165,16 @@ def point_cloud_import(ctx, sources):
             pass
 
         for source in sources:
-            click.echo(f"Writing {source}...          \r", nl=False)
+            click.echo(f"Writing {source}...")
 
             tmp_object_path = lfs_tmp_import_path / str(uuid.uuid4())
-            oid, size = _copy_and_get_sha256_and_size(source, tmp_object_path)
+            oid, size = import_func(source, tmp_object_path)
             actual_object_path = lfs_objects_path / oid[0:2] / oid[2:4] / oid
             actual_object_path.parents[0].mkdir(parents=True, exist_ok=True)
             tmp_object_path.rename(actual_object_path)
 
             # TODO - is this the right prefix and name?
-            tilename = os.path.basename(source)
+            tilename = os.path.splitext(os.path.basename(source))[0] + ".copc.laz"
             tile_prefix = hexhash(tilename)[0:2]
             blob_path = (
                 f"{ds_path}/.point-cloud-dataset.v1/tiles/{tile_prefix}/{tilename}"
@@ -183,7 +185,7 @@ def point_cloud_import(ctx, sources):
                 # TODO - available.<URL-IDX> <URL>
                 "kart.extent.crs84": _format_array(info["crs84_envelope"]),
                 "kart.extent.native": _format_array(info["native_envelope"]),
-                "kart.format": kart_format,
+                "kart.format": "pc:v1/copc-1.0",
                 "kart.pc.count": info["count"],
                 "oid": f"sha256:{oid}",
                 "size": size,
@@ -265,14 +267,56 @@ def _transform_3d_envelope(transform, envelope):
     return min(x0, x1), max(x0, x1), min(y0, y1), max(y0, y1), min(z0, z1), max(z0, z1)
 
 
-def _copy_and_get_sha256_and_size(src, dest):
-    BUF_SIZE = 65536
+_BUF_SIZE = 65536
+
+
+def _convert_tile_to_copc_lfs_blob(source, dest):
+    """
+    Converts a LAS/LAZ file of some sort as source to a COPC.LAZ file at dest.
+    Returns the SHA256 and length of the COPC.LAZ file.
+    """
+    # Note that this requires a cutting edge PDAL - e.g. 63eb89ab3f504e8af7259bf60c8158363c99b6e3.
+    import pdal
+
+    config = [
+        {
+            "type": "readers.las",
+            "filename": str(source),
+        },
+        {
+            "type": "writers.copc",
+            "filename": str(dest),
+            "forward": "all",
+        },
+    ]
+    pipeline = pdal.Pipeline(json.dumps(config))
+    try:
+        pipeline.execute()
+    except RuntimeError as e:
+        raise InvalidOperation(
+            f"Error converting {source}\n{e}", exit_code=INVALID_FILE_FORMAT
+        )
+    assert dest.is_file()
+
+    size = dest.stat().st_size
     sha256 = hashlib.sha256()
-    size = Path(src).stat().st_size
-    with open(str(src), "rb") as input:
+    with open(str(dest), "rb") as input:
+        while True:
+            data = input.read(_BUF_SIZE)
+            if not data:
+                break
+            sha256.update(data)
+    return sha256.hexdigest(), size
+
+
+def _copy_tile_to_copc_lfs_blob(source, dest):
+    """Copies a file from source to dest and returns the SHA256 and length of the file."""
+    sha256 = hashlib.sha256()
+    size = Path(source).stat().st_size
+    with open(str(source), "rb") as input:
         with open(str(dest), "wb") as output:
             while True:
-                data = input.read(BUF_SIZE)
+                data = input.read(_BUF_SIZE)
                 if not data:
                     break
                 sha256.update(data)

--- a/kart/tabular/base_dataset.py
+++ b/kart/tabular/base_dataset.py
@@ -1,11 +1,8 @@
-from __future__ import annotations
-
 import functools
 import logging
 import time
 
 from kart import crs_util
-from kart.exceptions import InvalidOperation
 from kart.promisor_utils import LibgitSubcode
 from kart.serialise_util import ensure_text, json_unpack
 from kart.spatial_filter import SpatialFilter
@@ -75,98 +72,6 @@ class BaseDataset(ImportSource):
         self.L = logging.getLogger(self.__class__.__qualname__)
 
         self.repo = repo
-
-    _RESERVED_WINDOWS_FILENAMES = frozenset(
-        {
-            "CON",
-            "PRN",
-            "AUX",
-            "NUL",
-            "COM1",
-            "COM2",
-            "COM3",
-            "COM4",
-            "COM5",
-            "COM6",
-            "COM7",
-            "COM8",
-            "COM9",
-            "LPT1",
-            "LPT2",
-            "LPT3",
-            "LPT4",
-            "LPT5",
-            "LPT6",
-            "LPT7",
-            "LPT8",
-            "LPT9",
-        }
-    )
-
-    @classmethod
-    def _validate_dataset_path(cls, path: str) -> None:
-        """
-        Checks that the given dataset path has no disallowed characters or path components.
-        """
-        # disallow ASCII control characters as well as a few printable characters
-        # (mostly because they're disallowed in Windows filenames)
-        # but also because allowing ':' would make filter-spec parsing ambiguous in the Kart CLI.
-        control_chars = set(range(0, 0x20))
-        try:
-            path_bytes = set(path.encode("utf8"))
-        except UnicodeEncodeError:
-            raise InvalidOperation(
-                f"Dataset path {path!r} cannot be encoded using UTF-8"
-            )
-        if not path_bytes:
-            raise InvalidOperation(f"Dataset path {path!r} may not be empty")
-
-        if path_bytes.intersection(control_chars):
-            raise InvalidOperation(
-                f"Dataset path {path!r} may not contain ASCII control characters"
-            )
-        other = ':<>"|?*'
-        if set(path_bytes).intersection(other.encode()):
-            raise InvalidOperation(
-                f"Dataset path {path!r} may not contain any of these characters: {other}"
-            )
-
-        if path.startswith("/"):
-            raise InvalidOperation(f"Dataset path {path!r} may not start with a '/'")
-
-        components = path.upper().split("/")
-        if any(not c for c in components):
-            raise InvalidOperation(
-                f"Dataset path {path!r} may not contain empty components"
-            )
-
-        bad_parts = sorted(cls._RESERVED_WINDOWS_FILENAMES.intersection(components))
-        if bad_parts:
-            raise InvalidOperation(
-                f"Dataset path {path!r} may not contain a component called {bad_parts[0]}"
-            )
-
-        if any(comp.startswith(".") or comp.endswith(".") for comp in components):
-            raise InvalidOperation(
-                f"Dataset path {path!r} may not contain a component starting or ending with a '.'"
-            )
-        if any(comp.endswith(" ") for comp in components):
-            raise InvalidOperation(
-                f"Dataset path {path!r} may not contain a component ending with a ' '"
-            )
-
-    @classmethod
-    def validate_dataset_paths(cls, paths: list[str]) -> None:
-        existing_paths_lower = {}
-        for path in paths:
-            cls._validate_dataset_path(path)
-            path_lower = path.casefold()
-            if path_lower in existing_paths_lower:
-                existing_path = existing_paths_lower[path_lower]
-                raise InvalidOperation(
-                    f"Dataset path {path!r} conflicts with existing path {existing_path!r}"
-                )
-            existing_paths_lower[path_lower] = path
 
     @classmethod
     def new_dataset_for_writing(cls, path, schema, repo=None):

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -1,4 +1,5 @@
 from glob import glob
+import re
 import subprocess
 import pytest
 
@@ -46,7 +47,9 @@ def test_import_single_las(
 
         repo = KartRepo(repo_path)
         with chdir(repo_path):
-            r = cli_runner.invoke(["point-cloud-import", f"{autzen}/autzen.las"])
+            r = cli_runner.invoke(
+                ["point-cloud-import", f"{autzen}/autzen.las", "--dataset-path=autzen"]
+            )
             assert r.exit_code == 0, r.stderr
 
             r = cli_runner.invoke(["remote", "add", "origin", DUMMY_REPO])
@@ -56,9 +59,10 @@ def test_import_single_las(
             stdout = subprocess.check_output(
                 ["kart", "lfs", "push", "origin", "--all", "--dry-run"], encoding="utf8"
             )
-            assert stdout.splitlines() == [
-                "push 068a349959a45957184606a0442f8dd69aef24543e11963bc63835301df532f5 => autzen/.point-cloud-dataset.v1/tiles/0d/autzen.las"
-            ]
+            assert re.match(
+                r"push [0-9a-f]{64} => autzen/.point-cloud-dataset.v1/tiles/e8/autzen.copc.laz",
+                stdout.splitlines()[0],
+            )
 
 
 def test_import_several_las(
@@ -73,7 +77,11 @@ def test_import_several_las(
         repo = KartRepo(repo_path)
         with chdir(repo_path):
             r = cli_runner.invoke(
-                ["point-cloud-import", *glob(f"{auckland}/auckland_*.laz")]
+                [
+                    "point-cloud-import",
+                    *glob(f"{auckland}/auckland_*.laz"),
+                    "--dataset-path=auckland",
+                ]
             )
             assert r.exit_code == 0, r.stderr
 
@@ -84,24 +92,12 @@ def test_import_several_las(
             stdout = subprocess.check_output(
                 ["kart", "lfs", "push", "origin", "--all", "--dry-run"], encoding="utf8"
             )
-            assert stdout.splitlines() == [
-                "push 6b980ce4d7f4978afd3b01e39670e2071a792fba441aca45be69be81cb48b08c => auckland/.point-cloud-dataset.v1/tiles/14/auckland_0_0.laz",
-                "push 46d84ea32dddeb29e4189febb2d2ab22b285e568fb8179ee96d17615502a7f3b => auckland/.point-cloud-dataset.v1/tiles/23/auckland_2_1.laz",
-                "push 1a4b8ac69123725e705657b9fd8000cd0ad33cc92f57992cc5902081700a697d => auckland/.point-cloud-dataset.v1/tiles/35/auckland_1_0.laz",
-                "push 06bd15fbb6616cf63a4a410c5ba4666dab76177a58cb99c3fa2afb46c9dd6379 => auckland/.point-cloud-dataset.v1/tiles/35/auckland_1_3.laz",
-                "push 09701813661e369395d088a9a44f1201200155e652a8b6e291e71904f45e32a6 => auckland/.point-cloud-dataset.v1/tiles/44/auckland_3_0.laz",
-                "push 2b54321de47d48c399a679c647cba20798399d604f3b350e6dcd1ce395d61031 => auckland/.point-cloud-dataset.v1/tiles/4c/auckland_0_1.laz",
-                "push 111579edfe022ebfd3388cc47d911c16c72c7ebd84c32a7a0c1dab6ed9ec896a => auckland/.point-cloud-dataset.v1/tiles/52/auckland_0_2.laz",
-                "push d89966fb10b30d6987955ae1b97c752ba875de89da1881e2b05820878d17eab9 => auckland/.point-cloud-dataset.v1/tiles/69/auckland_1_1.laz",
-                "push 74f144617acd46b95c02b3e4f3030fd2029476fab795b5a9a99a13c1ee184e36 => auckland/.point-cloud-dataset.v1/tiles/8b/auckland_2_3.laz",
-                "push 82563ccbbc55ba4b063ef6e8a41c031e8af508a6be6fec400565b88096dd1501 => auckland/.point-cloud-dataset.v1/tiles/96/auckland_2_0.laz",
-                "push a4acd08ca3763823df67fc0d4e45ce0e39525b49e31d8f20babc74d208e481a5 => auckland/.point-cloud-dataset.v1/tiles/9d/auckland_0_3.laz",
-                "push 1ca14275bbd4b74fedc00b64687f85776e6ebd32aceda413566ab7d6694ccff7 => auckland/.point-cloud-dataset.v1/tiles/b5/auckland_3_1.laz",
-                "push 4190c9056b732fadd6e86500e93047a787d88812f7a4af21c7759d92d1d48954 => auckland/.point-cloud-dataset.v1/tiles/ba/auckland_3_3.laz",
-                "push d47dad83c4259e4ff2b6efbb8f1262dbd903c70794d928c43e98c45edbcd927c => auckland/.point-cloud-dataset.v1/tiles/d5/auckland_1_2.laz",
-                "push 03e3d4dc6fc8e75c65ffdb39b630ffe26e4b95982b9765c919e34fb940e66fc0 => auckland/.point-cloud-dataset.v1/tiles/d5/auckland_3_2.laz",
-                "push 7fdde415acb376f5dcad93fcb6a9ef9cb9b1378edeb7f0c5ec6fd8beacdabedd => auckland/.point-cloud-dataset.v1/tiles/fc/auckland_2_2.laz",
-            ]
+            lines = stdout.splitlines()
+            for i in range(16):
+                assert re.match(
+                    r"push [0-9a-f]{64} => auckland/.point-cloud-dataset.v1/tiles/[0-9a-f]{2}/auckland_\d_\d.copc.laz",
+                    lines[i],
+                )
 
 
 def test_import_mismatched_las(
@@ -119,6 +115,7 @@ def test_import_mismatched_las(
                         "point-cloud-import",
                         *glob(f"{auckland}/auckland_*.laz"),
                         f"{autzen}/autzen.las",
+                        "--dataset-path=mixed",
                     ]
                 )
                 assert r.exit_code == INVALID_FILE_FORMAT


### PR DESCRIPTION
<img src="https://media3.giphy.com/media/XLIWxLU3KsmNM3Wt8w/giphy.gif"/>

COPC is a stricter standard - a COPC file  is also a valid LAZ 1.4 file
(Much like a COG file is a type of GeoTiff)

Moved dataset-name validation out of tabular, since it's not table specific.

https://github.com/koordinates/kart/issues/565

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
