### PR TITLE
Fix slowness when checking out spatial-filter WC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -849,7 +849,7 @@ jobs:
           git init
           git remote add origin https://github.com/${{ env.LIBGIT2_REPO }}.git
           git fetch -q --depth 1 origin ${{ env.LIBGIT2_TAG }}
-          git checkout ${{ env.LIBGIT2_TAG }}
+          git checkout FETCH_HEAD
           cmake -Wno-dev -B build -S . \
             -DBUILD_CLAR=OFF \
             -DCMAKE_C_COMPILER=/usr/lib/ccache/cc \
@@ -976,7 +976,7 @@ jobs:
           git init
           git remote add origin https://github.com/${{ env.LIBGIT2_REPO }}.git
           git fetch -q --depth 1 origin ${{ env.LIBGIT2_TAG }}
-          git checkout ${{ env.LIBGIT2_TAG }}
+          git checkout FETCH_HEAD
           cmake -Wno-dev -B build -S . \
             -DBUILD_CLAR=OFF \
             -DCMAKE_C_COMPILER=/usr/local/opt/ccache/libexec/cc \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on: [push, pull_request]
 env:
   PIP_CACHE_DIR: ${{ github.workspace }}/.cache/pip
   LIBGIT2_REPO: koordinates/libgit2
-  LIBGIT2_TAG: a7e2b1332b0adf6f852aed7d70bf925f3d388079
+  LIBGIT2_TAG: kart-v0.11.1
 
 jobs:
   #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please note that compatibility for 0.x releases (software or repositories) isn't
 
 _When adding new entries to the changelog, please include issue/PR numbers wherever possible._
 
+## 0.11.1
+
+* Fix for the slowness when creating the working copy in a spatially filtered repository (this was previously slower than usual in a spatially filtered repository, now it is faster) [#561](https://github.com/koordinates/kart/issues/561)
+
 ## 0.11.0
 
 ### Major changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## 0.11.1
 
-* Fix for the slowness when creating the working copy in a spatially filtered repository (this was previously slower than usual in a spatially filtered repository, now it is faster) [#561](https://github.com/koordinates/kart/issues/561)
+* Improve performance when creating a working copy in a spatially filtered repository (this was previously slower than in a non-filtered repository; now it is much faster) [#561](https://github.com/koordinates/kart/issues/561)
 
 ## 0.11.0
 

--- a/kart/working_copy/base.py
+++ b/kart/working_copy/base.py
@@ -905,7 +905,8 @@ class BaseWorkingCopy:
         """
         L = logging.getLogger(f"{self.__class__.__qualname__}.write_full")
 
-        with self.session() as sess:
+        self.repo.odb.refresh()
+        with pause_refreshing(self.repo.odb), self.session() as sess:
             dataset_count = len(datasets)
             for i, dataset in enumerate(datasets):
                 L.info(
@@ -1444,3 +1445,10 @@ class BaseWorkingCopy:
             self._reset_tracking_table_for_table(
                 sess, base_ds.table_name, feature_filter
             )
+
+
+@contextlib.contextmanager
+def pause_refreshing(odb):
+    odb.set_lookup_flags(pygit2.GIT_ODB_LOOKUP_NO_REFRESH)
+    yield
+    odb.set_lookup_flags(0)

--- a/kart/working_copy/base.py
+++ b/kart/working_copy/base.py
@@ -1449,6 +1449,9 @@ class BaseWorkingCopy:
 
 @contextlib.contextmanager
 def pause_refreshing(odb):
+    old_flags = odb.lookup_flags()
     odb.set_lookup_flags(pygit2.GIT_ODB_LOOKUP_NO_REFRESH)
-    yield
-    odb.set_lookup_flags(0)
+    try:
+        yield
+    finally:
+        odb.set_lookup_flags(old_flags)

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -199,7 +199,7 @@ set(PYGIT2_WHEEL_VER 1.9.0)
 ExternalProject_Add(
   pygit2
   GIT_REPOSITORY https://github.com/koordinates/pygit2.git
-  GIT_TAG ee304145fc588422c7d8ed930252e2e79f5bc2b2
+  GIT_TAG kart-v0.11.1
   BUILD_IN_SOURCE ON
   DEPENDS wheelBuildEnv LibGit2::LibGit2
   EXCLUDE_FROM_ALL ON

--- a/vendor/libgit2/Makefile
+++ b/vendor/libgit2/Makefile
@@ -1,5 +1,5 @@
 # v1.4.2 + koordinates changes
-LIBGIT2_REF ?= a7e2b1332b0adf6f852aed7d70bf925f3d388079
+LIBGIT2_REF ?= kart-v0.11.1
 LIBGIT2_REPO ?= koordinates/libgit2
 LIBGIT2_ARCHIVE := libgit2-$(LIBGIT2_REF).tar.gz
 

--- a/vendor/makefile.vc
+++ b/vendor/makefile.vc
@@ -7,12 +7,12 @@ GIT_REPO=koordinates/git
 GIT_RELEASE=kart-0.11.0-windows
 
 # v1.4.2 + koordinates changes
-LIBGIT2_REF=a7e2b1332b0adf6f852aed7d70bf925f3d388079
+LIBGIT2_REF=kart-v0.11.1
 LIBGIT2_REPO=koordinates/libgit2
 LIBGIT2_ARCHIVE=libgit2-$(LIBGIT2_REF).zip
 
 # v1.9.0 + koordinates changes
-PYGIT2_REF=ee304145fc588422c7d8ed930252e2e79f5bc2b2
+PYGIT2_REF=kart-v0.11.1
 PYGIT2_REPO=koordinates/pygit2
 PYGIT2_ARCHIVE=pygit2-$(PYGIT2_REF).zip
 PYGIT2_VER=1.9.0

--- a/vendor/pygit2/Makefile
+++ b/vendor/pygit2/Makefile
@@ -1,5 +1,5 @@
 # v1.9.0 + koordinates changes
-PYGIT2_REF ?= ee304145fc588422c7d8ed930252e2e79f5bc2b2
+PYGIT2_REF ?= kart-v0.11.1
 PYGIT2_REPO ?= koordinates/pygit2
 PYGIT2_ARCHIVE := pygit2-$(PYGIT2_REF).tar.gz
 


### PR DESCRIPTION
<img src="https://media4.giphy.com/media/yXVO50FJIJMSQ/giphy.gif"/>

Slowness is due to libgit2 repeatedly refreshing whenever it encounters
a missing object, in the hopes that the missing object is only due to
its stale view of the data on disk. The fix is to refresh once before
the WC checkout and then disable refreshing for the rest of the
checkout - this current-as-of-start-of-checkout view of the ODB is
good enough for us since we don't read and write concurrently.

https://github.com/koordinates/kart/issues/561