### PR TITLE
Make schema changes fail gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## 0.11.2 (UNRELEASED)
 
+- Bugfix: Better error message on using `kart conflicts -ogeojson` for `meta-item` conflicts. [#515](https://github.com/koordinates/kart/issues/515)
 - Removed the older `upgrade-to-tidy` and `upgrade-to-kart` features which were only relevant to Sno (predecessor of Kart). [[#585](https://github.com/koordinates/kart/issues/585]]
 - Added support for `--decorate` and `--no-decorate` in `kart log`. [[#586](https://github.com/koordinates/kart/issues/586]]
 

--- a/kart/conflicts.py
+++ b/kart/conflicts.py
@@ -1,6 +1,5 @@
 import logging
 import sys
-
 import click
 
 from .cli_util import OutputFormatType, parse_output_format
@@ -216,9 +215,19 @@ def conflicts_json_as_text(json_obj):
 def conflicts_json_as_geojson(json_obj):
     """Converts the JSON output of list_conflicts to geojson."""
     features = []
+    meta_item_keys = set()
     for key, feature in json_obj.items():
+        if type(feature) != dict or feature.get("type") != "Feature":
+            meta_item_keys.add(":".join(key.split(":")[:-1]))
+            continue
         feature["id"] = key
         features.append(feature)
+
+    if meta_item_keys:
+        L.warning(
+            f"There are meta-item conflicts that cannot be output as geojson: \n{meta_item_keys}"
+        )
+
     return {"type": "FeatureCollection", "features": features}
 
 


### PR DESCRIPTION
## Description
Added logs for conflicts with `geojson` output when parsing `meta-items` which can't be shown as `geojson`. This gives a better error message on using `kart conflicts -ogeojson` for `meta-item` conflicts.

## Related links:
- Fixes #515 

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
