### PR TITLE
Renames version to table-dataset-version

### DIFF
--- a/kart/apply.py
+++ b/kart/apply.py
@@ -50,7 +50,9 @@ def _meta_change_type(ds_diff_dict):
     return MetaChangeType.META_UPDATE
 
 
-def check_change_supported(repo_version, dataset, ds_path, meta_change_type, commit):
+def check_change_supported(
+    table_dataset_version, dataset, ds_path, meta_change_type, commit
+):
     desc = None
     if meta_change_type == MetaChangeType.CREATE_DATASET:
         desc = f"Patch creates dataset '{ds_path}'"
@@ -59,7 +61,7 @@ def check_change_supported(repo_version, dataset, ds_path, meta_change_type, com
     else:
         desc = f"Patch contains meta changes for dataset '{ds_path}'"
 
-    if repo_version < 2 and meta_change_type is not None:
+    if table_dataset_version < 2 and meta_change_type is not None:
         message = (
             V1_NO_META_UPDATE
             if meta_change_type == MetaChangeType.META_UPDATE
@@ -239,7 +241,7 @@ def apply_patch(
         dataset = rs.datasets.get(ds_path)
         meta_change_type = _meta_change_type(ds_diff_dict)
         check_change_supported(
-            repo.version, dataset, ds_path, meta_change_type, do_commit
+            repo.table_dataset_version, dataset, ds_path, meta_change_type, do_commit
         )
 
         meta_changes = ds_diff_dict.get("meta", {})

--- a/kart/data.py
+++ b/kart/data.py
@@ -141,7 +141,7 @@ def data_version(ctx, output_format):
     repo = ctx.obj.get_repo(
         allowed_states=KartRepoState.ALL_STATES, allow_unsupported_versions=True
     )
-    version = repo.version
+    version = repo.table_dataset_version
     if output_format == "text":
         click.echo(f"This Kart repo uses Datasets v{version}")
         if version >= 1:

--- a/kart/fast_import.py
+++ b/kart/fast_import.py
@@ -12,8 +12,8 @@ import pygit2
 from .cli_util import tool_environment
 from .exceptions import NO_CHANGES, InvalidOperation, NotFound, SubprocessError
 from .object_builder import ObjectBuilder
-from .repo_version import (
-    SUPPORTED_REPO_VERSIONS,
+from kart.tabular.version import (
+    SUPPORTED_VERSIONS,
     dataset_class_for_version,
     extra_blobs_for_version,
 )
@@ -279,10 +279,14 @@ def fast_import_tables(
 
     from_tree = from_commit.peel(pygit2.Tree) if from_commit else repo.empty_tree
 
-    assert repo.version in SUPPORTED_REPO_VERSIONS
-    extra_blobs = extra_blobs_for_version(repo.version) if not from_commit else []
+    assert repo.table_dataset_version in SUPPORTED_VERSIONS
+    extra_blobs = (
+        extra_blobs_for_version(repo.table_dataset_version) if not from_commit else []
+    )
 
-    ImportSource.check_valid(sources, dataset_class_for_version(repo.version))
+    ImportSource.check_valid(
+        sources, dataset_class_for_version(repo.table_dataset_version)
+    )
 
     if replace_existing == ReplaceExisting.DONT_REPLACE:
         for source in sources:
@@ -384,7 +388,7 @@ def fast_import_tables(
                 builder = ObjectBuilder(repo, trees[0])
                 for t in trees[1:]:
                     datasets = Datasets(
-                        repo, t, dataset_class_for_version(repo.version)
+                        repo, t, dataset_class_for_version(repo.table_dataset_version)
                     )
                     for ds in datasets:
                         try:
@@ -463,7 +467,7 @@ def _import_single_source(
             source=source,
         )
 
-    dataset_class = dataset_class_for_version(repo.version)
+    dataset_class = dataset_class_for_version(repo.table_dataset_version)
     dataset = dataset_class.new_dataset_for_writing(
         source.dest_path, source.schema, repo=repo
     )

--- a/kart/init.py
+++ b/kart/init.py
@@ -290,9 +290,9 @@ def import_(
         )
 
         if replace_ids is not None:
-            if repo.version < 2:
+            if repo.table_dataset_version < 2:
                 raise InvalidOperation(
-                    f"--replace-ids is not supported for V{repo.version} datasets"
+                    f"--replace-ids is not supported for V{repo.table_dataset_version} datasets"
                 )
             if not import_source.schema.pk_columns:
                 # non-PK datasets can use this if it's only ever an empty list.
@@ -304,9 +304,9 @@ def import_(
             replace_existing = True
 
         if replace_existing:
-            if repo.version < 2:
+            if repo.table_dataset_version < 2:
                 raise InvalidOperation(
-                    f"--replace-existing is not supported for V{repo.version} datasets"
+                    f"--replace-existing is not supported for V{repo.table_dataset_version} datasets"
                 )
             try:
                 existing_ds = repo.datasets()[dest_path]

--- a/kart/meta.py
+++ b/kart/meta.py
@@ -169,7 +169,7 @@ def meta_set(ctx, message, dataset, items):
     """
     repo = ctx.obj.repo
 
-    if repo.version < 2:
+    if repo.table_dataset_version < 2:
         raise InvalidOperation(
             "This repo doesn't support meta changes, use `kart upgrade`"
         )

--- a/kart/point_cloud/import_.py
+++ b/kart/point_cloud/import_.py
@@ -26,8 +26,8 @@ from kart.fast_import import (
 )
 from kart.serialise_util import hexhash, json_pack, ensure_bytes
 from kart.output_util import format_wkt_for_output
-from kart.repo_version import (
-    SUPPORTED_REPO_VERSIONS,
+from kart.tabular.version import (
+    SUPPORTED_VERSIONS,
     extra_blobs_for_version,
 )
 
@@ -183,8 +183,12 @@ def point_cloud_import(ctx, convert_to_copc, ds_path, sources):
         )
 
     # We still need to write .kart.repostructure.version unfortunately, even though it's only relevant to tabular datasets.
-    assert repo.version in SUPPORTED_REPO_VERSIONS
-    extra_blobs = extra_blobs_for_version(repo.version) if not repo.head_commit else []
+    assert repo.table_dataset_version in SUPPORTED_VERSIONS
+    extra_blobs = (
+        extra_blobs_for_version(repo.table_dataset_version)
+        if not repo.head_commit
+        else []
+    )
 
     header = generate_header(
         repo,

--- a/kart/structure.py
+++ b/kart/structure.py
@@ -15,9 +15,9 @@ from .exceptions import (
     NotYetImplemented,
 )
 from .pack_util import packfile_object_builder
-from .repo_version import extra_blobs_for_version
 from .structs import CommitWithReference
 from .tabular.schema import Schema
+from .tabular.version import extra_blobs_for_version
 
 L = logging.getLogger("kart.structure")
 
@@ -216,10 +216,10 @@ class RepoStructure:
 
         for ds_path, ds_diff in repo_diff.items():
             schema_delta = ds_diff.recursive_get(["meta", "schema.json"])
-            if schema_delta and self.version < 2:
+            if schema_delta and self.repo.table_dataset_version < 2:
                 # This should have been handled already, but just to be safe.
                 raise NotYetImplemented(
-                    "Meta changes are not supported until datasets V2"
+                    "Meta changes are not supported until table datasets V2"
                 )
 
             if schema_delta and schema_delta.type == "delete":
@@ -262,7 +262,7 @@ class RepoStructure:
 
             schema_delta = ds_diff.recursive_get(["meta", "schema.json"])
             if schema_delta:
-                if self.version < 2:
+                if self.repo.table_dataset_version < 2:
                     # This should have been handled already, but just to be safe.
                     raise NotYetImplemented(
                         "Meta changes are not supported until datasets V2"

--- a/kart/tabular/pk_generation.py
+++ b/kart/tabular/pk_generation.py
@@ -383,7 +383,7 @@ class PkGeneratingImportSource(ImportSource):
             unassigned_pks.update(pks)
 
         filtered_dataset_class = {2: FilteredDataset2, 3: FilteredDataset3}[
-            self.repo.version
+            self.repo.table_dataset_version
         ]
 
         def pk_filter(pk):

--- a/kart/upgrade/__init__.py
+++ b/kart/upgrade/__init__.py
@@ -9,7 +9,7 @@ from kart import checkout, context
 from kart.exceptions import InvalidOperation, NotFound
 from kart.fast_import import FastImportSettings, ReplaceExisting, fast_import_tables
 from kart.repo import KartConfigKeys, KartRepo
-from kart.repo_version import DEFAULT_NEW_REPO_VERSION
+from kart.tabular.version import DEFAULT_NEW_REPO_VERSION
 from kart.structure import RepoStructure
 from kart.tabular.dataset2 import Dataset2
 from kart.timestamps import minutes_to_tz_offset
@@ -96,7 +96,7 @@ class ForceLatestVersionRepo(KartRepo):
     """
 
     @property
-    def version(self):
+    def table_dataset_version(self):
         return DEFAULT_NEW_REPO_VERSION
 
 
@@ -135,7 +135,7 @@ def upgrade(ctx, source, dest, in_place):
             f"'{source}': not an existing Kart repository", param_hint="SOURCE"
         )
 
-    source_version = source_repo.version
+    source_version = source_repo.table_dataset_version
     if source_version == DEFAULT_NEW_REPO_VERSION:
         raise InvalidOperation(
             f"Cannot upgrade: source repository is already at latest known version (Datasets V{source_version})"

--- a/tests/test_repo_version.py
+++ b/tests/test_repo_version.py
@@ -18,4 +18,4 @@ def test_get_repo_version(
         3: Path(f"{archive}.tgz"),
     }
     with data_archive_readonly(archive_paths[repo_version]):
-        assert KartRepo(".").version == repo_version
+        assert KartRepo(".").table_dataset_version == repo_version


### PR DESCRIPTION
<img src="https://media1.giphy.com/media/5pYfSvnrE1ZXfCEh23/giphy.gif"/>

The repo version is renamed to make clear it is no longer the
repo version - instead it is the repo-wide, table-dataset version.
Table-datasets are to be unique in that they will have a repo-wide
version marker. Other datasets will be responsible for storing their
own version identifiers.

No changes to functionality.

Part of the foundation for point clouds (and other dataset types).
