### PR TITLE
Add commit<>commit diffs to point-cloud datasets

### DIFF
--- a/kart/dataset_mixins.py
+++ b/kart/dataset_mixins.py
@@ -1,5 +1,9 @@
-from kart.diff_structs import DatasetDiff, DeltaDiff
-from kart.key_filters import DatasetKeyFilter, MetaKeyFilter
+import functools
+
+import pygit2
+
+from kart.diff_structs import DatasetDiff, DeltaDiff, Delta
+from kart.key_filters import DatasetKeyFilter, MetaKeyFilter, UserStringKeyFilter
 
 
 class DatasetDiffMixin:
@@ -46,3 +50,130 @@ class DatasetDiffMixin:
         """
         # Subclasses to override.
         pass
+
+    def get_raw_diff_for_subtree(self, other, subtree_name, reverse=False):
+        """
+        Get a pygit2.Diff of the diff between some subtree of this dataset, and the same subtree of another dataset
+        (generally the "same" dataset at a different revision).
+        """
+
+        flags = pygit2.GIT_DIFF_SKIP_BINARY_CHECK
+        self_subtree = self.get_subtree(subtree_name)
+        other_subtree = other.get_subtree(subtree_name) if other else self._empty_tree
+
+        diff = self_subtree.diff_to_tree(other_subtree, flags=flags, swap=reverse)
+        self.L.debug(
+            "diff %s (%s -> %s / %s): %s changes",
+            subtree_name,
+            self_subtree.id,
+            other_subtree.id if other_subtree else None,
+            "R" if reverse else "F",
+            len(diff),
+        )
+        return diff
+
+    _INSERT_UPDATE_DELETE = (
+        pygit2.GIT_DELTA_ADDED,
+        pygit2.GIT_DELTA_MODIFIED,
+        pygit2.GIT_DELTA_DELETED,
+    )
+    _INSERT_UPDATE = (pygit2.GIT_DELTA_ADDED, pygit2.GIT_DELTA_MODIFIED)
+    _UPDATE_DELETE = (pygit2.GIT_DELTA_MODIFIED, pygit2.GIT_DELTA_DELETED)
+
+    def diff_subtree(
+        self,
+        other,
+        subtree_name,
+        key_filter=UserStringKeyFilter.MATCH_ALL,
+        key_decoder_method=None,
+        value_decoder_method=None,
+        reverse=False,
+    ):
+        """
+        Yields deltas from self -> other, but only for items that match the feature_filter.
+        If reverse is true, yields deltas from other -> self.
+        Uses get_raw_diff_from_subtree to find the initial diff, but interprets this diff
+        according to key_decoder_method and value_decoder_method.
+        """
+        # TODO - if the key-filter is very restrictive (ie it has only a few items in) then
+        # it would be more efficient if we first search for those items and diff only those.
+
+        raw_diff = self.get_raw_diff_for_subtree(other, subtree_name, reverse=reverse)
+        # NOTE - we could potentially call diff.find_similar() to detect renames here,
+        #
+
+        if reverse:
+            old, new = other, self
+        else:
+            old, new = self, other
+
+        def get_decoder(dataset, method_name):
+            return (
+                getattr(dataset, method_name)
+                if dataset is not None
+                else lambda key: key
+            )
+
+        old_key_decoder = get_decoder(old, key_decoder_method)
+        new_key_decoder = get_decoder(new, key_decoder_method)
+        old_value_decoder = get_decoder(old, value_decoder_method)
+        new_value_decoder = get_decoder(new, value_decoder_method)
+
+        subtree_path = subtree_name + "/"
+
+        for d in raw_diff.deltas:
+            self.L.debug(
+                "diff(): %s %s %s", d.status_char(), d.old_file.path, d.new_file.path
+            )
+
+            if d.status not in self._INSERT_UPDATE_DELETE:
+                # RENAMED, COPIED, IGNORED, TYPECHANGE, UNMODIFIED, UNREADABLE, UNTRACKED
+                raise NotImplementedError(f"Delta status: {d.status_char()}")
+
+            if d.status in self._UPDATE_DELETE:
+                old_path = subtree_path + d.old_file.path
+                old_key = old_key_decoder(old_path)
+            else:
+                old_key = None
+
+            if d.status in self._INSERT_UPDATE:
+                new_path = subtree_path + d.new_file.path
+                new_key = new_key_decoder(d.new_file.path)
+            else:
+                new_key = None
+
+            if old_key not in key_filter and new_key not in key_filter:
+                continue
+
+            if d.status == pygit2.GIT_DELTA_ADDED:
+                self.L.debug("diff(): insert %s (%s)", new_path, new_key)
+            elif d.status == pygit2.GIT_DELTA_MODIFIED:
+                self.L.debug(
+                    "diff(): update %s %s -> %s %s",
+                    old_path,
+                    old_key,
+                    new_path,
+                    new_key,
+                )
+            elif d.status == pygit2.GIT_DELTA_DELETED:
+                self.L.debug("diff(): delete %s %s", old_path, old_key)
+
+            if d.status in self._UPDATE_DELETE:
+                old_feature_blob = old.get_blob_at(old_path)
+                old_value_promise = functools.partial(
+                    old_value_decoder, old_feature_blob
+                )
+                old_half_delta = old_key, old_value_promise
+            else:
+                old_half_delta = None
+
+            if d.status in self._INSERT_UPDATE:
+                new_feature_blob = new.get_blob_at(new_path)
+                new_value_promise = functools.partial(
+                    new_value_decoder, new_feature_blob
+                )
+                new_half_delta = new_key, new_value_promise
+            else:
+                new_half_delta = None
+
+            yield Delta(old_half_delta, new_half_delta)

--- a/kart/lfs_util.py
+++ b/kart/lfs_util.py
@@ -1,9 +1,28 @@
+import logging
 import re
 
 import pygit2
 
+L = logging.getLogger(__name__)
 
 POINTER_PATTERN = re.compile(rb"^oid sha256:([0-9a-fA-F]{64})$", re.MULTILINE)
+
+
+def pointer_file_to_json(pointer_file_bytes):
+    if isinstance(pointer_file_bytes, pygit2.Blob):
+        pointer_file_bytes = pointer_file_bytes.data
+    pointer_file_str = pointer_file_bytes.decode("utf8")
+    result = {}
+    for line in pointer_file_str.splitlines():
+        if not line:
+            continue
+        parts = line.split(" ", maxsplit=1)
+        if len(parts) < 2:
+            L.warn(f"Error parsing pointer file:\n{line}")
+            continue
+        key, value = parts
+        result[key] = value
+    return result
 
 
 def get_hash_from_pointer_file(pointer_file_bytes):

--- a/kart/point_cloud/v1.py
+++ b/kart/point_cloud/v1.py
@@ -1,6 +1,13 @@
 from kart.core import find_blobs_in_tree
 from kart.base_dataset import BaseDataset
-from kart.lfs_util import get_hash_from_pointer_file, get_local_path_from_lfs_hash
+from kart.diff_structs import DeltaDiff
+from kart.key_filters import DatasetKeyFilter, FeatureKeyFilter
+from kart.lfs_util import (
+    get_hash_from_pointer_file,
+    get_local_path_from_lfs_hash,
+    pointer_file_to_json,
+)
+from kart.serialise_util import hexhash
 
 
 class PointCloudV1(BaseDataset):
@@ -40,3 +47,52 @@ class PointCloudV1(BaseDataset):
         """Returns a generator that yields every tilename along with the path where the tile content is stored locally."""
         for blob_name, lfs_hash in self.tilenames_with_lfs_hashes():
             yield blob_name, get_local_path_from_lfs_hash(self.repo, lfs_hash)
+
+    def decode_path(self, path):
+        rel_path = self.ensure_rel_path(path)
+        if rel_path.startswith("tiles/"):
+            return ("tiles", self.decode_tile_path(rel_path))
+        return super().decode_path(rel_path)
+
+    def encode_tile_path(self, tilename, relative=False, *, schema=None):
+        """Given a tile's name, returns the path the tile's pointer should be written to."""
+        tile_prefix = hexhash(tilename)[0:2]
+        rel_path = f"tiles/{tile_prefix}/{tilename}"
+        return rel_path if relative else self.ensure_full_path(rel_path)
+
+    @classmethod
+    def decode_tile_path(cls, tile_path):
+        return tile_path.rsplit("/", maxsplit=1)[-1]
+
+    def diff(self, other, ds_filter=DatasetKeyFilter.MATCH_ALL, reverse=False):
+        """
+        Generates a Diff from self -> other.
+        If reverse is true, generates a diff from other -> self.
+        """
+        ds_diff = super().diff(other, ds_filter=ds_filter, reverse=reverse)
+        tiles_filter = ds_filter.get("tiles", ds_filter.child_type())
+        ds_diff["tiles"] = DeltaDiff(
+            self.diff_tiles(other, tiles_filter, reverse=reverse)
+        )
+        return ds_diff
+
+    def diff_tiles(self, other, tiles_filter=FeatureKeyFilter.MATCH_ALL, reverse=False):
+        """
+        Yields tiles deltas from self -> other, but only for tiles that match the tiles_filter.
+        If reverse is true, yields tiles deltas from other -> self.
+        """
+        yield from self.diff_subtree(
+            other,
+            "tiles",
+            key_filter=tiles_filter,
+            key_decoder_method="decode_tile_path",
+            value_decoder_method="get_tile_summary_from_pointer_blob",
+            reverse=reverse,
+        )
+
+    def get_tile_summary_from_pointer_blob(self, tile_pointer_blob):
+        # For now just return the blob contents as a string - it's a reasonable summary.
+        result = pointer_file_to_json(tile_pointer_blob)
+        if "version" in result:
+            del result["version"]
+        return result

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -86,6 +86,18 @@ def test_import_single_las(
                 }
             }
 
+            r = cli_runner.invoke(["show", "HEAD", "autzen:tiles:autzen.copc.laz"])
+            assert r.exit_code == 0, r.stderr
+            assert r.stdout.splitlines()[4:] == [
+                "    Importing 1 LAZ tiles as autzen",
+                "",
+                "+++ autzen:tiles:autzen.copc.laz",
+                "+ {",
+                '+   "oid": "sha256:ce1b2d1757b8139b5ce6b60cc8a82cb5ea02333be29a1e152af858c4bdc27d20",',
+                '+   "size": "3585"',
+                "+ }",
+            ]
+
             r = cli_runner.invoke(["remote", "add", "origin", DUMMY_REPO])
             assert r.exit_code == 0, r.stderr
             repo.config[f"lfs.{DUMMY_REPO}/info/lfs.locksverify"] = False
@@ -101,6 +113,7 @@ def test_import_single_las(
             assert (repo_path / "autzen" / "tiles" / "autzen.copc.laz").is_file()
 
 
+@pytest.mark.slow
 def test_import_several_las(
     tmp_path, chdir, cli_runner, data_archive_readonly, requires_pdal, requires_git_lfs
 ):


### PR DESCRIPTION
<img src="https://media1.giphy.com/media/Ote7fuZrFEV12yjvs5/giphy.gif"/>

Moves the feature_diff code out of the table-based datasets and into
the base-dataset. This code runs a git-diff, then takes all the files
that have changed and optionally uses a method to decode the paths
(eg decode_to_primary_key) and a method to transform the blob contents
(eg get_feature_from_blob). Similar but more basic transforms now
exist for point-cloud tiles that make a summary of the tile just from
the information in the pointer file.

https://github.com/koordinates/kart/issues/565
