### PR TITLE
Make conflicts and diffs consistent

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-added-large-files
       - id: check-json
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/sirosen/check-jsonschema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## 0.11.2 (UNRELEASED)
 
+- Added support for `--output` option `kart conflicts`. [#135](https://github.com/koordinates/kart/issues/135)
 - Bugfix: Better error message on using `kart conflicts -ogeojson` for `meta-item` conflicts. [#515](https://github.com/koordinates/kart/issues/515)
 - Removed the older `upgrade-to-tidy` and `upgrade-to-kart` features which were only relevant to Sno (predecessor of Kart). [[#585](https://github.com/koordinates/kart/issues/585]]
 - Added support for `--decorate` and `--no-decorate` in `kart log`. [[#586](https://github.com/koordinates/kart/issues/586]]

--- a/kart/conflicts_util.py
+++ b/kart/conflicts_util.py
@@ -1,0 +1,127 @@
+import click
+
+# Stand in for a conflict if the conflict is going to be summarised anyway -
+# this helps code re-use between summary and full-diff output modes.
+_CONFLICT_PLACEHOLDER = object()
+
+
+def set_value_at_dict_path(root_dict, path, value):
+    """
+    Ensures the given path exists as a nested dict structure in root dict,
+    and then places the given value there. For example:
+    >>> d = {"x": 1}
+    >>> add_value_at_dict_path(d, ("a", "b", "c"), 100)
+    >>> d
+    {"a": {"b": {"c": 100}}, "x": 1}
+    """
+    cur_dict = root_dict
+    for c in path[:-1]:
+        cur_dict.setdefault(c, {})
+        cur_dict = cur_dict[c]
+
+    leaf = path[-1]
+    cur_dict[leaf] = value
+
+
+def summarise_conflicts(cur_dict, summarise):
+    """
+    Recursively traverses the tree of categorised conflicts,
+    looking for a dict where the values are placeholders.
+    For example:
+    {
+        K1: _CONFLICT_PLACEHOLDER,
+        K2: _CONFLICT_PLACEHOLDER,
+    }
+    When found, it will be replaced with one of the following,
+    depending on the summarise-level specified:
+    summarise=1: [K1, K2]
+    summarise=2: 2 (the size of the dict)
+    """
+    first_value = next(iter(cur_dict.values())) if cur_dict else None
+    if first_value == _CONFLICT_PLACEHOLDER:
+        if summarise == 1:
+            return sorted(cur_dict.keys(), key=_path_sort_key)
+        elif summarise >= 2:
+            return len(cur_dict)
+
+    for k, v in cur_dict.items():
+        cur_dict[k] = summarise_conflicts(v, summarise)
+    return cur_dict
+
+
+def _path_sort_key(path):
+    """Sort conflicts in a sensible way."""
+    if isinstance(path, str) and ":" in path:
+        return tuple(_path_part_sort_key(p) for p in path.split(":"))
+    else:
+        return _path_part_sort_key(path)
+
+
+def _path_part_sort_key(path_part):
+    # Treat stringified numbers as numbers
+    if isinstance(path_part, str) and path_part.isdigit():
+        path_part = int(path_part)
+
+    # Put meta before features:
+    if path_part == "meta":
+        return "A", path_part
+    elif path_part == "feature":
+        return "B", path_part
+
+    # Put complicated conflicts last:
+    if isinstance(path_part, str) and "," in path_part:
+        return "Z", path_part
+
+    if isinstance(path_part, int):
+        return "N", "", path_part
+    else:
+        return "N", path_part
+
+
+def conflicts_json_as_text(value, path="", level=0) -> str:
+    """Converts the JSON output of list_conflicts to a string.
+
+    The conflicts themselves should already be in the appropriate format -
+    this function deals with the hierarchy that contains them.
+    """
+    if isinstance(value, str):
+        return f"{value}\n"
+    elif isinstance(value, int):
+        return f"{value} conflicts\n"
+    elif isinstance(value, dict):
+        separator = "\n" if level == 0 else ""
+        return separator.join(
+            item_to_text(k, v, path, level) for k, v in sorted(value.items())
+        )
+    elif isinstance(value, list):
+        indent = "    " * level
+        return "".join(f"{indent}{path}{item}\n" for item in value)
+
+
+def item_to_text(key: str, value: dict, path: str, level: int) -> str:
+    key_text = f"{path}{key}:"
+    color = get_key_text_color(key_text)
+    styled_key_text = click.style("    " * level + key_text, fg=color)
+    value_text = conflicts_json_as_text(value, key_text, level + 1)
+
+    if isinstance(value, int):
+        return f"{styled_key_text} {value_text}"
+    else:
+        return f"{styled_key_text}\n{value_text}"
+
+
+def get_key_text_color(key_text: str) -> str:
+    """Takes a given path and outputs an appropriate style for it
+
+    The format for the key_text is:
+        - For meta items: <dataset>:meta:schema.json:ancestor/theirs/ours:
+        - For features:   <dataset>:feature:id:ancestor/theirs/ours:
+    """
+    style = {
+        ":ancestor:": "red",
+        ":ours:": "green",
+        ":theirs:": "cyan",
+    }
+    for key, color in style.items():
+        if key_text.endswith(key):
+            return color

--- a/kart/conflicts_writer.py
+++ b/kart/conflicts_writer.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+import logging
+import sys
+import click
+import pygit2
+
+from typing import Union, Type, List
+
+from .crs_util import CoordinateReferenceString
+from .merge_util import MergeContext, MergeIndex, RichConflict
+
+
+from .conflicts_util import (
+    _CONFLICT_PLACEHOLDER,
+    set_value_at_dict_path,
+    summarise_conflicts,
+    conflicts_json_as_text,
+)
+from .merge_util import MergeContext, MergeIndex, ensure_conflicts_ready, rich_conflicts
+from pathlib import Path
+from .output_util import dump_json_output, resolve_output_path
+from pathlib import Path
+from .key_filters import RepoKeyFilter
+from . import diff_util
+
+L = logging.getLogger("kart.conflicts_writer")
+
+
+class BaseConflictsWriter:
+    """
+    A base class for writing conflicts output.
+    """
+
+    def __init__(
+        self,
+        repo: pygit2.Repository,
+        user_key_filters: tuple = (),
+        output_path: str = "-",
+        summarise: int = 0,
+        flat: bool = False,
+        *,
+        json_style: str = "pretty",
+        target_crs: CoordinateReferenceString = None,
+        merge_index: MergeIndex = None,
+        merge_context: MergeContext = None,
+    ):
+        self.repo = repo
+        self.target_crs = target_crs
+        self.flat = flat
+        self.summarise = summarise
+        self.merge_context = merge_context
+        self.merge_index = merge_index
+        self.repo_key_filter = RepoKeyFilter.build_from_user_patterns(user_key_filters)
+        self.json_style = json_style
+        self.output_path = self._check_output_path(
+            repo, self._normalize_output_path(output_path)
+        )
+        self.json_style = json_style
+        self.target_crs = target_crs
+        target_rs = repo.structure("HEAD")
+        self.all_ds_paths = diff_util.get_all_ds_paths(
+            target_rs, target_rs, self.repo_key_filter
+        )
+
+        if merge_index is None:
+            self.merge_index = MergeIndex.read_from_repo(repo)
+        if merge_context is None:
+            self.merge_context = MergeContext.read_from_repo(repo)
+
+    @classmethod
+    def _normalize_output_path(cls, output_path: str) -> Union[str, Path]:
+        if not output_path or output_path == "-":
+            return output_path
+        if isinstance(output_path, str):
+            output_path = Path(output_path)
+        if isinstance(output_path, Path):
+            output_path = output_path.expanduser()
+        return output_path
+
+    @classmethod
+    def get_conflicts_writer_class(
+        cls, output_format: str
+    ) -> Union[Type[BaseConflictsWriter], None]:
+        """Returns suitable subclass for desired output format"""
+        output_format_to_writer = {
+            "quiet": QuietConflictsWriter,
+            "json": JsonConflictsWriter,
+            "text": TextConflictsWriter,
+            "geojson": GeojsonConflictsWriter,
+        }
+
+        cls.output_format = output_format
+        if not output_format_to_writer.get(output_format):
+            raise click.BadParameter(
+                f"Unrecognized output format: {output_format}",
+                param_hint="output_format",
+            )
+
+        return output_format_to_writer.get(output_format)
+
+    def get_conflicts(self) -> List[RichConflict]:
+        """Returns a list of rich conflicts"""
+        conflicts = rich_conflicts(
+            self.merge_index.unresolved_conflicts.values(),
+            self.merge_context,
+        )
+        return conflicts
+
+    @classmethod
+    def _check_output_path(
+        cls,
+        repo: pygit2.Repository,
+        output_path: Union[str, Path],
+        output_format: str = None,
+    ) -> Union[str, Path]:
+        """Make sure the given output_path is valid for this implementation (ie, are directories supported)."""
+        if output_format and isinstance(output_path, Path) and output_path.is_dir():
+            raise click.BadParameter(
+                f"Directory is not valid for --output with -o {output_format}",
+                param_hint="--output",
+            )
+        return output_path
+
+    def exit_with_code(self):
+        if hasattr(self.merge_context, "conflicts") and self.merge_context.conflicts:
+            sys.exit(1)
+        else:
+            sys.exit(0)
+
+    def list_conflicts(self) -> dict:
+        """Lists all the conflicts in merge_index, categorised into nested dicts.
+
+        Example:
+
+        ::
+
+            {
+                "dataset_A": {
+                    "feature":
+                        "5": {"ancestor": "...", "ours": ..., "theirs": ...},
+                        "11": {"ancestor": "...", "ours": ..., "theirs": ...},
+                    },
+                    "meta": {
+                        "gpkg_spatial_ref_sys": {"ancestor": ..., "ours": ..., "theirs": ...}}
+                    }
+                },
+                "dataset_B": {...}
+            }
+        """
+        output_dict = {}
+        conflict_output = _CONFLICT_PLACEHOLDER
+
+        conflicts = self.get_conflicts()
+        if not self.repo_key_filter.match_all:
+            conflicts = (c for c in conflicts if c.matches_filter(self.repo_key_filter))
+
+        if not self.summarise:
+            conflicts = ensure_conflicts_ready(conflicts, self.merge_context.repo)
+
+        for conflict in conflicts:
+            if not self.summarise:
+                conflict_output = conflict.output(
+                    self.output_format,
+                    include_label=self.flat,
+                    target_crs=self.target_crs,
+                )
+
+            if self.flat:
+                if isinstance(conflict_output, dict):
+                    output_dict.update(conflict_output)
+                else:
+                    output_dict[conflict.label] = conflict_output
+            else:
+                set_value_at_dict_path(
+                    output_dict, conflict.decoded_path, conflict_output
+                )
+
+        if self.summarise:
+            output_dict = summarise_conflicts(output_dict, self.summarise)
+        return output_dict
+
+
+class QuietConflictsWriter(BaseConflictsWriter):
+    def write_conflicts(self):
+        pass
+
+
+class JsonConflictsWriter(BaseConflictsWriter):
+    """Writes JSON conficts.
+
+    Of all the conflict-writers, JSON conflicts are the most descriptive - nothing is left out.
+    The basic conflicts structure is as follows - for meta items:
+        {"kart.conflicts/v1": {"dataset-path": { "meta": { "schema.json": { "ancestor/ours/theirs": [...]}}}}}
+    And for features:
+        {"kart.conflicts/v1": {"dataset-path": { "feature": { "id": { "ancestor/ours/theirs": [...]}}}}}
+    """
+
+    @classmethod
+    def _check_output_path(
+        cls,
+        repo: pygit2.Repository,
+        output_path: Union[str, Path],
+        output_format: str = "json",
+    ) -> Union[str, Path]:
+        """Make sure the given output_path is valid for this implementation (ie, are directories supported)."""
+        return super()._check_output_path(repo, output_path, output_format)
+
+    def write_conflicts(self):
+        output_obj = super().list_conflicts()
+        dump_json_output(
+            {"kart.conflicts/v1": output_obj},
+            self.output_path,
+            json_style=self.json_style,
+        )
+
+
+class TextConflictsWriter(BaseConflictsWriter):
+    """Writes human-readable conflicts.
+
+    Non-empty geometries are not specified in full - instead they look like this:
+    POINT(...) or POLYGON(...) - so conflicts of this kind are lossy where geometry is involved, and shouldn't be parsed.
+    Instead, use a JSON conflict if you need to parse it, as `kart create-patch` does.
+    Any changes to schema.json will be highlighted in a human-readable way, other meta-items conflicts will simply show
+    the changes on the ancestor, theirs and ours branch.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fp = resolve_output_path(self.output_path)
+        self.pecho = {"file": self.fp, "color": self.fp.isatty()}
+
+    @classmethod
+    def _check_output_path(
+        cls,
+        repo: pygit2.Repository,
+        output_path: Union[str, Path],
+        output_format: str = "text",
+    ) -> Union[str, Path]:
+        """Make sure the given output_path is valid for this implementation (ie, are directories supported)."""
+        return super()._check_output_path(repo, output_path, output_format)
+
+    def write_conflicts(self):
+        output_dict = super().list_conflicts()
+        click.secho(conflicts_json_as_text(output_dict), **self.pecho)
+
+
+class GeojsonConflictsWriter(BaseConflictsWriter):
+    """Writes all feature conflicts as a single GeoJSON FeatureCollection of GeoJSON features.
+
+    The id of each feature in the collection indicates which branch it belongs to.
+
+    Example:
+
+        dataset:feature:123:ancestor - the common ancestor version of feature 123
+        dataset:feature:123:ours - our version of the conflicting change made to feature 123
+        dataset:feature:123:theirs - their version of the conflicting change made to feature 123
+
+    Note:
+
+        Meta conflicts aren't output at all.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.flat = True
+        self.summarise = 0
+
+    @classmethod
+    def _check_output_path(cls, repo: pygit2.Repository, output_path: Path):
+        """Make sure the given output_path is valid for this implementation (ie, are directories supported)."""
+        if isinstance(output_path, Path):
+            if output_path.is_file():
+                raise click.BadParameter(
+                    "Output path should be a directory for GeoJSON format.",
+                    param_hint="--output",
+                )
+            if not output_path.exists():
+                output_path.mkdir()
+            else:
+                geojson_paths = list(output_path.glob("*.geojson"))
+                if geojson_paths:
+                    L.debug(
+                        "Cleaning %d *.geojson files from %s ...",
+                        len(geojson_paths),
+                        output_path,
+                    )
+                for p in geojson_paths:
+                    p.unlink()
+        else:
+            output_path = "-"
+        return output_path
+
+    def write_conflicts(self) -> None:
+        if len(self.all_ds_paths) > 1 and not isinstance(self.output_path, Path):
+            raise click.BadParameter(
+                "Need to specify a directory via --output for GeoJSON with more than one dataset",
+                param_hint="--output",
+            )
+        conflicts = self.get_conflicts()
+
+        if not self.repo_key_filter.match_all:
+            conflicts = (c for c in conflicts if c.matches_filter(self.repo_key_filter))
+
+        conflicts = ensure_conflicts_ready(conflicts, self.merge_context.repo)
+
+        geojson_conflicts = self.get_geojson_conflicts(conflicts)
+        self.output_geojson_conflicts(geojson_conflicts)
+
+    def get_geojson_conflicts(self, conflicts: List[RichConflict]) -> dict:
+        """Returns geojson conflicts as a dict"""
+        output_dict = {}
+        for conflict in conflicts:
+            conflict_output = conflict.output(
+                "geojson", include_label=self.flat, target_crs=self.target_crs
+            )
+
+            if isinstance(conflict_output, dict):
+                output_dict.update(conflict_output)
+            else:
+                output_dict[conflict.label] = conflict_output
+        return output_dict
+
+    def output_geojson_conflicts(self, json_obj: dict) -> None:
+        """Writes the geojson conflicts to the specified output stream"""
+        self._warn_about_any_meta_conflicts(json_obj)
+        conflicts = self.separate_geojson_conflicts_by_ds(json_obj)
+
+        for ds_path, features in conflicts.items():
+            if self.output_path == "-":
+                ds_output_path = "-"
+            else:
+                ds_output_filename = str(ds_path).replace("/", "__") + ".geojson"
+                ds_output_path = self.output_path / ds_output_filename
+
+            output_obj = {"type": "FeatureCollection", "features": features}
+            dump_json_output(
+                output_obj,
+                ds_output_path,
+                json_style=self.json_style,
+            )
+
+    def separate_geojson_conflicts_by_ds(self, json_obj: dict) -> dict:
+        """Separates geojson conflicts by datasets"""
+        conflicts = dict()
+        for key, feature in json_obj.items():
+            if "meta" == key.split(":")[1]:
+                continue
+            ds_path = key.split(":")[0]
+            features = conflicts.get(ds_path, [])
+            feature["id"] = key
+            features.append(feature)
+            conflicts[ds_path] = features
+        return conflicts
+
+    def _warn_about_any_meta_conflicts(self, json_obj: dict) -> None:
+        ds_path = set()
+        for key, feature in json_obj.items():
+            if "meta" == key.split(":")[1]:
+                ds_path.add(key.split(":")[0])
+
+        for path in ds_path:
+            click.echo(
+                f"Warning: {path} meta changes aren't included in GeoJSON output.",
+                err=True,
+            )

--- a/kart/diff_util.py
+++ b/kart/diff_util.py
@@ -2,16 +2,25 @@ import logging
 
 from .diff_structs import DatasetDiff, RepoDiff
 from .key_filters import DatasetKeyFilter, RepoKeyFilter
+from .structure import RepoStructure
 
 L = logging.getLogger("kart.diff_util")
 
 
-def get_all_ds_paths(base_rs, target_rs, repo_key_filter=RepoKeyFilter.MATCH_ALL):
-    """
-    Returns a list of all dataset paths in either RepoStructure (that match repo_key_filter).
+def get_all_ds_paths(
+    base_rs: RepoStructure,
+    target_rs: RepoStructure,
+    repo_key_filter=RepoKeyFilter.MATCH_ALL,
+):
+    """Returns a list of all dataset paths in either RepoStructure (that match repo_key_filter).
 
-    base_rs, target_rs - kart.structure.RepoStructure objects
-    repo_key_filter - controls which datasets match and are included in the result.
+    Args:
+        base_rs (kart.structure.RepoStructure)
+        target_rs (kart.structure.RepoStructure)
+        repo_key_filter (kart.key_filters.RepoKeyFilter): Controls which datasets match and are included in the result.
+
+    Returns:
+        Sorted list of all dataset paths in either RepoStructure (that match repo_key_filter).
     """
     base_ds_paths = {ds.path for ds in base_rs.datasets()}
     target_ds_paths = {ds.path for ds in target_rs.datasets()}

--- a/kart/merge_util.py
+++ b/kart/merge_util.py
@@ -731,7 +731,7 @@ def merge_status_to_text(jdict, fresh):
             False if the user is just checking the current state.
     """
     # this is here to avoid an import loop
-    from kart.conflicts import conflicts_json_as_text
+    from .conflicts_util import conflicts_json_as_text
 
     merging_text = merge_context_to_text(jdict["merging"])
 

--- a/kart/tabular/feature_output.py
+++ b/kart/tabular/feature_output.py
@@ -55,11 +55,19 @@ def feature_as_json(row, pk_value, geometry_transform=None):
         yield k, v
 
 
-def feature_as_geojson(row, pk_value, change=None, geometry_transform=None):
+def feature_as_geojson(
+    row,
+    pk_value,
+    ds_path=None,
+    change_type=None,
+    geometry_transform=None,
+):
     """
     Turns a row into a dict representing a GeoJSON feature.
     """
-    change_id = f"{change}::{pk_value}" if change else str(pk_value)
+    change_id = str(pk_value)
+    if ds_path:
+        change_id = f"{ds_path}:feature:{pk_value}:{change_type}"
     f = {
         "type": "Feature",
         "geometry": None,

--- a/tests/test_conflicts.py
+++ b/tests/test_conflicts.py
@@ -6,6 +6,7 @@ from kart.repo import KartRepo
 from kart.structs import CommitWithReference
 
 H = pytest.helpers.helpers()
+CONFLICTS_OUTPUT_FORMATS = ["text", "geojson", "json", "quiet"]
 
 
 def test_merge_index_roundtrip(data_archive, cli_runner):
@@ -71,7 +72,14 @@ def test_summarise_conflicts(data_archive, cli_runner):
             "",
         ]
 
-        r = cli_runner.invoke(["conflicts", "-s", "-o", "json"])
+        r = cli_runner.invoke(
+            [
+                "conflicts",
+                "-s",
+                "-o",
+                "json",
+            ]
+        )
         assert r.exit_code == 0, r
         assert json.loads(r.stdout) == {
             "kart.conflicts/v1": {
@@ -79,7 +87,12 @@ def test_summarise_conflicts(data_archive, cli_runner):
             }
         }
 
-        r = cli_runner.invoke(["conflicts", "-ss"])
+        r = cli_runner.invoke(
+            [
+                "conflicts",
+                "-ss",
+            ]
+        )
         assert r.exit_code == 0, r
         assert r.stdout.splitlines() == [
             "nz_waca_adjustments:",
@@ -87,7 +100,14 @@ def test_summarise_conflicts(data_archive, cli_runner):
             "",
         ]
 
-        r = cli_runner.invoke(["conflicts", "-ss", "-o", "json"])
+        r = cli_runner.invoke(
+            [
+                "conflicts",
+                "-ss",
+                "-o",
+                "json",
+            ]
+        )
         assert r.exit_code == 0, r
         assert json.loads(r.stdout) == {
             "kart.conflicts/v1": {"nz_waca_adjustments": {"feature": 4}},
@@ -97,7 +117,6 @@ def test_summarise_conflicts(data_archive, cli_runner):
 def test_list_conflicts(data_archive, cli_runner):
     with data_archive("conflicts/points.tgz") as _:
         r = cli_runner.invoke(["merge", "theirs_branch"])
-
         expected_text = [
             "nz_pa_points_topo_150k:",
             "    nz_pa_points_topo_150k:feature:",
@@ -167,7 +186,12 @@ def test_list_conflicts(data_archive, cli_runner):
             }
         }
         r = cli_runner.invoke(
-            ["conflicts", "-o", "json", "nz_pa_points_topo_150k:feature:4"]
+            [
+                "conflicts",
+                "-o",
+                "json",
+                "nz_pa_points_topo_150k:feature:4",
+            ]
         )
         assert r.exit_code == 0, r
         assert json.loads(r.stdout) == expected_json
@@ -182,57 +206,62 @@ def test_list_conflicts(data_archive, cli_runner):
         )
 
         expected_geojson = {
+            "type": "FeatureCollection",
             "features": [
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "coordinates": [177.2757807736718, -38.08491506728025],
                         "type": "Point",
+                        "coordinates": [177.2757807736718, -38.08491506728025],
                     },
-                    "id": "nz_pa_points_topo_150k:feature:5:ancestor",
                     "properties": {
                         "fid": 5,
+                        "t50_fid": 2426275,
+                        "name_ascii": None,
                         "macronated": "N",
                         "name": None,
-                        "name_ascii": None,
-                        "t50_fid": 2426275,
                     },
-                    "type": "Feature",
+                    "id": "nz_pa_points_topo_150k:feature:5:ancestor",
                 },
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "coordinates": [177.2757807736718, -38.08491506728025],
                         "type": "Point",
+                        "coordinates": [177.2757807736718, -38.08491506728025],
                     },
-                    "id": "nz_pa_points_topo_150k:feature:5:ours",
                     "properties": {
                         "fid": 5,
+                        "t50_fid": 2426275,
+                        "name_ascii": None,
                         "macronated": "N",
                         "name": "ours_version",
-                        "name_ascii": None,
-                        "t50_fid": 2426275,
                     },
-                    "type": "Feature",
+                    "id": "nz_pa_points_topo_150k:feature:5:ours",
                 },
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "coordinates": [177.2757807736718, -38.08491506728025],
                         "type": "Point",
+                        "coordinates": [177.2757807736718, -38.08491506728025],
                     },
-                    "id": "nz_pa_points_topo_150k:feature:5:theirs",
                     "properties": {
                         "fid": 5,
+                        "t50_fid": 2426275,
+                        "name_ascii": None,
                         "macronated": "N",
                         "name": "theirs_version",
-                        "name_ascii": None,
-                        "t50_fid": 2426275,
                     },
-                    "type": "Feature",
+                    "id": "nz_pa_points_topo_150k:feature:5:theirs",
                 },
             ],
-            "type": "FeatureCollection",
         }
         r = cli_runner.invoke(
-            ["conflicts", "-o", "geojson", "nz_pa_points_topo_150k:feature:5"]
+            [
+                "conflicts",
+                "-o",
+                "geojson",
+                "nz_pa_points_topo_150k:feature:5",
+            ]
         )
         assert r.exit_code == 0, r
         assert json.loads(r.stdout) == expected_geojson
@@ -250,7 +279,12 @@ def test_list_conflicts_transform_crs(data_archive, cli_runner):
         r = cli_runner.invoke(["merge", "theirs_branch"])
 
         r = cli_runner.invoke(
-            ["conflicts", "-o", "json", "nz_pa_points_topo_150k:feature:4"]
+            [
+                "conflicts",
+                "-o",
+                "json",
+                "nz_pa_points_topo_150k:feature:4",
+            ]
         )
         assert r.exit_code == 0, r
         json_layer = json.loads(r.stdout)["kart.conflicts/v1"][H.POINTS.LAYER]
@@ -338,7 +372,7 @@ def test_find_renames(data_working_copy, cli_runner):
         assert not index.conflicts
 
 
-def test_json_conflicts_as_geojson(data_working_copy, cli_runner):
+def test_meta_item_conflicts_as_geojson(data_working_copy, cli_runner):
     with data_working_copy("points") as (repo_path, wc):
         repo = KartRepo(repo_path)
 
@@ -358,3 +392,122 @@ def test_json_conflicts_as_geojson(data_working_copy, cli_runner):
         r = cli_runner.invoke(["merge", "theirs_branch"])
         r = cli_runner.invoke(["conflicts", "-o", "geojson"])
         assert r.exit_code == 0, r
+
+
+@pytest.mark.parametrize(
+    "output_format", [o for o in CONFLICTS_OUTPUT_FORMATS if o not in {"quiet"}]
+)
+def test_conflicts_output_to_file(output_format, data_archive, cli_runner):
+    with data_archive("conflicts/polygons.tgz") as repo_path:
+        r = cli_runner.invoke(["merge", "theirs_branch"])
+        assert r.exit_code == 0, r
+
+        r = cli_runner.invoke(
+            ["conflicts", f"--output-format={output_format}", "--output=out"]
+        )
+        assert r.exit_code == 0, r
+        assert (repo_path / "out").exists()
+
+
+def test_conflicts_geojson_usage(data_archive, cli_runner, tmp_path):
+    with data_archive("conflicts/polygons.tgz") as repo_path:
+        r = cli_runner.invoke(["merge", "theirs_branch"])
+        assert r.exit_code == 0, r
+
+        # output to stdout
+        r = cli_runner.invoke(
+            [
+                "conflicts",
+                "--output-format=geojson",
+            ]
+        )
+        assert r.exit_code == 0, r.stderr
+        # output to stdout (by default)
+        r = cli_runner.invoke(["conflicts", "--output-format=geojson"])
+        assert r.exit_code == 0, r.stderr
+
+        # output to a directory that doesn't yet exist
+        r = cli_runner.invoke(
+            [
+                "conflicts",
+                "--output-format=geojson",
+                f"--output={tmp_path / 'abc'}",
+            ]
+        )
+        assert r.exit_code == 0, r.stderr
+        assert {p.name for p in (tmp_path / "abc").iterdir()} == {
+            "nz_waca_adjustments.geojson"
+        }
+
+        # output to a directory that does exist
+        d = tmp_path / "def"
+        d.mkdir()
+        # this gets left alone
+        (d / "empty.file").write_bytes(b"")
+        # this gets deleted.
+        (d / "some.geojson").write_bytes(b"{}")
+        r = cli_runner.invoke(
+            [
+                "conflicts",
+                "--output-format=geojson",
+                f"--output={d}",
+            ]
+        )
+        assert r.exit_code == 0, r.stderr
+        assert {p.name for p in d.iterdir()} == {
+            "nz_waca_adjustments.geojson",
+            "empty.file",
+        }
+
+        # can't import in merge state, so abort
+        r = cli_runner.invoke(["merge", "--abort"])
+        assert r.exit_code == 0, r.stdout
+
+        # adding datasets
+        with data_archive("gpkg-3d-points") as src:
+            src_gpkg_path = src / "points-3d.gpkg"
+            r = cli_runner.invoke(["-C", repo_path, "import", src_gpkg_path])
+            assert r.exit_code == 0, r.stderr
+
+        with data_archive("gpkg-points") as data:
+            with data_archive("polygons"):
+                src_gpkg_path = data / "nz-pa-points-topo-150k.gpkg"
+                r = cli_runner.invoke(["-C", repo_path, "import", src_gpkg_path])
+                assert r.exit_code == 0, r.stderr
+
+        # commit changes and merge again
+        r = cli_runner.invoke(["commit", "-m", "test-commit"])
+        assert r.exit_code == 0, r
+
+        r = cli_runner.invoke(["merge", "theirs_branch"])
+        assert r.exit_code == 0, r
+
+        # file/stdout output isn't allowed when there are multiple datasets
+        r = cli_runner.invoke(
+            [
+                "conflicts",
+                "--output-format=geojson",
+            ]
+        )
+        assert r.exit_code == 2, r.stderr
+        assert (
+            r.stderr.splitlines()[-1]
+            == "Error: Invalid value for --output: Need to specify a directory via --output for GeoJSON with more than one dataset"
+        )
+
+        # Can't specify an (existing) regular file either
+        myfile = tmp_path / "ghi"
+        myfile.write_bytes(b"")
+        assert myfile.exists()
+        r = cli_runner.invoke(
+            [
+                "conflicts",
+                "--output-format=geojson",
+                f"--output={myfile}",
+            ]
+        )
+        assert r.exit_code == 2, r.stderr
+        assert (
+            r.stderr.splitlines()[-1]
+            == "Error: Invalid value for --output: Output path should be a directory for GeoJSON format."
+        )

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -33,7 +33,7 @@ def _check_html_output(s):
 
 @pytest.mark.parametrize("output_format", DIFF_OUTPUT_FORMATS)
 def test_diff_points(output_format, data_working_copy, cli_runner):
-    """ diff the working copy against HEAD """
+    """diff the working copy against HEAD"""
     with data_working_copy("points") as (repo_path, wc):
         # empty
         r = cli_runner.invoke(
@@ -94,96 +94,96 @@ def test_diff_points(output_format, data_working_copy, cli_runner):
             odata = json.loads(r.stdout)
             assert len(odata["features"]) == 6
             assert odata == {
+                "type": "FeatureCollection",
                 "features": [
                     {
+                        "type": "Feature",
                         "geometry": {
-                            "coordinates": [177.0959629713586, -38.00433803621768],
                             "type": "Point",
+                            "coordinates": [177.0959629713586, -38.00433803621768],
                         },
-                        "id": "U-::1",
                         "properties": {
                             "fid": 1,
+                            "t50_fid": 2426271,
+                            "name_ascii": None,
                             "macronated": "N",
                             "name": None,
-                            "name_ascii": None,
-                            "t50_fid": 2426271,
                         },
-                        "type": "Feature",
+                        "id": "nz_pa_points_topo_150k:feature:1:U-",
                     },
                     {
+                        "type": "Feature",
                         "geometry": {
-                            "coordinates": [177.0959629713586, -38.00433803621768],
                             "type": "Point",
+                            "coordinates": [177.0959629713586, -38.00433803621768],
                         },
-                        "id": "U+::9998",
                         "properties": {
                             "fid": 9998,
-                            "macronated": "N",
-                            "name": None,
-                            "name_ascii": None,
                             "t50_fid": 2426271,
-                        },
-                        "type": "Feature",
-                    },
-                    {
-                        "geometry": {
-                            "coordinates": [177.0786628443959, -37.9881848576018],
-                            "type": "Point",
-                        },
-                        "id": "U-::2",
-                        "properties": {
-                            "fid": 2,
+                            "name_ascii": None,
                             "macronated": "N",
                             "name": None,
-                            "name_ascii": None,
-                            "t50_fid": 2426272,
                         },
-                        "type": "Feature",
+                        "id": "nz_pa_points_topo_150k:feature:9998:U+",
                     },
                     {
+                        "type": "Feature",
                         "geometry": {
-                            "coordinates": [177.0786628443959, -37.9881848576018],
                             "type": "Point",
+                            "coordinates": [177.0786628443959, -37.9881848576018],
                         },
-                        "id": "U+::2",
                         "properties": {
                             "fid": 2,
+                            "t50_fid": 2426272,
+                            "name_ascii": None,
+                            "macronated": "N",
+                            "name": None,
+                        },
+                        "id": "nz_pa_points_topo_150k:feature:2:U-",
+                    },
+                    {
+                        "type": "Feature",
+                        "geometry": {
+                            "type": "Point",
+                            "coordinates": [177.0786628443959, -37.9881848576018],
+                        },
+                        "properties": {
+                            "fid": 2,
+                            "t50_fid": None,
+                            "name_ascii": None,
                             "macronated": "N",
                             "name": "test",
-                            "name_ascii": None,
-                            "t50_fid": None,
                         },
-                        "type": "Feature",
+                        "id": "nz_pa_points_topo_150k:feature:2:U+",
                     },
                     {
+                        "type": "Feature",
                         "geometry": {
-                            "coordinates": [177.07125219628702, -37.97947548462757],
                             "type": "Point",
+                            "coordinates": [177.07125219628702, -37.97947548462757],
                         },
-                        "id": "D::3",
                         "properties": {
                             "fid": 3,
+                            "t50_fid": 2426273,
+                            "name_ascii": "Tauwhare Pa",
                             "macronated": "N",
                             "name": "Tauwhare Pa",
-                            "name_ascii": "Tauwhare Pa",
-                            "t50_fid": 2426273,
                         },
-                        "type": "Feature",
+                        "id": "nz_pa_points_topo_150k:feature:3:D",
                     },
                     {
-                        "geometry": {"coordinates": [0.0, 0.0], "type": "Point"},
-                        "id": "I::9999",
+                        "type": "Feature",
+                        "geometry": {"type": "Point", "coordinates": [0.0, 0.0]},
                         "properties": {
                             "fid": 9999,
+                            "t50_fid": 9999999,
+                            "name_ascii": "Te Motu-a-kore",
                             "macronated": "N",
                             "name": "Te Motu-a-kore",
-                            "name_ascii": "Te Motu-a-kore",
-                            "t50_fid": 9999999,
                         },
-                        "type": "Feature",
+                        "id": "nz_pa_points_topo_150k:feature:9999:I",
                     },
                 ],
-                "type": "FeatureCollection",
             }
 
         elif output_format == "json":
@@ -312,7 +312,7 @@ def test_diff_json_lines_with_feature_count_estimate(
 
 @pytest.mark.parametrize("output_format", DIFF_OUTPUT_FORMATS)
 def test_diff_reprojection(output_format, data_working_copy, cli_runner):
-    """ diff the working copy against HEAD """
+    """diff the working copy against HEAD"""
     with data_working_copy("points") as (repo_path, wc):
         # make some changes
         repo = KartRepo(repo_path)
@@ -387,7 +387,7 @@ def test_show_crs_with_aspatial_dataset(data_archive, cli_runner):
 
 @pytest.mark.parametrize("output_format", DIFF_OUTPUT_FORMATS)
 def test_diff_polygons(output_format, data_working_copy, cli_runner):
-    """ diff the working copy against HEAD """
+    """diff the working copy against HEAD"""
     with data_working_copy("polygons") as (repo, wc):
         # empty
         r = cli_runner.invoke(
@@ -447,9 +447,12 @@ def test_diff_polygons(output_format, data_working_copy, cli_runner):
             odata = json.loads(r.stdout)
             assert len(odata["features"]) == 6
             assert odata == {
+                "type": "FeatureCollection",
                 "features": [
                     {
+                        "type": "Feature",
                         "geometry": {
+                            "type": "MultiPolygon",
                             "coordinates": [
                                 [
                                     [
@@ -474,19 +477,19 @@ def test_diff_polygons(output_format, data_working_copy, cli_runner):
                                     ]
                                 ]
                             ],
-                            "type": "MultiPolygon",
                         },
-                        "id": "U-::1424927",
                         "properties": {
-                            "adjusted_nodes": 1122,
-                            "date_adjusted": "2011-03-25T07:30:45",
                             "id": 1424927,
+                            "date_adjusted": "2011-03-25T07:30:45",
                             "survey_reference": None,
+                            "adjusted_nodes": 1122,
                         },
-                        "type": "Feature",
+                        "id": "nz_waca_adjustments:feature:1424927:U-",
                     },
                     {
+                        "type": "Feature",
                         "geometry": {
+                            "type": "MultiPolygon",
                             "coordinates": [
                                 [
                                     [
@@ -511,19 +514,19 @@ def test_diff_polygons(output_format, data_working_copy, cli_runner):
                                     ]
                                 ]
                             ],
-                            "type": "MultiPolygon",
                         },
-                        "id": "U+::9998",
                         "properties": {
-                            "adjusted_nodes": 1122,
-                            "date_adjusted": "2011-03-25T07:30:45",
                             "id": 9998,
+                            "date_adjusted": "2011-03-25T07:30:45",
                             "survey_reference": None,
+                            "adjusted_nodes": 1122,
                         },
-                        "type": "Feature",
+                        "id": "nz_waca_adjustments:feature:9998:U+",
                     },
                     {
+                        "type": "Feature",
                         "geometry": {
+                            "type": "MultiPolygon",
                             "coordinates": [
                                 [
                                     [
@@ -541,19 +544,19 @@ def test_diff_polygons(output_format, data_working_copy, cli_runner):
                                     ]
                                 ]
                             ],
-                            "type": "MultiPolygon",
                         },
-                        "id": "U-::1443053",
                         "properties": {
-                            "adjusted_nodes": 1238,
+                            "id": 1443053,
                             "date_adjusted": "2011-05-10T12:09:10",
-                            "id": 1443053,
                             "survey_reference": None,
+                            "adjusted_nodes": 1238,
                         },
-                        "type": "Feature",
+                        "id": "nz_waca_adjustments:feature:1443053:U-",
                     },
                     {
+                        "type": "Feature",
                         "geometry": {
+                            "type": "MultiPolygon",
                             "coordinates": [
                                 [
                                     [
@@ -571,19 +574,19 @@ def test_diff_polygons(output_format, data_working_copy, cli_runner):
                                     ]
                                 ]
                             ],
-                            "type": "MultiPolygon",
                         },
-                        "id": "U+::1443053",
                         "properties": {
-                            "adjusted_nodes": 1238,
-                            "date_adjusted": "2019-01-01T00:00:00",
                             "id": 1443053,
+                            "date_adjusted": "2019-01-01T00:00:00",
                             "survey_reference": "test",
+                            "adjusted_nodes": 1238,
                         },
-                        "type": "Feature",
+                        "id": "nz_waca_adjustments:feature:1443053:U+",
                     },
                     {
+                        "type": "Feature",
                         "geometry": {
+                            "type": "MultiPolygon",
                             "coordinates": [
                                 [
                                     [
@@ -614,19 +617,19 @@ def test_diff_polygons(output_format, data_working_copy, cli_runner):
                                     ]
                                 ]
                             ],
-                            "type": "MultiPolygon",
                         },
-                        "id": "D::1452332",
                         "properties": {
-                            "adjusted_nodes": 558,
-                            "date_adjusted": "2011-06-07T15:22:58",
                             "id": 1452332,
+                            "date_adjusted": "2011-06-07T15:22:58",
                             "survey_reference": None,
+                            "adjusted_nodes": 558,
                         },
-                        "type": "Feature",
+                        "id": "nz_waca_adjustments:feature:1452332:D",
                     },
                     {
+                        "type": "Feature",
                         "geometry": {
+                            "type": "MultiPolygon",
                             "coordinates": [
                                 [
                                     [
@@ -638,19 +641,16 @@ def test_diff_polygons(output_format, data_working_copy, cli_runner):
                                     ]
                                 ]
                             ],
-                            "type": "MultiPolygon",
                         },
-                        "id": "I::9999999",
                         "properties": {
-                            "adjusted_nodes": 123,
-                            "date_adjusted": "2019-07-05T13:04:00",
                             "id": 9999999,
+                            "date_adjusted": "2019-07-05T13:04:00",
                             "survey_reference": "Null Island™ 🗺",
+                            "adjusted_nodes": 123,
                         },
-                        "type": "Feature",
+                        "id": "nz_waca_adjustments:feature:9999999:I",
                     },
                 ],
-                "type": "FeatureCollection",
             }
 
         elif output_format == "json":
@@ -735,7 +735,7 @@ def test_diff_polygons(output_format, data_working_copy, cli_runner):
 
 @pytest.mark.parametrize("output_format", DIFF_OUTPUT_FORMATS)
 def test_diff_table(output_format, data_working_copy, cli_runner):
-    """ diff the working copy against HEAD """
+    """diff the working copy against HEAD"""
     with data_working_copy("table") as (repo_path, wc):
         # empty
         r = cli_runner.invoke(
@@ -811,123 +811,123 @@ def test_diff_table(output_format, data_working_copy, cli_runner):
             odata = json.loads(r.stdout)
             assert len(odata["features"]) == 6
             assert odata == {
+                "type": "FeatureCollection",
                 "features": [
                     {
+                        "type": "Feature",
                         "geometry": None,
-                        "id": "U-::1",
                         "properties": {
-                            "AREA": 1784.0634,
-                            "CNTY_FIPS": "077",
-                            "FIPS": "27077",
-                            "NAME": "Lake of the Woods",
                             "OBJECTID": 1,
-                            "POP1990": 4076.0,
-                            "POP2000": 4651.0,
-                            "POP90_SQMI": 2,
-                            "STATE_FIPS": "27",
+                            "NAME": "Lake of the Woods",
                             "STATE_NAME": "Minnesota",
-                            "Shape_Area": 0.5654499337414509,
-                            "Shape_Leng": 4.055459982439919,
-                        },
-                        "type": "Feature",
-                    },
-                    {
-                        "geometry": None,
-                        "id": "U+::9998",
-                        "properties": {
-                            "AREA": 1784.0634,
+                            "STATE_FIPS": "27",
                             "CNTY_FIPS": "077",
                             "FIPS": "27077",
-                            "NAME": "Lake of the Woods",
-                            "OBJECTID": 9998,
+                            "AREA": 1784.0634,
                             "POP1990": 4076.0,
                             "POP2000": 4651.0,
                             "POP90_SQMI": 2,
-                            "STATE_FIPS": "27",
-                            "STATE_NAME": "Minnesota",
-                            "Shape_Area": 0.5654499337414509,
                             "Shape_Leng": 4.055459982439919,
+                            "Shape_Area": 0.5654499337414509,
                         },
-                        "type": "Feature",
+                        "id": "countiestbl:feature:1:U-",
                     },
                     {
+                        "type": "Feature",
                         "geometry": None,
-                        "id": "U-::2",
                         "properties": {
-                            "AREA": 2280.2319,
+                            "OBJECTID": 9998,
+                            "NAME": "Lake of the Woods",
+                            "STATE_NAME": "Minnesota",
+                            "STATE_FIPS": "27",
+                            "CNTY_FIPS": "077",
+                            "FIPS": "27077",
+                            "AREA": 1784.0634,
+                            "POP1990": 4076.0,
+                            "POP2000": 4651.0,
+                            "POP90_SQMI": 2,
+                            "Shape_Leng": 4.055459982439919,
+                            "Shape_Area": 0.5654499337414509,
+                        },
+                        "id": "countiestbl:feature:9998:U+",
+                    },
+                    {
+                        "type": "Feature",
+                        "geometry": None,
+                        "properties": {
+                            "OBJECTID": 2,
+                            "NAME": "Ferry",
+                            "STATE_NAME": "Washington",
+                            "STATE_FIPS": "53",
                             "CNTY_FIPS": "019",
                             "FIPS": "53019",
-                            "NAME": "Ferry",
-                            "OBJECTID": 2,
+                            "AREA": 2280.2319,
                             "POP1990": 6295.0,
                             "POP2000": 7199.0,
                             "POP90_SQMI": 3,
-                            "STATE_FIPS": "53",
-                            "STATE_NAME": "Washington",
-                            "Shape_Area": 0.7180593026451161,
                             "Shape_Leng": 3.786160993863997,
+                            "Shape_Area": 0.7180593026451161,
                         },
-                        "type": "Feature",
+                        "id": "countiestbl:feature:2:U-",
                     },
                     {
+                        "type": "Feature",
                         "geometry": None,
-                        "id": "U+::2",
                         "properties": {
-                            "AREA": 2280.2319,
+                            "OBJECTID": 2,
+                            "NAME": "test",
+                            "STATE_NAME": "Washington",
+                            "STATE_FIPS": "53",
                             "CNTY_FIPS": "019",
                             "FIPS": "53019",
-                            "NAME": "test",
-                            "OBJECTID": 2,
+                            "AREA": 2280.2319,
                             "POP1990": 6295.0,
                             "POP2000": 9867.0,
                             "POP90_SQMI": 3,
-                            "STATE_FIPS": "53",
-                            "STATE_NAME": "Washington",
-                            "Shape_Area": 0.7180593026451161,
                             "Shape_Leng": 3.786160993863997,
+                            "Shape_Area": 0.7180593026451161,
                         },
-                        "type": "Feature",
+                        "id": "countiestbl:feature:2:U+",
                     },
                     {
+                        "type": "Feature",
                         "geometry": None,
-                        "id": "D::3",
                         "properties": {
-                            "AREA": 2529.9794,
+                            "OBJECTID": 3,
+                            "NAME": "Stevens",
+                            "STATE_NAME": "Washington",
+                            "STATE_FIPS": "53",
                             "CNTY_FIPS": "065",
                             "FIPS": "53065",
-                            "NAME": "Stevens",
-                            "OBJECTID": 3,
+                            "AREA": 2529.9794,
                             "POP1990": 30948.0,
                             "POP2000": 40652.0,
                             "POP90_SQMI": 12,
-                            "STATE_FIPS": "53",
-                            "STATE_NAME": "Washington",
-                            "Shape_Area": 0.7954858988987561,
                             "Shape_Leng": 4.876296245235406,
+                            "Shape_Area": 0.7954858988987561,
                         },
-                        "type": "Feature",
+                        "id": "countiestbl:feature:3:D",
                     },
                     {
+                        "type": "Feature",
                         "geometry": None,
-                        "id": "I::9999",
                         "properties": {
-                            "AREA": 1784.0634,
+                            "OBJECTID": 9999,
+                            "NAME": "Lake of the Gruffalo",
+                            "STATE_NAME": "Minnesota",
+                            "STATE_FIPS": "27",
                             "CNTY_FIPS": "077",
                             "FIPS": "27077",
-                            "NAME": "Lake of the Gruffalo",
-                            "OBJECTID": 9999,
+                            "AREA": 1784.0634,
                             "POP1990": 4076.0,
                             "POP2000": 4651.0,
                             "POP90_SQMI": 2,
-                            "STATE_FIPS": "27",
-                            "STATE_NAME": "Minnesota",
-                            "Shape_Area": 0.565449933741451,
                             "Shape_Leng": 4.05545998243992,
+                            "Shape_Area": 0.565449933741451,
                         },
-                        "type": "Feature",
+                        "id": "countiestbl:feature:9999:I",
                     },
                 ],
-                "type": "FeatureCollection",
             }
 
         elif output_format == "json":
@@ -1153,7 +1153,7 @@ def test_diff_rev_rev(head_sha, head1_sha, data_archive_readonly, cli_runner):
 
 
 def test_diff_rev_wc(data_working_copy, cli_runner):
-    """ diff the working copy against commits """
+    """diff the working copy against commits"""
     # ID  R0  ->  R1  ->  WC
     # 1   a       a1      a
     # 2   b       b1      b1

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -114,14 +114,15 @@ def test_resolve_with_file(data_archive, cli_runner):
         r = cli_runner.invoke(["diff", "ancestor_branch..ours_branch", "-o", "geojson"])
         assert r.exit_code == 0, r.stderr
         ours_geojson = json.loads(r.stdout)["features"][0]
-        assert ours_geojson["id"] == "I::98001"
+        print(ours_geojson["id"])
+        assert ours_geojson["id"] == "nz_waca_adjustments:feature:98001:I"
 
         r = cli_runner.invoke(
             ["diff", "ancestor_branch..theirs_branch", "-o", "geojson"]
         )
         assert r.exit_code == 0, r.stderr
         theirs_geojson = json.loads(r.stdout)["features"][0]
-        assert theirs_geojson["id"] == "I::98001"
+        assert theirs_geojson["id"] == "nz_waca_adjustments:feature:98001:I"
 
         r = cli_runner.invoke(["merge", "theirs_branch", "-o", "json"])
         assert r.exit_code == 0, r.stderr

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -114,7 +114,6 @@ def test_resolve_with_file(data_archive, cli_runner):
         r = cli_runner.invoke(["diff", "ancestor_branch..ours_branch", "-o", "geojson"])
         assert r.exit_code == 0, r.stderr
         ours_geojson = json.loads(r.stdout)["features"][0]
-        print(ours_geojson["id"])
         assert ours_geojson["id"] == "nz_waca_adjustments:feature:98001:I"
 
         r = cli_runner.invoke(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -338,72 +338,72 @@ def check_points_diff_output(r, output_format):
 
         assert r.exit_code == 0, r
         assert r.stdout.splitlines() == [
-            '--- nz_pa_points_topo_150k:meta:schema.json',
-            '+++ nz_pa_points_topo_150k:meta:schema.json',
-            '  [',
-            '    {',
+            "--- nz_pa_points_topo_150k:meta:schema.json",
+            "+++ nz_pa_points_topo_150k:meta:schema.json",
+            "  [",
+            "    {",
             '      "id": "e97b4015-2765-3a33-b174-2ece5c33343b",',
             '      "name": "fid",',
             '      "dataType": "integer",',
             '      "primaryKeyIndex": 0,',
             '      "size": 64',
-            '    },',
-            '    {',
+            "    },",
+            "    {",
             '      "id": "f488ae9b-6e15-1fe3-0bda-e0d5d38ea69e",',
             '      "name": "geom",',
             '      "dataType": "geometry",',
             '      "geometryType": "POINT",',
             '      "geometryCRS": "EPSG:4326"',
-            '    },',
-            '    {',
+            "    },",
+            "    {",
             '      "id": "4a1c7a86-c425-ea77-7f1a-d74321a10edc",',
             '      "name": "t50_fid",',
             '      "dataType": "integer",',
             '      "size": 32',
-            '    },',
-            '    {',
+            "    },",
+            "    {",
             '      "id": "d2a62351-a66d-bde2-ce3e-356fec9641e9",',
             '      "name": "name_ascii",',
             '      "dataType": "text",',
             '      "length": 75',
-            '    },',
-            '    {',
+            "    },",
+            "    {",
             '      "id": "c3389414-a511-5385-7dcd-891c4ead1663",',
             '      "name": "macronated",',
             '      "dataType": "text",',
             '      "length": 1',
-            '    },',
-            '    {',
+            "    },",
+            "    {",
             '      "id": "45b00eaa-5700-662d-8a21-9614e40c437b",',
             '      "name": "name",',
             '      "dataType": "text",',
             '      "length": 75',
-            '    },',
-            '+   {',
+            "    },",
+            "+   {",
             colour_id_line,
             '+     "name": "colour",',
             '+     "dataType": "text",',
             '+     "length": 32',
-            '+   },',
-            '  ]',
-            '--- nz_pa_points_topo_150k:feature:1',
-            '+++ nz_pa_points_topo_150k:feature:1',
-            '-                                     name = ␀',
-            '+                                     name = test',
-            '+                                   colour = ␀',
-            '--- nz_pa_points_topo_150k:feature:2',
-            '+++ nz_pa_points_topo_150k:feature:2',
-            '-                                     name = ␀',
-            '+                                     name = blue house',
-            '+                                   colour = blue',
-            '+++ nz_pa_points_topo_150k:feature:9999',
-            '+                                      fid = 9999',
-            '+                                     geom = POINT(...)',
-            '+                                  t50_fid = 9999999',
-            '+                               name_ascii = Te Motu-a-kore',
-            '+                               macronated = 0',
-            '+                                     name = Te Motu-a-kore',
-            '+                                   colour = red',
+            "+   },",
+            "  ]",
+            "--- nz_pa_points_topo_150k:feature:1",
+            "+++ nz_pa_points_topo_150k:feature:1",
+            "-                                     name = ␀",
+            "+                                     name = test",
+            "+                                   colour = ␀",
+            "--- nz_pa_points_topo_150k:feature:2",
+            "+++ nz_pa_points_topo_150k:feature:2",
+            "-                                     name = ␀",
+            "+                                     name = blue house",
+            "+                                   colour = blue",
+            "+++ nz_pa_points_topo_150k:feature:9999",
+            "+                                      fid = 9999",
+            "+                                     geom = POINT(...)",
+            "+                                  t50_fid = 9999999",
+            "+                               name_ascii = Te Motu-a-kore",
+            "+                               macronated = 0",
+            "+                                     name = Te Motu-a-kore",
+            "+                                   colour = red",
         ]
     elif output_format == "json":
         # New column "colour" has an ID is deterministically generated from the commit hash,
@@ -571,84 +571,84 @@ def check_points_diff_output(r, output_format):
             in r.stderr
         )
         assert json.loads(r.stdout) == {
+            "type": "FeatureCollection",
             "features": [
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "coordinates": [177.0959629713586, -38.00433803621768],
                         "type": "Point",
+                        "coordinates": [177.0959629713586, -38.00433803621768],
                     },
-                    "id": "U-::1",
                     "properties": {
                         "fid": 1,
+                        "t50_fid": 2426271,
+                        "name_ascii": None,
                         "macronated": "N",
                         "name": None,
-                        "name_ascii": None,
-                        "t50_fid": 2426271,
                     },
-                    "type": "Feature",
+                    "id": "nz_pa_points_topo_150k:feature:1:U-",
                 },
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "coordinates": [177.0959629713586, -38.00433803621768],
                         "type": "Point",
+                        "coordinates": [177.0959629713586, -38.00433803621768],
                     },
-                    "id": "U+::1",
                     "properties": {
-                        "colour": None,
                         "fid": 1,
+                        "t50_fid": 2426271,
+                        "name_ascii": None,
                         "macronated": "N",
                         "name": "test",
-                        "name_ascii": None,
-                        "t50_fid": 2426271,
+                        "colour": None,
                     },
-                    "type": "Feature",
+                    "id": "nz_pa_points_topo_150k:feature:1:U+",
                 },
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "coordinates": [177.0786628443959, -37.9881848576018],
                         "type": "Point",
+                        "coordinates": [177.0786628443959, -37.9881848576018],
                     },
-                    "id": "U-::2",
                     "properties": {
                         "fid": 2,
+                        "t50_fid": 2426272,
+                        "name_ascii": None,
                         "macronated": "N",
                         "name": None,
-                        "name_ascii": None,
-                        "t50_fid": 2426272,
                     },
-                    "type": "Feature",
+                    "id": "nz_pa_points_topo_150k:feature:2:U-",
                 },
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "coordinates": [177.0786628443959, -37.9881848576018],
                         "type": "Point",
+                        "coordinates": [177.0786628443959, -37.9881848576018],
                     },
-                    "id": "U+::2",
                     "properties": {
-                        "colour": "blue",
                         "fid": 2,
+                        "t50_fid": 2426272,
+                        "name_ascii": None,
                         "macronated": "N",
                         "name": "blue house",
-                        "name_ascii": None,
-                        "t50_fid": 2426272,
+                        "colour": "blue",
                     },
-                    "type": "Feature",
+                    "id": "nz_pa_points_topo_150k:feature:2:U+",
                 },
                 {
-                    "geometry": {"coordinates": [0.0, 0.0], "type": "Point"},
-                    "id": "I::9999",
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [0.0, 0.0]},
                     "properties": {
-                        "colour": "red",
                         "fid": 9999,
+                        "t50_fid": 9999999,
+                        "name_ascii": "Te Motu-a-kore",
                         "macronated": "0",
                         "name": "Te Motu-a-kore",
-                        "name_ascii": "Te Motu-a-kore",
-                        "t50_fid": 9999999,
+                        "colour": "red",
                     },
-                    "type": "Feature",
+                    "id": "nz_pa_points_topo_150k:feature:9999:I",
                 },
             ],
-            "type": "FeatureCollection",
         }
 
 
@@ -875,9 +875,12 @@ def check_polygons_diff_output(r, output_format):
             in r.stderr
         )
         assert json.loads(r.stdout) == {
+            "type": "FeatureCollection",
             "features": [
                 {
+                    "type": "Feature",
                     "geometry": {
+                        "type": "MultiPolygon",
                         "coordinates": [
                             [
                                 [
@@ -895,19 +898,19 @@ def check_polygons_diff_output(r, output_format):
                                 ]
                             ]
                         ],
-                        "type": "MultiPolygon",
                     },
-                    "id": "U-::1443053",
                     "properties": {
-                        "adjusted_nodes": 1238,
-                        "date_adjusted": "2011-05-10T12:09:10",
                         "id": 1443053,
+                        "date_adjusted": "2011-05-10T12:09:10",
                         "survey_reference": None,
+                        "adjusted_nodes": 1238,
                     },
-                    "type": "Feature",
+                    "id": "nz_waca_adjustments:feature:1443053:U-",
                 },
                 {
+                    "type": "Feature",
                     "geometry": {
+                        "type": "MultiPolygon",
                         "coordinates": [
                             [
                                 [
@@ -925,20 +928,20 @@ def check_polygons_diff_output(r, output_format):
                                 ]
                             ]
                         ],
-                        "type": "MultiPolygon",
                     },
-                    "id": "U+::1443053",
                     "properties": {
+                        "id": 1443053,
+                        "date_adjusted": "2011-05-10T12:09:10",
+                        "surv_ref": "test",
                         "adjusted_nodes": 1238,
                         "colour": None,
-                        "date_adjusted": "2011-05-10T12:09:10",
-                        "id": 1443053,
-                        "surv_ref": "test",
                     },
-                    "type": "Feature",
+                    "id": "nz_waca_adjustments:feature:1443053:U+",
                 },
                 {
+                    "type": "Feature",
                     "geometry": {
+                        "type": "MultiPolygon",
                         "coordinates": [
                             [
                                 [
@@ -969,19 +972,19 @@ def check_polygons_diff_output(r, output_format):
                                 ]
                             ]
                         ],
-                        "type": "MultiPolygon",
                     },
-                    "id": "U-::1452332",
                     "properties": {
-                        "adjusted_nodes": 558,
-                        "date_adjusted": "2011-06-07T15:22:58",
                         "id": 1452332,
+                        "date_adjusted": "2011-06-07T15:22:58",
                         "survey_reference": None,
+                        "adjusted_nodes": 558,
                     },
-                    "type": "Feature",
+                    "id": "nz_waca_adjustments:feature:1452332:U-",
                 },
                 {
+                    "type": "Feature",
                     "geometry": {
+                        "type": "MultiPolygon",
                         "coordinates": [
                             [
                                 [
@@ -1012,20 +1015,20 @@ def check_polygons_diff_output(r, output_format):
                                 ]
                             ]
                         ],
-                        "type": "MultiPolygon",
                     },
-                    "id": "U+::1452332",
                     "properties": {
+                        "id": 1452332,
+                        "date_adjusted": "2011-06-07T15:22:58",
+                        "surv_ref": None,
                         "adjusted_nodes": 558,
                         "colour": "yellow",
-                        "date_adjusted": "2011-06-07T15:22:58",
-                        "id": 1452332,
-                        "surv_ref": None,
                     },
-                    "type": "Feature",
+                    "id": "nz_waca_adjustments:feature:1452332:U+",
                 },
                 {
+                    "type": "Feature",
                     "geometry": {
+                        "type": "Polygon",
                         "coordinates": [
                             [
                                 [0.0, 0.0],
@@ -1035,20 +1038,17 @@ def check_polygons_diff_output(r, output_format):
                                 [0.0, 0.0],
                             ]
                         ],
-                        "type": "Polygon",
                     },
-                    "id": "I::9999999",
                     "properties": {
+                        "id": 9999999,
+                        "date_adjusted": "2019-07-05T13:04:00",
+                        "surv_ref": "Null Island™ 🗺",
                         "adjusted_nodes": 123,
                         "colour": None,
-                        "date_adjusted": "2019-07-05T13:04:00",
-                        "id": 9999999,
-                        "surv_ref": "Null Island™ 🗺",
                     },
-                    "type": "Feature",
+                    "id": "nz_waca_adjustments:feature:9999999:I",
                 },
             ],
-            "type": "FeatureCollection",
         }
 
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -317,7 +317,6 @@ def test_status_merging(data_archive, cli_runner):
             "nz_pa_points_topo_150k:",
             "    nz_pa_points_topo_150k:feature: 4 conflicts",
             "",
-            "",
             "View conflicts with `kart conflicts` and resolve them with `kart resolve`.",
             "Once no conflicts remain, complete this merge with `kart merge --continue`.",
             "Or use `kart merge --abort` to return to the previous state.",


### PR DESCRIPTION
## Description

- Changed feature's GeoJSON id to be same as JSON path. Example: `dataset:feature:id:U-`
  - This is simpler or atleast less surprising than ids like `U+::123`.
- Added support for `--output` for JSON, text and GeoJSON formats in `kart conflicts`.
  - Added support for writing `kart conflicts` to separate directories according to datasets for GeoJSON output.
- Refactor `kart conflicts` to make use of polymorphism.

## Related links:

- Resolves #135 

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
