### PR TITLE
Basic support for committing point cloud tile diffs

### DIFF
--- a/kart/diff_util.py
+++ b/kart/diff_util.py
@@ -50,7 +50,10 @@ class WCDiffContext:
         index = pygit2.Index(str(self.workdir_index_path))
         index._repo = self.repo
         return index.diff_to_workdir(
-            pygit2.GIT_DIFF_INCLUDE_UNTRACKED | pygit2.GIT_DIFF_UPDATE_INDEX
+            pygit2.GIT_DIFF_INCLUDE_UNTRACKED
+            | pygit2.GIT_DIFF_UPDATE_INDEX
+            # GIT_DIFF_UPDATE_INDEX just updates timestamps in the index to make the diff quicker next time
+            # none of the paths or hashes change, and the end result stays the same.
         )
 
     @functools.lru_cache(maxsize=1)

--- a/kart/object_builder.py
+++ b/kart/object_builder.py
@@ -101,7 +101,9 @@ class ObjectBuilder:
         return self.repo[commit_oid]
 
     def _ensure_writeable(self, writeable):
-        if not isinstance(writeable, (pygit2.Tree, pygit2.Blob, bytes, type(None))):
+        if not isinstance(
+            writeable, (pygit2.Tree, pygit2.Blob, bytes, bytearray, type(None))
+        ):
             raise ValueError(f"Expected a writeable type but found {type(writeable)}")
 
 
@@ -132,6 +134,9 @@ def copy_and_modify_tree(repo, tree, changes):
             tree_builder.insert(name, new_value.oid, pygit2.GIT_FILEMODE_BLOB)
         elif isinstance(new_value, bytes):
             blob_oid = repo.create_blob(new_value)
+            tree_builder.insert(name, blob_oid, pygit2.GIT_FILEMODE_BLOB)
+        elif isinstance(new_value, bytearray):
+            blob_oid = repo.create_blob(bytes(new_value))
             tree_builder.insert(name, blob_oid, pygit2.GIT_FILEMODE_BLOB)
         elif new_value is None:
             try:

--- a/kart/point_cloud/v1.py
+++ b/kart/point_cloud/v1.py
@@ -1,14 +1,18 @@
 import functools
+import re
+import shutil
 
 from kart.core import find_blobs_in_tree
 from kart.base_dataset import BaseDataset
 from kart.diff_structs import DatasetDiff, DeltaDiff
+from kart.exceptions import NotYetImplemented
 from kart.key_filters import DatasetKeyFilter, FeatureKeyFilter
 from kart.lfs_util import (
     get_hash_and_size_of_file,
     get_hash_from_pointer_file,
     get_local_path_from_lfs_hash,
-    pointer_file_to_json,
+    pointer_file_bytes_to_dict,
+    dict_to_pointer_file_bytes,
 )
 from kart.serialise_util import hexhash
 
@@ -78,7 +82,7 @@ class PointCloudV1(BaseDataset):
 
     def get_tile_summary_from_pointer_blob(self, tile_pointer_blob):
         # For now just return the blob contents as a string - it's a reasonable summary.
-        result = pointer_file_to_json(
+        result = pointer_file_bytes_to_dict(
             tile_pointer_blob, {"name": tile_pointer_blob.name}
         )
         if "version" in result:
@@ -135,9 +139,15 @@ class PointCloudV1(BaseDataset):
         def wc_to_ds_path_transform(wc_path):
             return self.tilename_to_blob_path(wc_path, relative=True)
 
+        wc_tiles_path_pattern = re.escape(f"{self.path}/tiles/")
+        wc_tile_ext_pattern = re.escape(".laz")
+        wc_tiles_pattern = re.compile(
+            rf"^{wc_tiles_path_pattern}[^/]+{wc_tile_ext_pattern}$"
+        )
+
         yield from self.generate_wc_diff_from_worktree_index(
             wc_diff_context,
-            only_in_subfolder="tiles",
+            wc_path_filter_pattern=wc_tiles_pattern,
             key_filter=tile_filter,
             wc_to_ds_path_transform=wc_to_ds_path_transform,
             ds_key_decoder=self.tilename_from_path,
@@ -149,3 +159,62 @@ class PointCloudV1(BaseDataset):
     def get_tile_summary_promise_from_wc_path(self, wc_path):
         wc_path = self.repo.workdir_file(wc_path)
         return functools.partial(self.get_tile_summary_from_wc_path, wc_path)
+
+    def apply_diff(
+        self, dataset_diff, object_builder, *, resolve_missing_values_from_ds=None
+    ):
+        """
+        Given a diff that only affects this dataset, write it to the given treebuilder.
+        Blobs will be created in the repo, and referenced in the resulting tree, but
+        no commit is created - this is the responsibility of the caller.
+        """
+        meta_diff = dataset_diff.get("meta")
+        if meta_diff:
+            raise NotYetImplemented(
+                "Sorry, committing meta diffs for point cloud datasets is not yet supported"
+            )
+
+        tile_diff = dataset_diff.get("tile")
+        if tile_diff:
+            self.apply_tile_diff(
+                tile_diff,
+                object_builder,
+                resolve_missing_values_from_ds=resolve_missing_values_from_ds,
+            )
+
+    def apply_tile_diff(
+        self, tile_diff, object_builder, *, resolve_missing_values_from_ds=None
+    ):
+        lfs_objects_path = self.repo.gitdir_path / "lfs" / "objects"
+        lfs_tmp_path = lfs_objects_path / "tmp"
+        lfs_tmp_path.mkdir(parents=True, exist_ok=True)
+
+        with object_builder.chdir(self.inner_path):
+            for delta in tile_diff.values():
+                if delta.type in ("insert", "update"):
+                    tilename = delta.new_key
+                    path_in_wc = self.repo.workdir_file(f"{self.path}/tiles/{tilename}")
+                    assert path_in_wc.is_file()
+
+                    oid = delta.new_value["oid"]
+                    assert oid.startswith("sha256:")
+                    size = delta.new_value["size"]
+                    actual_object_path = get_local_path_from_lfs_hash(self.repo, oid)
+                    actual_object_path.parents[0].mkdir(parents=True, exist_ok=True)
+                    shutil.copy(path_in_wc, actual_object_path)
+
+                    pointer_dict = {
+                        "version": "https://git-lfs.github.com/spec/v1",
+                        "oid": oid,
+                        "size": size,
+                    }
+                    object_builder.insert(
+                        self.tilename_to_blob_path(tilename, relative=True),
+                        dict_to_pointer_file_bytes(pointer_dict),
+                    )
+
+                else:  # delete:
+                    tilename = delta.old_key
+                    object_builder.remove(
+                        self.tilename_to_blob_path(tilename, relative=True)
+                    )

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -213,7 +213,9 @@ def test_import_mismatched_las(
                 assert "Non-homogenous" in r.stderr
 
 
-def test_working_copy_edit(cli_runner, data_working_copy):
+def test_working_copy_edit(cli_runner, data_working_copy, monkeypatch):
+    monkeypatch.setenv("X_KART_POINT_CLOUDS", "1")
+
     # TODO - remove Kart's requirement for a GPKG working copy
     with data_working_copy("point-cloud/auckland.tgz") as (repo_path, wc_path):
         r = cli_runner.invoke(["diff"])
@@ -249,3 +251,31 @@ def test_working_copy_edit(cli_runner, data_working_copy):
             "+                                      oid = sha256:522ef2ff7f66b51516021cde1fa7b9f301acde6713772958d6f1303fdac40c25",
             "+                                     size = 1334",
         ]
+
+        r = cli_runner.invoke(["commit", "-m", "Edit point cloud tiles"])
+        assert r.exit_code == 0, r.stderr
+
+        r = cli_runner.invoke(["show"])
+        assert r.exit_code == 0, r.stderr
+        assert r.stdout.splitlines()[4:] == [
+            "    Edit point cloud tiles",
+            "",
+            "--- auckland:tile:auckland_1_1.copc.laz",
+            "+++ auckland:tile:auckland_1_1.copc.laz",
+            "-                                      oid = sha256:1d9934b50ebd057d893281813fda8deffb0ad03b3c354ec1c5d7557134c40be1",
+            "+                                      oid = sha256:dafd2ed5671190433ca1e7cea364a94d9e00c11f0a7b3927ce93554df5b1cd5c",
+            "-                                     size = 23570",
+            "+                                     size = 68665",
+            "--- auckland:tile:auckland_3_3.copc.laz",
+            "-                                     name = auckland_3_3.copc.laz",
+            "-                                      oid = sha256:522ef2ff7f66b51516021cde1fa7b9f301acde6713772958d6f1303fdac40c25",
+            "-                                     size = 1334",
+            "+++ auckland:tile:auckland_4_4.copc.laz",
+            "+                                     name = auckland_4_4.copc.laz",
+            "+                                      oid = sha256:522ef2ff7f66b51516021cde1fa7b9f301acde6713772958d6f1303fdac40c25",
+            "+                                     size = 1334",
+        ]
+
+        r = cli_runner.invoke(["diff"])
+        assert r.exit_code == 0, r.stderr
+        assert r.stdout.splitlines() == []


### PR DESCRIPTION
<img src="https://media2.giphy.com/media/TijL9TieqPfLq/giphy.gif"/>

For each tile diff, commits it by
- copying the tile to the local LFS cache
- writing a pointer-file to the ODB
- updating the worktree-index so the diff disappears

Also makes sure that only tiles/*.laz are committable -
- QGIS likes to create random files next to tiles, that we don't want to commit

https://github.com/koordinates/kart/issues/565