### PR TITLE
Upgrade GDAL to 3.4.0

### DIFF
--- a/vendor/gdal/Makefile
+++ b/vendor/gdal/Makefile
@@ -162,7 +162,9 @@ $(configure-gdal): | src $(libs) $(ccache-deps)
 		--without-jasper \
 		--without-jpeg \
 		--without-jpeg12 \
+		--without-jxl \
 		--without-lerc \
+		--without-lz4 \
 		--without-netcdf \
 		--without-odbc \
 		--without-openjpeg \

--- a/vendor/gdal/Makefile
+++ b/vendor/gdal/Makefile
@@ -1,5 +1,5 @@
-GDAL_VERSION ?= 3.3.2
-GDAL_SO = libgdal.29
+GDAL_VERSION ?= 3.4.0
+GDAL_SO = libgdal.30
 SHELL = /bin/bash
 
 export PREFIX ?= $(abspath env)


### PR DESCRIPTION
<img src="https://media1.giphy.com/media/uBQNLeszLtiNO/giphy.gif"/>

Pull GDAL 3.4.0 into Kart instead of 3.3.2

Currently makes no discernible difference - may fix some bugs, see release notes [here](https://github.com/OSGeo/gdal/releases/tag/v3.4.0) - but will be required later for point-cloud support via PDAL.

## Related links:

https://github.com/koordinates/kart/issues/565