### PR TITLE
add ext-run command for extension invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Added support for `--decorate` and `--no-decorate` in `kart log`. [#586](https://github.com/koordinates/kart/issues/586)
 - Bugfix: Fixed a bug where creating a MSSQL working copy fails when there are large (~10KB) geometries. [#617](https://github.com/koordinates/kart/issues/617)
 - Bugfix: Fixed `kart diff <commit-id>` for a commit containing a dataset that has since been deleted using `kart data rm`. [#611](https://github.com/koordinates/kart/issues/611)
+- Add `ext-run` to provide an execution environment for prototyping ideas/extensions.
 
 ## 0.11.1
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,10 @@
+import contextlib
+import json
 import os
 import platform
 import re
+import sys
+from pathlib import Path
 
 import pygit2
 import pytest
@@ -43,6 +47,19 @@ def empty_gitconfig(monkeypatch, tmpdir):
     )
 
 
+@pytest.fixture
+def sys_path_reset(monkeypatch):
+    """A context manager to save & reset after code that changes sys.path"""
+
+    @contextlib.contextmanager
+    def _sys_path_reset():
+        with monkeypatch.context() as m:
+            m.setattr("sys.path", sys.path[:])
+            yield
+
+    return _sys_path_reset
+
+
 def test_config(empty_gitconfig, cli_runner):
     # don't load the ~/.gitconfig file from conftest.py
     # (because it sets init.defaultBranch and we're trying to test what
@@ -77,3 +94,66 @@ def test_cli_tool_environment():
         env_exec = tool_environment(env_in)
         assert env_exec is not env_in
         assert env_exec == env_in
+
+
+def test_ext_run(tmp_path, cli_runner, sys_path_reset):
+    # missing script
+    with sys_path_reset():
+        r = cli_runner.invoke(["ext-run", tmp_path / "zero.py"])
+    assert r.exit_code == 2, r
+
+    # invalid syntax
+    with open(tmp_path / "one.py", "wt") as fs:
+        fs.write("def nope")
+    with sys_path_reset():
+        r = cli_runner.invoke(["ext-run", tmp_path / "one.py"])
+    assert r.exit_code == 1, r
+    assert "Error: loading " in r.stderr
+    assert "SyntaxError" in r.stderr
+    assert "line 1" in r.stderr
+
+    # main() with wrong argspec
+    with open(tmp_path / "two.py", "wt") as fs:
+        fs.write("def main():\n  print('nope')")
+    with sys_path_reset():
+        r = cli_runner.invoke(["ext-run", tmp_path / "two.py"])
+    assert r.exit_code == 1, r
+    assert "requires a main(ctx, args) function" in r.stderr
+
+    # no main()
+    with open(tmp_path / "three_a.py", "wt") as fs:
+        fs.write("A = 3")
+    with sys_path_reset():
+        r = cli_runner.invoke(["ext-run", tmp_path / "three_a.py"])
+    assert r.exit_code == 1, r
+    assert "does not have a main(ctx, args) function" in r.stderr
+
+    # working example
+    with open(tmp_path / "three.py", "wt") as fs:
+        fs.write(
+            "\n".join(
+                [
+                    "import json",
+                    "import kart",
+                    "import three_a",
+                    "def main(ctx, args):",
+                    "  print(json.dumps([",
+                    "    repr(ctx), args,",
+                    "    bool(kart.is_frozen), three_a.A,",
+                    "    __file__, __name__",
+                    "  ]))",
+                ]
+            )
+        )
+    with sys_path_reset():
+        r = cli_runner.invoke(["ext-run", tmp_path / "three.py", "arg1", "arg2"])
+    print(r.stdout)
+    print(r.stderr)
+    assert r.exit_code == 0, r
+
+    sctx, sargs, val1, val2, sfile, sname = json.loads(r.stdout)
+    assert sctx.startswith("<click.core.Context object")
+    assert sargs == ["arg1", "arg2"]
+    assert (val1, val2) == (False, 3)
+    assert Path(sfile) == (tmp_path / "three.py")
+    assert sname == "kart.ext_run.three"


### PR DESCRIPTION
It can be useful to run scripts inside Kart's execution environment for prototyping or extensions. Add a new command, `kart ext-run PY_SCRIPT [ARGS...]` to do this.

It uses importlib to import and validate (as best we can) the script before calling a `main(ctx, args)` function.

example script:

```console
$ cat >plugin.py <<EOF
import kart

def main(ctx, args):
  print("hi from a plugin!", args)
  print("am i frozen?", kart.is_frozen)
EOF

$ kart -C /path/to/repo ext-run plugin.py arg1 arg2
hi from a plugin! ('arg1', 'arg2')
am i frozen? None
```

Obviously Kart doesn't have a public API, so it's all on the user to keep any extensions working.

## Related links:

<!-- If you have links to [issues](https://github.com/koordinates/kart/issues) etc, link them here. -->

## Checklist:

- [X] Have you reviewed your own change?
- [X] Have you included test(s)?
- [X] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
