### PR TITLE
Allow missing WC parts.

### DIFF
--- a/kart/base_diff_writer.py
+++ b/kart/base_diff_writer.py
@@ -8,7 +8,7 @@ import click
 
 from . import diff_util
 from .diff_structs import WORKING_COPY_EDIT
-from .exceptions import NO_WORKING_COPY, CrsError, InvalidOperation, NotFound
+from .exceptions import CrsError, InvalidOperation
 from .key_filters import RepoKeyFilter
 from .promisor_utils import FetchPromisedBlobsProcess, object_is_promised
 from .spatial_filter import SpatialFilter
@@ -157,11 +157,8 @@ class BaseDiffWriter:
             # and target is set to HEAD.
             base_rs = repo.structure(commit_parts[0])
             target_rs = repo.structure("HEAD")
-            # TODO: this code shouldn't special-case tabular working copies
-            table_wc = repo.wc.tabular
-            if not table_wc:
-                raise NotFound("No working copy", exit_code=NO_WORKING_COPY)
-            repo.working_copy.assert_tree_match(target_rs.tree)
+            repo.working_copy.assert_exists("Cannot generate working copy diff")
+            repo.working_copy.assert_matches_tree(target_rs.tree)
             include_wc_diff = True
         return base_rs, target_rs, include_wc_diff
 

--- a/kart/diff_util.py
+++ b/kart/diff_util.py
@@ -1,6 +1,7 @@
 import functools
 import logging
 
+import click
 import pygit2
 
 from .diff_structs import DatasetDiff, RepoDiff
@@ -30,9 +31,13 @@ class WCDiffContext:
         self.all_ds_paths = all_ds_paths
 
     @property
-    def table_working_copy(self):
+    def working_copy(self):
         assert not self.is_bare
-        return self.repo.working_copy.tabular
+        return self.repo.working_copy
+
+    @property
+    def wc(self):
+        return self.working_copy
 
     @property
     def workdir_path(self):
@@ -123,7 +128,10 @@ def get_repo_diff(
 
     all_ds_paths = get_all_ds_paths(base_rs, target_rs, repo_key_filter)
     if wc_diff_context is None:
-        wc_diff_context = WCDiffContext(target_rs.repo, all_ds_paths)
+        wc_diff_context = WCDiffContext(
+            target_rs.repo,
+            all_ds_paths,
+        )
 
     repo_diff = RepoDiff()
     for ds_path in all_ds_paths:

--- a/kart/fsck.py
+++ b/kart/fsck.py
@@ -65,9 +65,10 @@ def fsck(ctx, reset_datasets, fsck_args):
 
         # compare repo tree id to what's in the DB
         try:
-            oid = table_wc.assert_tree_match(repo.head_tree)
+            table_wc.assert_matches_tree(repo.head_tree)
             click.secho(
-                f"✔︎ Working Copy tree id matches repository: {oid}", fg="green"
+                f"✔︎ Working Copy tree id matches repository: {repo.head_tree}",
+                fg="green",
             )
         except WorkingCopyTreeMismatch as e:
             # try and find the tree we _do_ have
@@ -111,7 +112,7 @@ def fsck(ctx, reset_datasets, fsck_args):
             )
             click.echo(f"{track_count} rows marked as changed in working-copy")
 
-            wc_diff = table_wc.diff_db_to_tree(dataset)
+            wc_diff = table_wc.diff_ds_to_wc(dataset)
             wc_diff.prune()
 
             if wc_diff:

--- a/kart/status.py
+++ b/kart/status.py
@@ -90,7 +90,7 @@ def get_working_copy_status_json(repo):
         rs = repo.structure()
         wc_diff = diff_util.get_repo_diff(rs, rs, include_wc_diff=True)
     else:
-        wc_diff = table_wc.diff_to_tree()
+        wc_diff = table_wc.diff_repo_to_wc()
     if wc_diff:
         output["changes"] = get_diff_status_including_pk_conflicts_json(wc_diff, repo)
 

--- a/kart/tabular/rich_table_dataset.py
+++ b/kart/tabular/rich_table_dataset.py
@@ -2,11 +2,10 @@ import functools
 import time
 
 import click
-import pygit2
 from osgeo import osr
 
 from kart import crs_util
-from kart.diff_structs import Delta, DeltaDiff
+from kart.diff_structs import Delta, DeltaDiff, DatasetDiff
 from kart.exceptions import PATCH_DOES_NOT_APPLY, InvalidOperation, NotYetImplemented
 from kart.key_filters import DatasetKeyFilter, FeatureKeyFilter
 from kart.promisor_utils import fetch_promised_blobs, object_is_promised
@@ -176,7 +175,10 @@ class RichTableDataset(TableDataset):
         return ds_diff
 
     def diff_to_wc(self, wc_diff_context, ds_filter=DatasetKeyFilter.MATCH_ALL):
-        return wc_diff_context.table_working_copy.diff_db_to_tree(self, ds_filter)
+        table_wc = wc_diff_context.wc.tabular
+        if table_wc is None:
+            return DatasetDiff()
+        return table_wc.diff_ds_to_wc(self, ds_filter)
 
     def diff_feature(
         self, other, feature_filter=FeatureKeyFilter.MATCH_ALL, reverse=False

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -91,7 +91,7 @@ def test_commit(
         tree = repo.head_tree
         assert dataset.encode_1pk_to_path(pk_del) not in tree
 
-        table_wc.assert_tree_match(tree)
+        table_wc.assert_matches_tree(tree)
         change_count = table_wc.tracking_changes_count(dataset)
 
         if partial:

--- a/tests/test_working_copy_mysql.py
+++ b/tests/test_working_copy_mysql.py
@@ -64,9 +64,7 @@ def test_checkout_workingcopy(
             table_wc = repo.wc.tabular
             assert table_wc.status() & TableWorkingCopyStatus.INITIALISED
             assert table_wc.status() & TableWorkingCopyStatus.HAS_DATA
-
-            head_tree_id = repo.head_tree.hex
-            table_wc.assert_tree_match(head_tree_id)
+            table_wc.assert_matches_head_tree()
 
             # Also test the importer by making sure we can import this from the WC:
             r = cli_runner.invoke(["import", mysql_url, f"{table}:{table}_2"])

--- a/tests/test_working_copy_postgis.py
+++ b/tests/test_working_copy_postgis.py
@@ -66,9 +66,7 @@ def test_checkout_workingcopy(
             table_wc = repo.wc.tabular
             assert table_wc.status() & TableWorkingCopyStatus.INITIALISED
             assert table_wc.status() & TableWorkingCopyStatus.HAS_DATA
-
-            head_tree_id = repo.head_tree.hex
-            table_wc.assert_tree_match(head_tree_id)
+            table_wc.assert_matches_head_tree()
 
             # Also test the importer by making sure we can import this from the WC:
             r = cli_runner.invoke(["import", postgres_url, f"{table}:{table}_2"])
@@ -460,7 +458,7 @@ def test_edit_crs(data_archive, cli_runner, new_postgis_db_schema):
                     assert table_wc.is_dirty()
 
                     commit_id = repo.structure().commit_diff(
-                        table_wc.diff_to_tree(), "Modify CRS"
+                        table_wc.diff_repo_to_wc(), "Modify CRS"
                     )
                     table_wc.update_state_table_tree(commit_id.hex)
 

--- a/tests/test_working_copy_sqlserver.py
+++ b/tests/test_working_copy_sqlserver.py
@@ -118,9 +118,7 @@ def test_checkout_workingcopy(
             table_wc = repo.wc.tabular
             assert table_wc.status() & TableWorkingCopyStatus.INITIALISED
             assert table_wc.status() & TableWorkingCopyStatus.HAS_DATA
-
-            head_tree_id = repo.head_tree.hex
-            table_wc.assert_tree_match(head_tree_id)
+            table_wc.assert_matches_head_tree()
 
             # Also test the importer by making sure we can import this from the WC:
             r = cli_runner.invoke(["import", sqlserver_url, f"{table}:{table}_2"])


### PR DESCRIPTION
Work on making Kart more lenient if some part of the WC are missing when
it tries to do a WC diff, since it will soon be common for only
part of the WC to be present (ie a repo with only tabular data
generally has no PC WC, and a repo with only PC data may have
no tabular WC).

Currently has no real effect since there is only one part that is
implemented - the tabular part - but is part of the tidy up /
refactor for implementing the PC part too.

https://github.com/koordinates/kart/issues/565