### PR TITLE
More working copy parts refactoring

### DIFF
--- a/kart/apply.py
+++ b/kart/apply.py
@@ -229,6 +229,7 @@ def apply_patch(
 
     rs = repo.structure(ref)
     # TODO: this code shouldn't special-case tabular working copies
+    # Specifically, we need to check if those part(s) of the WC exists which the patch applies to.
     table_wc = repo.working_copy.tabular
     if not do_commit and not table_wc:
         # TODO: might it be useful to apply without committing just to *check* if the patch applies?
@@ -301,10 +302,8 @@ def apply_patch(
             resolve_missing_values_from_rs=resolve_missing_values_from_rs,
         )
 
-    if table_wc and new_wc_target:
-        # oid refers to either a commit or tree
-        click.echo(f"Updating {table_wc} ...")
-        table_wc.reset(new_wc_target, track_changes_as_dirty=not do_commit)
+    if new_wc_target:
+        repo.working_copy.reset(new_wc_target, track_changes_as_dirty=not do_commit)
 
 
 @click.command()

--- a/kart/checkout.py
+++ b/kart/checkout.py
@@ -99,8 +99,14 @@ def checkout(
         )
     else:
         # We also allow switching of spatial filter by just writing it to the config and then running
-        # `kart checkout`. TODO this may not be a good idea.
+        # `kart checkout`. Updating the spatial filter by running an explicit command is preferred,
+        # since then we can do the necessary checks and make the change all at once, but since we
+        # store the spatial filter in the config, we need to handle it if the user has changed it.
         do_switch_spatial_filter = not repo.spatial_filter.matches_working_copy(repo)
+        if do_switch_spatial_filter:
+            click.echo(
+                "The spatial filter has been updated in the config and no longer matches the working copy."
+            )
 
     discard_changes = discard_changes or force
     if (do_switch_commit or do_switch_spatial_filter) and not discard_changes:

--- a/kart/data.py
+++ b/kart/data.py
@@ -111,13 +111,7 @@ def data_rm(ctx, message, output_format, datasets):
         raise click.UsageError("Aborting commit due to empty commit message.")
 
     new_commit = repo.structure().commit_diff(repo_diff, commit_msg)
-
-    # TODO: this code shouldn't special-case tabular working copies
-    table_wc = repo.working_copy.tabular
-    if table_wc:
-        if not do_json:
-            click.echo(f"Updating {table_wc} ...")
-        table_wc.reset(new_commit)
+    repo.working_copy.reset_to_head()
 
     jdict = commit_obj_to_json(new_commit, repo, repo_diff)
     if do_json:

--- a/kart/key_filters.py
+++ b/kart/key_filters.py
@@ -152,6 +152,14 @@ class RepoKeyFilter(KeyFilterDict):
         return groups["dataset_glob"], subdataset, groups["rest"] or None
 
     @classmethod
+    def datasets(cls, dataset_paths):
+        """Returns a RepoKeyFilter that matches everything in all of the given datasets."""
+        result = cls()
+        for dataset_path in dataset_paths:
+            result[dataset_path] = DatasetKeyFilter.MATCH_ALL
+        return result
+
+    @classmethod
     def build_from_user_patterns(cls, user_patterns):
         """
         Given a list of strings like ["datasetA:1", "datasetA:2", "datasetB"],

--- a/kart/meta.py
+++ b/kart/meta.py
@@ -5,7 +5,6 @@ import click
 import pygit2
 
 from .apply import apply_patch
-from .checkout import reset_wc_if_needed
 from .cli_util import (
     OutputFormatType,
     StringFromFile,
@@ -296,4 +295,4 @@ def commit_files(ctx, message, ref, amend, allow_empty, remove_empty_files, item
             repo.references[ref].set_target(new_commit.id)
 
     click.echo(f"Committed as: {new_commit.hex}")
-    reset_wc_if_needed(repo, new_commit)
+    repo.working_copy.reset_to_head()

--- a/kart/point_cloud/checkout.py
+++ b/kart/point_cloud/checkout.py
@@ -12,7 +12,7 @@ from .v1 import PointCloudV1
 # Some of this may move at some point to be part of "filesystem" checkout which will also handle attachments.
 
 
-def reset_wc_if_needed(repo):
+def checkout_point_clouds(repo):
     """Checks out point cloud tiles to working copy directory."""
     if repo.is_bare:
         return

--- a/tests/test_conflicts.py
+++ b/tests/test_conflicts.py
@@ -475,10 +475,6 @@ def test_conflicts_geojson_usage(data_archive, cli_runner, tmp_path):
                 r = cli_runner.invoke(["-C", repo_path, "import", src_gpkg_path])
                 assert r.exit_code == 0, r.stderr
 
-        # commit changes and merge again
-        r = cli_runner.invoke(["commit", "-m", "test-commit"])
-        assert r.exit_code == 0, r
-
         r = cli_runner.invoke(["merge", "theirs_branch"])
         assert r.exit_code == 0, r
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -60,7 +60,7 @@ def test_init_import_single_table_source(data_archive_readonly, tmp_path, cli_ru
         lines = r.stdout.splitlines()
         assert len(lines) >= 2
         assert "to nz_pa_points_topo_150k/ ..." in lines[2]
-        assert lines[-1] == "Creating working copy at emptydir.gpkg ..."
+        assert lines[-1] == "Creating GPKG working copy at emptydir.gpkg ..."
 
 
 @pytest.mark.slow

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -132,9 +132,11 @@ def test_import(
     """ Import the GeoPackage (eg. `kx-foo-layer.gpkg`) into a Kart repository. """
     param_ids = H.parameter_ids(request)
 
+    from kart.working_copy import WorkingCopy
+
     # wrap the original functions with benchmarking
     orig_import_func = fast_import.fast_import_tables
-    orig_checkout_func = init._add_datasets_to_working_copy
+    orig_reset_func = WorkingCopy.reset
 
     def _benchmark_import(*args, **kwargs):
         # one round/iteration isn't very statistical, but hopefully crude idea
@@ -142,15 +144,15 @@ def test_import(
             orig_import_func, args=args, kwargs=kwargs, rounds=1, iterations=1
         )
 
-    def _benchmark_checkout(*args, **kwargs):
+    def _benchmark_reset(*args, **kwargs):
         return benchmark.pedantic(
-            orig_checkout_func, args=args, kwargs=kwargs, rounds=1, iterations=1
+            orig_reset_func, args=args, kwargs=kwargs, rounds=1, iterations=1
         )
 
     if profile == "fast_import":
         monkeypatch.setattr(init, "fast_import_tables", _benchmark_import)
     else:
-        monkeypatch.setattr(init, "_add_datasets_to_working_copy", _benchmark_checkout)
+        monkeypatch.setattr(WorkingCopy, "reset", _benchmark_reset)
 
     with data_archive(archive) as data:
         # list tables

--- a/tests/test_working_copy_gpkg.py
+++ b/tests/test_working_copy_gpkg.py
@@ -37,7 +37,7 @@ def test_checkout_workingcopy(
         r = cli_runner.invoke(["checkout"])
         wc_path = Path(repo.config["kart.workingcopy.location"])
         assert r.exit_code == 0, r
-        assert r.stdout.splitlines() == [f"Creating working copy at {wc_path} ..."]
+        assert r.stdout.splitlines() == [f"Creating GPKG working copy at {wc_path} ..."]
         assert wc_path.exists()
         table_wc = repo.working_copy.tabular
 

--- a/tests/test_working_copy_mysql.py
+++ b/tests/test_working_copy_mysql.py
@@ -50,7 +50,7 @@ def test_checkout_workingcopy(
             assert r.exit_code == 0, r.stderr
             assert (
                 r.stdout.splitlines()[-1]
-                == f"Creating working copy at {strip_password(mysql_url)} ..."
+                == f"Creating MySQL working copy at {strip_password(mysql_url)} ..."
             )
 
             r = cli_runner.invoke(["status"])

--- a/tests/test_working_copy_postgis.py
+++ b/tests/test_working_copy_postgis.py
@@ -52,7 +52,7 @@ def test_checkout_workingcopy(
             assert r.exit_code == 0, r.stderr
             assert (
                 r.stdout.splitlines()[-1]
-                == f"Creating working copy at {strip_password(postgres_url)} ..."
+                == f"Creating PostGIS working copy at {strip_password(postgres_url)} ..."
             )
 
             r = cli_runner.invoke(["status"])

--- a/tests/test_working_copy_sqlserver.py
+++ b/tests/test_working_copy_sqlserver.py
@@ -104,7 +104,7 @@ def test_checkout_workingcopy(
             assert r.exit_code == 0, r.stderr
             assert (
                 r.stdout.splitlines()[-1]
-                == f"Creating working copy at {strip_password(sqlserver_url)} ..."
+                == f"Creating SQL Server working copy at {strip_password(sqlserver_url)} ..."
             )
 
             r = cli_runner.invoke(["status"])


### PR DESCRIPTION
<img src="https://media2.giphy.com/media/JCaztdVFiLu3ZIMRFq/giphy-downsized-medium.gif"/>

Access to working copies should generally go through
the repo.working_copy interface - that way more parts can
be added transparently, since operations can be performed
on all parts at once. This fixes most calls to go via this interface.

Various clean ups:
Got rid of reset_wc_if_needed - its the caller's responsiblity
to decide when and how to reset the WC.
(This was of limited utility anyway since the caller in any case has to
decide whether to check for uncommitted changes and warn the user, etc).

No need for "rewrite_full" - this is just a variation on reset().
No need for "_add_datasets_to_working_copy" - this is also just a reset() operation.

https://github.com/koordinates/kart/issues/565