### PR TITLE
Fix kart branch -o json for empty repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Bugfix: Fixed `kart diff <commit-id>` for a commit containing a dataset that has since been deleted using `kart data rm`. [#611](https://github.com/koordinates/kart/issues/611)
 - Add `ext-run` to provide an execution environment for prototyping ideas/extensions.
 - Added more context about datasets to JSONL diffs. [#624](https://github.com/koordinates/kart/pull/624)
+- Fix `kart branch -o json` when branch HEAD is unborn or repo is empty - this would either fail outright or report that HEAD is on branch "null" which is not exactly true. [#637](https://github.com/koordinates/kart/issues/637)
 
 ## 0.11.1
 

--- a/kart/branch.py
+++ b/kart/branch.py
@@ -46,8 +46,16 @@ def branch(ctx, output_format, args):
 
 def list_branches_json(repo):
     output = {"current": None, "branches": {}}
-    if not repo.is_empty and not repo.head_is_detached:
-        output["current"] = repo.head.shorthand
+
+    if not repo.head_is_detached:
+        if not repo.head_is_unborn:
+            output["current"] = repo.head.shorthand
+        else:
+            target = repo.references.get("HEAD").target
+            if target.startswith("refs/heads/"):
+                target_shorthand = target[len("refs/heads/") :]
+                output["current"] = target_shorthand
+
     branches = {}
     for branch_name in repo.listall_branches():
         branches[branch_name] = branch_obj_to_json(repo, repo.branches[branch_name])

--- a/tests/test_branch.py
+++ b/tests/test_branch.py
@@ -146,7 +146,7 @@ def test_branches_empty(tmp_path, cli_runner, chdir):
         assert text_branches(cli_runner) == []
 
         assert json_branches(cli_runner) == {
-            "kart.branch/v1": {"current": None, "branches": {}}
+            "kart.branch/v1": {"current": "main", "branches": {}}
         }
 
 


### PR DESCRIPTION
<img src="https://media1.giphy.com/media/TgKHZ51jQsNQmLpejG/giphy.gif"/>

Fix `kart branch -o json` when branch HEAD is unborn
 or repo is empty - this would either fail outright
or report that HEAD is on branch "null" which is not exactly true.
When HEAD is unborn, then the HEAD is still on a branch, sort of,
but that branch is unborn. We can still report the name of the
branch, which is more useful than not doing so.

Note that this code no longer checks repo.is_empty - this should generally be avoided since it generally isn't what we care about. In this case we are interested in whether the repo's HEAD branch is unborn. repo.is_empty is poor proxy for this and it's a bit random - even just writing settings to the config can make a repo "non-empty".

## Related links:

https://github.com/koordinates/kart/issues/637

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
