### PR TITLE
Formalise post-commit WC operations

### DIFF
--- a/kart/commit.py
+++ b/kart/commit.py
@@ -157,7 +157,7 @@ def commit(ctx, message, allow_empty, allow_pk_conflicts, output_format, filters
         wc_diff, commit_msg, allow_empty=allow_empty
     )
 
-    repo.working_copy.set_state_post_commit(
+    repo.working_copy.soft_reset_after_commit(
         new_commit,
         quiet=do_json,
         mark_as_clean=commit_diff_writer.repo_key_filter,

--- a/kart/diff_structs.py
+++ b/kart/diff_structs.py
@@ -232,6 +232,15 @@ class RichDict(UserDict):
 
     __repr__ = __str__
 
+    def recursive_len(self, max_depth=None):
+        if max_depth == 1:
+            return len(self)
+        total = 0
+        max_depth = max_depth - 1 if max_depth else None
+        for child in self.values():
+            total += child.recursive_len(max_depth)
+        return total
+
     def recursive_get(self, keys, default=None):
         """Given a list of keys ["a", "b", "c"] returns self["a"]["b"]["c"] if it exists, or default."""
         if len(keys) == 0:
@@ -456,6 +465,9 @@ class DeltaDiff(Diff):
                 return (inf, str(k))
 
         return sorted(self.items(), key=key)
+
+    def recursive_len(self, max_depth=None):
+        return len(self)
 
 
 class DatasetDiff(Diff):

--- a/kart/key_filters.py
+++ b/kart/key_filters.py
@@ -22,6 +22,9 @@ class UserStringKeyFilter(set):
         super().__init__(*args, **kwargs)
         self.match_all = match_all
 
+    def __bool__(self):
+        return self.match_all or bool(len(self))
+
     def __contains__(self, key):
         if self.match_all:
             return True
@@ -38,6 +41,25 @@ class UserStringKeyFilter(set):
     def add(self, key):
         if not self.match_all:
             super().add(key)
+
+    def recursive_len(self, max_depth=None):
+        return len(self)
+
+    def recursive_get(self, keys):
+        # Defining this allows us to call recursive_set on the parents in this way:
+        # repo_key_filter.recursive_get([dataset_path, "feature", feature_key]).
+        # This will return True iff dataset_path:feature:feature_key is contained in
+        # the overall repo_key_filter.
+        assert len(keys) == 1
+        return keys[0] in self
+
+    def recursive_set(self, keys, value):
+        # Defining this allows us to call recursive_set on the parents in this way:
+        # repo_key_filter.recursive_set([dataset_path, "feature", feature_key], True)
+        # to add the given dataset_path:feature:feature_key to the overall filter.
+        assert len(keys) == 1
+        assert value is True
+        self.add(keys[0])
 
 
 UserStringKeyFilter.MATCH_ALL = UserStringKeyFilter(match_all=True)
@@ -58,6 +80,9 @@ class KeyFilterDict(RichDict):
     def __init__(self, *args, match_all=False, **kwargs):
         super().__init__(*args, **kwargs)
         self.match_all = match_all
+
+    def __bool__(self):
+        return self.match_all or bool(len(self))
 
     def __contains__(self, key):
         return self.match_all or super().__contains__(key)

--- a/kart/tabular/working_copy/base.py
+++ b/kart/tabular/working_copy/base.py
@@ -1435,7 +1435,7 @@ class TableWorkingCopy(WorkingCopyPart):
 
             self._mark_as_clean_for_table(sess, base_ds.table_name, feature_filter)
 
-    def set_state_post_commit(
+    def soft_reset_after_commit(
         self,
         target_tree_or_commit,
         *,

--- a/kart/tabular/working_copy/base.py
+++ b/kart/tabular/working_copy/base.py
@@ -734,22 +734,22 @@ class TableWorkingCopy(WorkingCopyPart):
             )
             return (row[0] for row in r)
 
-    def reset_tracking_table(self, repo_key_filter=RepoKeyFilter.MATCH_ALL):
+    def _mark_as_clean(self, sess, repo_key_filter):
         """Delete the rows from the tracking table that match the given filter."""
+        if not repo_key_filter:
+            return
+
         kart_track = self.kart_tables.kart_track
-        with self.session() as sess:
-            if repo_key_filter.match_all:
-                sess.execute(sa.delete(kart_track))
-                return
+        if repo_key_filter.match_all:
+            sess.execute(sa.delete(kart_track))
+            return
 
-            for dataset_path, dataset_filter in repo_key_filter.items():
-                table_name = TableDataset.dataset_path_to_table_name(dataset_path)
-                feature_filter = dataset_filter.get(
-                    "feature", dataset_filter.child_type()
-                )
-                self._reset_tracking_table_for_table(sess, table_name, feature_filter)
+        for dataset_path, dataset_filter in repo_key_filter.items():
+            table_name = TableDataset.dataset_path_to_table_name(dataset_path)
+            feature_filter = dataset_filter.get("feature", dataset_filter.child_type())
+            self._mark_as_clean_for_table(sess, table_name, feature_filter)
 
-    def _reset_tracking_table_for_table(self, sess, table_name, feature_filter):
+    def _mark_as_clean_for_table(self, sess, table_name, feature_filter):
         kart_track = self.kart_tables.kart_track
         if feature_filter.match_all:
             sess.execute(
@@ -977,7 +977,9 @@ class TableWorkingCopy(WorkingCopyPart):
         """Hook for updating the last-modified timestamp stored for a particular dataset, if there is one."""
         pass
 
-    def _write_features(self, sess, dataset, pk_list, *, ignore_missing=False):
+    def _write_features_from_dataset(
+        self, sess, dataset, pk_list, *, ignore_missing=False
+    ):
         """Write the features from the dataset with the given PKs to the table for the dataset."""
         if not pk_list:
             return 0
@@ -998,10 +1000,47 @@ class TableWorkingCopy(WorkingCopyPart):
 
         return feat_count
 
-    def _delete_features(self, sess, dataset, pk_list):
-        """Delete all of the features with the given PKs in the table for the dataset."""
-        if not pk_list:
+    def _delete_features(self, sess, repo_key_filter, track_changes_as_dirty=False):
+        """Deletes the features that match the given repo_key_filter."""
+        if not repo_key_filter:
+            return
+
+        base_tree_id = self.get_tree_id()
+        base_datasets = self.repo.datasets(base_tree_id, "table")
+
+        if repo_key_filter.match_all:
+            for base_ds in base_datasets:
+                with self._suspend_triggers(sess, base_ds):
+                    self._delete_features_from_dataset(
+                        sess,
+                        base_ds,
+                        repo_key_filter.recursive_get(base_ds.path, "feature"),
+                    )
+            return
+
+        for dataset_path, dataset_filter in repo_key_filter.items():
+            base_ds = base_datasets.get(dataset_path)
+            if not base_ds:
+                continue
+            feature_filter = dataset_filter.get("feature", dataset_filter.child_type())
+            with self._suspend_triggers(sess, base_ds):
+                self._delete_features_from_dataset(sess, base_ds, feature_filter)
+
+    def _delete_features_from_dataset(self, sess, dataset, features_to_delete):
+        """
+        Delete all of the features with the given PKs in the table for the dataset.
+        features_to_delete should be a FeatureKeyFilter, or a list of primary key values.
+        """
+        if not features_to_delete:
             return 0
+
+        if isinstance(features_to_delete, FeatureKeyFilter):
+            if features_to_delete.match_all:
+                r = sess.execute(f"DELETE FROM {self.table_identifier(dataset)};")
+                return r.rowcount
+            pk_list = list(features_to_delete)
+        else:
+            pk_list = features_to_delete
 
         pk_column = self.preparer.quote(dataset.primary_key)
         sql = f"""DELETE FROM {self.table_identifier(dataset)} WHERE {pk_column} IN :pks;"""
@@ -1031,17 +1070,6 @@ class TableWorkingCopy(WorkingCopyPart):
                     )
                 )
                 self._drop_sequence(sess, dataset)
-
-    def drop_features(self, pk_lists):
-        """
-        Drop the given features from the given datasets.
-        Doesn't do any further work like modifying the kart_track table in any way.
-        """
-        base_tree_id = self.get_tree_id()
-        base_datasets = self.repo.datasets(base_tree_id, "table")
-        with self.session() as sess:
-            for ds_path, pk_list in pk_lists.items():
-                self._delete_features(sess, base_datasets[ds_path], pk_list)
 
     def _delete_meta(self, sess, dataset):
         """
@@ -1298,8 +1326,8 @@ class TableWorkingCopy(WorkingCopyPart):
             ctx = contextlib.nullcontext()
 
         with ctx:
-            self._delete_features(sess, target_ds, pks)
-            self._write_features(sess, target_ds, pks, ignore_missing=True)
+            self._delete_features_from_dataset(sess, target_ds, pks)
+            self._write_features_from_dataset(sess, target_ds, pks, ignore_missing=True)
 
     def _is_meta_update_supported(self, meta_diff):
         """
@@ -1394,19 +1422,41 @@ class TableWorkingCopy(WorkingCopyPart):
             # todo: suspend/remove spatial index
             L.debug("Cleaning up dirty rows...")
 
-            count = self._delete_features(sess, base_ds, dirty_pk_list)
+            count = self._delete_features_from_dataset(sess, base_ds, dirty_pk_list)
             L.debug(
                 f"_reset_dirty_rows(): removed {count} features, tracking Δ count={track_count}"
             )
-            count = self._write_features(
+            count = self._write_features_from_dataset(
                 sess, base_ds, dirty_pk_list, ignore_missing=True
             )
             L.debug(
                 f"_reset_dirty_rows(): wrote {count} features, tracking Δ count={track_count}"
             )
 
-            self._reset_tracking_table_for_table(
-                sess, base_ds.table_name, feature_filter
+            self._mark_as_clean_for_table(sess, base_ds.table_name, feature_filter)
+
+    def set_state_post_commit(
+        self,
+        target_tree_or_commit,
+        *,
+        mark_as_clean=None,
+        now_outside_spatial_filter=None,
+    ):
+        """
+        Marks the working copy as now being based on the given target tree or commit.
+        mark_as_clean - a RepoKeyFilter - deletes these PKs from the tracking table.
+        now_outside_spatial_filter - a RepoKeyFilter - drops any features that match now_outside_spatial_filter altogether.
+        """
+        tree_id = (
+            target_tree_or_commit.peel(pygit2.Tree).hex
+            if target_tree_or_commit
+            else None
+        )
+        with self.session() as sess:
+            self._update_state_table_tree(sess, tree_id)
+            self._mark_as_clean(sess, mark_as_clean)
+            self._delete_features(
+                sess, now_outside_spatial_filter, track_changes_as_dirty=False
             )
 
 

--- a/kart/working_copy.py
+++ b/kart/working_copy.py
@@ -242,7 +242,7 @@ class WorkingCopy:
                 rewrite_full=rewrite_full,
             )
 
-    def set_state_post_commit(
+    def soft_reset_after_commit(
         self,
         commit_or_tree,
         *,
@@ -273,7 +273,7 @@ class WorkingCopy:
             )
 
         for p in self.parts():
-            p.set_state_post_commit(
+            p.soft_reset_after_commit(
                 commit_or_tree,
                 mark_as_clean=mark_as_clean,
                 now_outside_spatial_filter=now_outside_spatial_filter,
@@ -334,7 +334,7 @@ class WorkingCopyPart:
     ):
         raise NotImplementedError()
 
-    def set_state_post_commit(
+    def soft_reset_after_commit(
         self,
         commit_or_tree,
         *,

--- a/kart/working_copy.py
+++ b/kart/working_copy.py
@@ -204,6 +204,8 @@ class WorkingCopy:
     ):
         """
         Resets the working copy to the given target-tree (or the tree pointed to by the given target-commit).
+        This is called when we want to move content from the Kart repo ODB into the working copy - ie, during
+        create-workingcopy, checkout, switch, restore, reset.
 
         Any existing changes which match the repo_key_filter will be discarded. Existing changes which do not
         math the repo_key_filter will be kept.
@@ -238,6 +240,43 @@ class WorkingCopy:
                 repo_key_filter=repo_key_filter,
                 track_changes_as_dirty=track_changes_as_dirty,
                 rewrite_full=rewrite_full,
+            )
+
+    def set_state_post_commit(
+        self,
+        commit_or_tree,
+        *,
+        quiet=False,
+        mark_as_clean=None,
+        now_outside_spatial_filter=None,
+    ):
+        """
+        Like a reset, this marks the working copy as now being based on the given target-tree (or the tree in the given
+        target-commit). Unlike a reset, this doesn't update the dataset contents - this is called post-commit, so the
+        overall flow of dataset contents is from working copy into the Kart repo ODB. However, we still need to tidy up
+        a few things afterwards:
+        - the working copy is now based on the newly created commit, not the previous commit which is now the parent.
+        - all of the dataset contents that were committed should no longer be tracked as dirty - it can be marked as clean.
+        - newly committed features which are outside the spatial filter should be removed from the working copy, since they
+          are no longer dirty and now no different to anything else outside the spatial filter.
+
+        mark_as_clean - a RepoKeyFilter of what was committed and can be marked as clean. Most commonly, this is simply
+            RepoKeyFilter.MATCH_ALL
+        now_outside_spatial_filter - a RepoKeyFilter of the newly committed features that can simply be dropped since
+            they are outside the spatial filter.
+        """
+        if now_outside_spatial_filter and not quiet:
+            # TODO we currently only check if vector features match the filter - no other dataset types are supported.
+            total_count = now_outside_spatial_filter.recursive_len()
+            click.echo(
+                f"Removing {total_count} features from the working copy that no longer match the spatial filter..."
+            )
+
+        for p in self.parts():
+            p.set_state_post_commit(
+                commit_or_tree,
+                mark_as_clean=mark_as_clean,
+                now_outside_spatial_filter=now_outside_spatial_filter,
             )
 
 
@@ -292,5 +331,14 @@ class WorkingCopyPart:
         repo_key_filter=RepoKeyFilter.MATCH_ALL,
         track_changes_as_dirty=False,
         rewrite_full=False,
+    ):
+        raise NotImplementedError()
+
+    def set_state_post_commit(
+        self,
+        commit_or_tree,
+        *,
+        mark_as_clean=None,
+        now_outside_spatial_filter=None,
     ):
         raise NotImplementedError()

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -106,7 +106,7 @@ def test_commit(
         else:
             assert (
                 change_count == 0
-            ), f"Changes still listed in {table_wc.TRACKING_TABLE} after full commit"
+            ), f"Changes still listed in {table_wc.KART_TRACK_NAME} after full commit"
 
             r = cli_runner.invoke(["diff", "--exit-code"])
             assert r.exit_code == 0, r

--- a/tests/test_working_copy_gpkg.py
+++ b/tests/test_working_copy_gpkg.py
@@ -616,7 +616,7 @@ def test_geopackage_locking_edit(data_working_copy, cli_runner, monkeypatch):
         table_wc = KartRepo(repo_path).working_copy.tabular
 
         is_checked = False
-        orig_func = TableWorkingCopy._write_features
+        orig_func = TableWorkingCopy._write_features_from_dataset
 
         def _wrap(*args, **kwargs):
             nonlocal is_checked
@@ -630,7 +630,7 @@ def test_geopackage_locking_edit(data_working_copy, cli_runner, monkeypatch):
 
             return orig_func(*args, **kwargs)
 
-        monkeypatch.setattr(TableWorkingCopy, "_write_features", _wrap)
+        monkeypatch.setattr(TableWorkingCopy, "_write_features_from_dataset", _wrap)
 
         r = cli_runner.invoke(["checkout", H.POINTS.HEAD1_SHA])
         assert r.exit_code == 0, r


### PR DESCRIPTION
<img src="https://media3.giphy.com/media/eoIqbd2HHaKSQ/giphy.gif"/>

After committing we need to do any/all of the following:
- update the WC to be tracking the latest commit-tree
- clear some PKs from the tracking table so they are no longer marked
  as dirty
- drop some features from the WC if they are outside the spatial filter

This adds that compound-operation to the WC, and tidies up the names
etc of some of the sub-operations (eg mark_as_clean is clearer than
reset_tracking_table). It also switches these methods to take key_filters
instead of ad-hoc structures like dicts or lists, which makes them
a little more self-documenting.

https://github.com/koordinates/kart/issues/565
