### PR TITLE
Add --with-dataset-types to `kart meta get`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 - Changed format of feature IDs in GeoJSON output to be more informative and consistent. [#135](https://github.com/koordinates/kart/issues/135)
 - Fixed primary key issues for shapefile import - now generates an `auto_pk` by default, but uses an existing field if specified (doesn't use the FID). [#646](https://github.com/koordinates/kart/pull/646)
+- Add `--with-dataset-types` option to `kart meta get` which is informative now that there is more than one type of dataset. [#649](https://github.com/koordinates/kart/pull/649) 
 
 ## 0.11.3
 

--- a/kart/meta.py
+++ b/kart/meta.py
@@ -53,10 +53,15 @@ def meta(ctx, **kwargs):
     help="[deprecated] How to format the JSON output. Only used with -o json",
 )
 @click.option("--ref", default="HEAD")
+@click.option(
+    "--with-dataset-types",
+    is_flag=True,
+    help="When set, includes the dataset type and version as pseudo meta-items (these cannot be updated).",
+)
 @click.argument("dataset", required=False)
 @click.argument("keys", required=False, nargs=-1)
 @click.pass_context
-def meta_get(ctx, output_format, json_style, ref, dataset, keys):
+def meta_get(ctx, output_format, json_style, ref, with_dataset_types, dataset, keys):
     """
     Prints the value of meta keys.
 
@@ -80,6 +85,12 @@ def meta_get(ctx, output_format, json_style, ref, dataset, keys):
             all_items[ds.path] = get_meta_items(ds, keys)
         else:
             all_items[ds.path] = ds.meta_items()
+        if with_dataset_types:
+            all_items[ds.path] = {
+                "datasetType": ds.DATASET_TYPE,
+                "version": ds.VERSION,
+                **all_items[ds.path],
+            }
 
     output_type, fmt = parse_output_format(output_format, json_style)
 

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -22,9 +22,6 @@ class TestMetaGet:
 
     @pytest.mark.parametrize("output_format", ("text", "json"))
     def test_all(self, output_format, data_archive_readonly, cli_runner):
-        # All datasets now support getting metadata in either V1 or V2 format,
-        # but if you don't specify a particular item, they will show all V2 items -
-        # these are more self-explanatory to an end-user.
         with data_archive_readonly("points"):
             r = cli_runner.invoke(
                 ["meta", "get", "nz_pa_points_topo_150k", "-o", output_format]
@@ -39,6 +36,38 @@ class TestMetaGet:
             else:
                 output = json.loads(r.stdout)
                 output = output["nz_pa_points_topo_150k"]
+                assert output["title"] == EXPECTED_TITLE
+                assert output["description"]
+                assert output["schema.json"]
+                assert output["crs/EPSG:4326.wkt"]
+
+    @pytest.mark.parametrize("output_format", ("text", "json"))
+    def test_with_dataset_types(self, output_format, data_archive_readonly, cli_runner):
+        with data_archive_readonly("points"):
+            r = cli_runner.invoke(
+                [
+                    "meta",
+                    "get",
+                    "nz_pa_points_topo_150k",
+                    "--with-dataset-types",
+                    "-o",
+                    output_format,
+                ]
+            )
+            assert r.exit_code == 0, r
+            if output_format == "text":
+                assert "datasetType" in r.stdout
+                assert "version" in r.stdout
+                assert "title" in r.stdout
+                assert EXPECTED_TITLE in r.stdout
+                assert "description" in r.stdout
+                assert "schema.json" in r.stdout
+                assert "crs/EPSG:4326.wkt" in r.stdout
+            else:
+                output = json.loads(r.stdout)
+                output = output["nz_pa_points_topo_150k"]
+                assert output["datasetType"] == "table"
+                assert output["version"] == 3
                 assert output["title"] == EXPECTED_TITLE
                 assert output["description"]
                 assert output["schema.json"]


### PR DESCRIPTION
<img src="https://media0.giphy.com/media/rIq6ASPIqo2k0/giphy.gif"/>

Simply adds two fields to each dataset's meta output:
"datasetType" and "version"
datasetType is always a string, and version is always an integer. 

Existing datasets will mostly be datasetType="table", version=3
Experimental point cloud datasets are datasetType="point-cloud" version=1

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
