### PR TITLE
PC: Restores and resets

### DIFF
--- a/kart/diff_structs.py
+++ b/kart/diff_structs.py
@@ -121,6 +121,9 @@ class Delta:
     def new_key(self):
         return self.new.key if self.new is not None else None
 
+    def is_rename(self):
+        return self.type == "update" and self.old_key != self.new_key
+
     @property
     def old_value(self):
         if self.old is not None:

--- a/kart/workdir.py
+++ b/kart/workdir.py
@@ -349,7 +349,7 @@ class FileSystemWorkingCopy(WorkingCopyPart):
             assert isinstance(dataset, PointCloudV1)
 
             reset_index_paths.append(dataset.path)
-            ds_tiles_dir = self.path / dataset.path
+            ds_tiles_dir = (self.path / dataset.path).resolve()
             # Sanity check to make sure we're not deleting something we shouldn't.
             assert self.path in ds_tiles_dir.parents
             assert self.repo.workdir_path in ds_tiles_dir.parents
@@ -361,7 +361,7 @@ class FileSystemWorkingCopy(WorkingCopyPart):
     def _update_dataset_in_workdir(
         self, ds_path, diff_to_apply, ds_filter, track_changes_as_dirty
     ):
-        ds_tiles_dir = self.path / ds_path
+        ds_tiles_dir = (self.path / ds_path).resolve()
         # Sanity check to make sure we're not messing with files we shouldn't:
         assert self.path in ds_tiles_dir.parents
         assert self.repo.workdir_path in ds_tiles_dir.parents


### PR DESCRIPTION
<img src="https://media3.giphy.com/media/TWTCdemH9OoEmx3iYq/giphy.gif"/>

Finish off working-copy.reset() for PC working copy part.
Don't reset PC datasets in the WC by fully rewriting them every time: instead,
make only the necessary changes to get it to the target state.
With this change, resets and restores start working properly, including
partial restores eg `kart restore -s COMMIT dataset:tile:tile-to-restore`

https://github.com/koordinates/kart/issues/565
