### PR TITLE
Support tab completion in powershell for kart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## 0.11.4 (UNRELEASED)
 
+- Support tab completion in powershell for kart. [#643](https://github.com/koordinates/kart/issues/643)
 - Add `--install-tab-completion` option for installing shell completion. [#643](https://github.com/koordinates/kart/issues/643)
 - Add tab completion for kart commands and user-specific data. [#643](https://github.com/koordinates/kart/issues/643)
 - Changed format of feature IDs in GeoJSON output to be more informative and consistent. [#135](https://github.com/koordinates/kart/issues/135)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ attrs==21.4.0
     # via jsonschema
 cached-property==1.5.2
     # via pygit2
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via -r requirements/requirements.in
 cffi==1.15.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,7 +13,7 @@ attrs==21.4.0
     #   pytest
 backcall==0.2.0
     # via ipython
-colorama==0.4.4
+colorama==0.4.5
     # via
     #   -c requirements/docs.txt
     #   -c requirements/test.txt
@@ -96,7 +96,7 @@ tomli==2.0.1
     # via
     #   -c requirements/test.txt
     #   pytest
-traitlets==5.2.2.post1
+traitlets==5.3.0
     # via
     #   ipython
     #   matplotlib-inline

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,15 +6,15 @@
 #
 alabaster==0.7.12
     # via sphinx
-babel==2.10.2
+babel==2.10.3
     # via sphinx
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via
     #   -c requirements/../requirements.txt
     #   requests
 charset-normalizer==2.0.12
     # via requests
-colorama==0.4.4
+colorama==0.4.5
     # via
     #   -c requirements/test.txt
     #   sphinx-autobuild
@@ -63,7 +63,7 @@ sphinx-autobuild==2021.3.14
     # via -r requirements/docs.in
 sphinx-rtd-theme==1.0.0
     # via -r requirements/docs.in
-sphinx==5.0.1
+sphinx==5.0.2
     # via
     #   sphinx-autobuild
     #   sphinx-rtd-theme

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,7 +12,7 @@ attrs==21.4.0
     # via
     #   -c requirements/../requirements.txt
     #   pytest
-colorama==0.4.4
+colorama==0.4.5
     # via -r requirements/test.in
 coverage[toml]==6.4.1
     # via pytest-cov


### PR DESCRIPTION
Added tab completion support for Powershell (or `pwsh`). Run the following command to install:
```sh
kart config --install-tab-completion pwsh # (powershell or auto works too)
```

## Related links:
- #643 

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
