### PR TITLE
add man-page installation mechanism 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,14 @@ vendor-install:
 	-$(RM) $(vendor-install)
 	$(MAKE) $(vendor-install)
 
+man-build := $(VIRTUAL_ENV)/man
+
+.PHONY: man
+man:
+	click-man --target $(man-build) kart
+	gzip -f $(man-build)/*
+	sudo mv -f $(man-build)/* /usr/share/man/man1
+
 # Install Python (just release) dependencies
 .PHONY: py-deps
 py-deps: $(vendor-install) $(py-install-main) | $(VIRTUAL_ENV)
@@ -145,6 +153,7 @@ py-deps: $(vendor-install) $(py-install-main) | $(VIRTUAL_ENV)
 # Install Python (development & release) py-deps
 .PHONY: py-deps-dev
 py-deps-dev: py-deps $(py-install-dev) $(py-install-tools)
+
 
 # App code
 kart-app-release = $(VIRTUAL_ENV)/$(PY_SITEPACKAGES)/kart

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,19 +8,23 @@ attrs==21.4.0
     # via jsonschema
 cached-property==1.5.2
     # via pygit2
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via -r requirements/requirements.in
-cffi==1.15.0
+cffi==1.15.1
     # via
     #   cryptography
     #   pygit2
-click==8.1.3
+click-man==0.4.1
     # via -r requirements/requirements.in
+click==8.1.3
+    # via
+    #   -r requirements/requirements.in
+    #   click-man
 cryptography==37.0.2
     # via -r requirements/requirements.in
 greenlet==1.1.2
     # via sqlalchemy
-importlib-metadata==4.11.4
+importlib-metadata==4.12.0
     # via
     #   click
     #   jsonschema
@@ -47,9 +51,9 @@ rtree==0.9.7
     # via -r requirements/requirements.in
 shellingham==1.4.0
     # via -r requirements/requirements.in
-sqlalchemy==1.4.37
+sqlalchemy==1.4.39
     # via -r requirements/requirements.in
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via importlib-metadata
 zipp==3.8.0
     # via importlib-metadata

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,7 +13,7 @@ attrs==21.4.0
     #   pytest
 backcall==0.2.0
     # via ipython
-colorama==0.4.4
+colorama==0.4.5
     # via
     #   -c requirements/docs.txt
     #   -c requirements/test.txt
@@ -24,7 +24,7 @@ decorator==5.1.1
     #   ipython
 execnet==1.9.0
     # via pytest-xdist
-importlib-metadata==4.11.4
+importlib-metadata==4.12.0
     # via
     #   -c requirements/../requirements.txt
     #   -c requirements/docs.txt
@@ -62,7 +62,7 @@ pluggy==1.0.0
     # via
     #   -c requirements/test.txt
     #   pytest
-prompt-toolkit==3.0.29
+prompt-toolkit==3.0.30
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
@@ -96,11 +96,11 @@ tomli==2.0.1
     # via
     #   -c requirements/test.txt
     #   pytest
-traitlets==5.2.2.post1
+traitlets==5.3.0
     # via
     #   ipython
     #   matplotlib-inline
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via
     #   -c requirements/../requirements.txt
     #   -c requirements/docs.txt

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,15 +6,15 @@
 #
 alabaster==0.7.12
     # via sphinx
-babel==2.10.2
+babel==2.10.3
     # via sphinx
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via
     #   -c requirements/../requirements.txt
     #   requests
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via requests
-colorama==0.4.4
+colorama==0.4.5
     # via
     #   -c requirements/test.txt
     #   sphinx-autobuild
@@ -24,9 +24,9 @@ docutils==0.17.1
     #   sphinx-rtd-theme
 idna==3.3
     # via requests
-imagesize==1.3.0
+imagesize==1.4.1
     # via sphinx
-importlib-metadata==4.11.4
+importlib-metadata==4.12.0
     # via
     #   -c requirements/../requirements.txt
     #   -c requirements/test.txt
@@ -51,7 +51,7 @@ pyparsing==3.0.9
     #   packaging
 pytz==2022.1
     # via babel
-requests==2.28.0
+requests==2.28.1
     # via sphinx
 six==1.16.0
     # via
@@ -63,7 +63,7 @@ sphinx-autobuild==2021.3.14
     # via -r requirements/docs.in
 sphinx-rtd-theme==1.0.0
     # via -r requirements/docs.in
-sphinx==5.0.1
+sphinx==5.0.2
     # via
     #   sphinx-autobuild
     #   sphinx-rtd-theme
@@ -79,9 +79,9 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-tornado==6.1
+tornado==6.2
     # via livereload
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via
     #   -c requirements/../requirements.txt
     #   -c requirements/test.txt

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -8,6 +8,7 @@ Rtree~=0.9.4
 sqlalchemy
 pyodbc ; platform_system!="Linux"
 shellingham
+click-man
 
 # jsonschema>=4.2 pulls in importlib_resources, which breaks PyInstaller<4.8
 # https://github.com/pyinstaller/pyinstaller/pull/6195

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,7 +12,7 @@ attrs==21.4.0
     # via
     #   -c requirements/../requirements.txt
     #   pytest
-colorama==0.4.4
+colorama==0.4.5
     # via -r requirements/test.in
 coverage[toml]==6.4.1
     # via pytest-cov
@@ -22,7 +22,7 @@ gprof2dot==2021.2.21
     # via pytest-profiling
 html5lib==1.1
     # via -r requirements/test.in
-importlib-metadata==4.11.4
+importlib-metadata==4.12.0
     # via
     #   -c requirements/../requirements.txt
     #   pluggy
@@ -47,7 +47,7 @@ pytest-cov==3.0.0
     # via -r requirements/test.in
 pytest-helpers-namespace==2021.12.29
     # via -r requirements/test.in
-pytest-mock==3.7.0
+pytest-mock==3.8.1
     # via -r requirements/test.in
 pytest-profiling==1.7.0
     # via -r requirements/test.in
@@ -75,7 +75,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via
     #   -c requirements/../requirements.txt
     #   importlib-metadata


### PR DESCRIPTION
## Description
Run the following command to build man pages using [click-man](https://github.com/click-contrib/click-man).
```
make man
```
Using [sphinx-click](https://github.com/click-contrib/sphinx-click) to make man pages with `sphinx build` doesn't seem to be ideal as it seems to do a better job rendering HTML than man-style output in comparison to [click-man](https://github.com/click-contrib/click-man). 

## Related links:
- #658 

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
