### PR TITLE
Add basic support for --convert-to-dataset-format

### DIFF
--- a/kart/base_diff_writer.py
+++ b/kart/base_diff_writer.py
@@ -111,6 +111,7 @@ class BaseDiffWriter:
         self.target_crs = target_crs
 
         self.commit = None
+        self.do_convert_to_dataset_format = False
 
     def include_target_commit_as_header(self):
         """
@@ -118,6 +119,9 @@ class BaseDiffWriter:
         with all the info for commit C.
         """
         self.commit = self.target_rs.commit
+
+    def convert_to_dataset_format(self, do_convert_to_dataset_format=True):
+        self.do_convert_to_dataset_format = do_convert_to_dataset_format
 
     @classmethod
     def _normalize_output_path(cls, output_path):
@@ -251,6 +255,7 @@ class BaseDiffWriter:
             include_wc_diff=self.include_wc_diff,
             workdir_diff_cache=self.workdir_diff_cache,
             repo_key_filter=self.repo_key_filter,
+            convert_to_dataset_format=self.do_convert_to_dataset_format,
         )
 
     def get_dataset_diff(self, ds_path):
@@ -272,6 +277,7 @@ class BaseDiffWriter:
             include_wc_diff=self.include_wc_diff,
             workdir_diff_cache=self.workdir_diff_cache,
             ds_filter=self.repo_key_filter[ds_path],
+            convert_to_dataset_format=self.do_convert_to_dataset_format,
         )
 
     def _unfiltered_ds_feature_deltas(self, ds_path, ds_diff):

--- a/kart/commit.py
+++ b/kart/commit.py
@@ -101,6 +101,15 @@ class CommitDiffWriter(BaseDiffWriter):
     ),
 )
 @click.option(
+    "--convert-to-dataset-format",
+    is_flag=True,
+    default=False,
+    help=(
+        "Converts any new files in-place, where needed, to ensure they match the existing dataset's format, immediately "
+        "before they are committed."
+    ),
+)
+@click.option(
     "--output-format",
     "-o",
     type=click.Choice(["text", "json"]),
@@ -110,7 +119,15 @@ class CommitDiffWriter(BaseDiffWriter):
     "filters",
     nargs=-1,
 )
-def commit(ctx, message, allow_empty, allow_pk_conflicts, output_format, filters):
+def commit(
+    ctx,
+    message,
+    allow_empty,
+    allow_pk_conflicts,
+    convert_to_dataset_format,
+    output_format,
+    filters,
+):
     """
     Record a snapshot of all of the changes to the repository.
 
@@ -124,6 +141,7 @@ def commit(ctx, message, allow_empty, allow_pk_conflicts, output_format, filters
     check_git_user(repo)
 
     commit_diff_writer = CommitDiffWriter(repo, "HEAD", filters)
+    commit_diff_writer.convert_to_dataset_format(convert_to_dataset_format)
     wc_diff = commit_diff_writer.get_repo_diff()
 
     if not wc_diff and not allow_empty:

--- a/kart/dataset_mixins.py
+++ b/kart/dataset_mixins.py
@@ -40,7 +40,11 @@ class DatasetDiffMixin:
         return DeltaDiff.diff_dicts(meta_old, meta_new)
 
     def diff_to_working_copy(
-        self, workdir_diff_cache, ds_filter=DatasetKeyFilter.MATCH_ALL
+        self,
+        workdir_diff_cache,
+        ds_filter=DatasetKeyFilter.MATCH_ALL,
+        *,
+        convert_to_dataset_format=False,
     ):
         """
         Generates a diff from self to the working-copy.

--- a/kart/diff.py
+++ b/kart/diff.py
@@ -115,6 +115,12 @@ def feature_count_diff(
         "the stream when it is ready. If the estimate is not ready before the process exits, it will not be added."
     ),
 )
+@click.option(
+    "--convert-to-dataset-format",
+    is_flag=True,
+    help="Ignores file format differences in any new files when generating the diff - assumes that the new files will "
+    "also committed using --convert-to-dataset-format, so the conversion step will remove the format differences.",
+)
 @click.argument("commit_spec", required=False, nargs=1)
 @click.argument("filters", nargs=-1)
 def diff(
@@ -128,6 +134,7 @@ def diff(
     commit_spec,
     filters,
     add_feature_count_estimate,
+    convert_to_dataset_format,
 ):
     """
     Show changes between two commits, or between a commit and the working copy.
@@ -171,6 +178,7 @@ def diff(
         target_crs=crs,
         diff_estimate_accuracy=add_feature_count_estimate,
     )
+    diff_writer.convert_to_dataset_format(convert_to_dataset_format)
     diff_writer.write_diff()
 
     if exit_code or output_type == "quiet":

--- a/kart/diff_util.py
+++ b/kart/diff_util.py
@@ -40,6 +40,7 @@ def get_repo_diff(
     include_wc_diff=False,
     workdir_diff_cache=None,
     repo_key_filter=RepoKeyFilter.MATCH_ALL,
+    convert_to_dataset_format=False,
 ):
     """
     Generates a RepoDiff containing an entry for every dataset in the repo
@@ -67,6 +68,7 @@ def get_repo_diff(
             include_wc_diff=include_wc_diff,
             workdir_diff_cache=workdir_diff_cache,
             ds_filter=repo_key_filter[ds_path],
+            convert_to_dataset_format=convert_to_dataset_format,
         )
     # No need to recurse since self.get_dataset_diff already prunes the dataset diffs.
     repo_diff.prune(recurse=False)
@@ -81,6 +83,7 @@ def get_dataset_diff(
     include_wc_diff=False,
     workdir_diff_cache=None,
     ds_filter=DatasetKeyFilter.MATCH_ALL,
+    convert_to_dataset_format=False,
 ):
     """
     Generates the DatasetDiff for the dataset at path dataset_path.
@@ -120,7 +123,9 @@ def get_dataset_diff(
 
         if target_ds is not None:
             target_wc_diff = target_ds.diff_to_working_copy(
-                workdir_diff_cache, ds_filter=ds_filter
+                workdir_diff_cache,
+                ds_filter=ds_filter,
+                convert_to_dataset_format=convert_to_dataset_format,
             )
             L.debug(
                 "target<>working_copy diff (%s): %s",

--- a/kart/point_cloud/import_.py
+++ b/kart/point_cloud/import_.py
@@ -33,6 +33,7 @@ from kart.point_cloud.metadata_util import (
     rewrite_and_merge_metadata,
     check_for_non_homogenous_metadata,
     format_tile_info_for_pointer_file,
+    set_file_extension,
 )
 from kart.serialise_util import hexhash, json_pack, ensure_bytes
 from kart.tabular.version import (
@@ -165,8 +166,7 @@ def point_cloud_import(ctx, convert_to_copc, ds_path, do_checkout, sources):
             pointer_dict.update(
                 format_tile_info_for_pointer_file(source_to_metadata[source]["tile"])
             )
-            # TODO - is this the right prefix and name?
-            tilename = _remove_las_ext(os.path.basename(source)) + import_ext
+            tilename = set_file_extension(os.path.basename(source), import_ext)
             tile_prefix = hexhash(tilename)[0:2]
             blob_path = f"{ds_inner_path}/tile/{tile_prefix}/{tilename}"
             write_blob_to_stream(

--- a/kart/tabular/rich_table_dataset.py
+++ b/kart/tabular/rich_table_dataset.py
@@ -175,7 +175,11 @@ class RichTableDataset(TableDataset):
         return ds_diff
 
     def diff_to_working_copy(
-        self, workdir_diff_cache, ds_filter=DatasetKeyFilter.MATCH_ALL
+        self,
+        workdir_diff_cache,
+        ds_filter=DatasetKeyFilter.MATCH_ALL,
+        *,
+        convert_to_dataset_format=False,
     ):
         table_wc = self.repo.working_copy.tabular
         if table_wc is None:


### PR DESCRIPTION
<img src="https://media1.giphy.com/media/cOESitZBfs4UrObPjg/giphy.gif"/>

This flag is now supported by PC datasets when generating WC diffs.

`kart commit` has partial support of this flag, but only insofar
as it respects it while it generates the high-level diff of what is
to be committed - it doesn't yet actually perform the in-place
conversion of the PC tiles in the WC that need to be converted,
instead exiting with NOT_YET_IMPLEMENTED if it encounters such a tile.

https://github.com/koordinates/kart/issues/565