### PR TITLE
Add check for `.bash_profile` for MacOS

### DIFF
--- a/kart/completion.py
+++ b/kart/completion.py
@@ -1,6 +1,7 @@
 import os
 import re
 import sys
+import platform
 import subprocess
 from enum import Enum
 from pathlib import Path
@@ -100,6 +101,9 @@ def install_bash(*, prog_name: str, complete_var: str, shell: str) -> Path:
     # But installing in the locations from the docs doesn't seem to have effect
     completion_path = Path.home() / f".bash_completions/{prog_name}.sh"
     bashrc_path = Path.home() / ".bashrc"
+    bash_profile = Path.home() / ".bash_profile"
+    if platform.system() == "Darwin" and bash_profile.exists():
+        bashrc_path = bash_profile
     completion_init_lines = [f"source {completion_path}"]
     return install_helper(
         prog_name,

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,4 +1,5 @@
 import os
+import platform
 from pathlib import Path
 import subprocess
 
@@ -19,7 +20,10 @@ def test_completion_install_no_shell(cli_runner):
 
 
 def test_completion_install_bash(cli_runner):
-    bash_completion_path: Path = Path.home() / ".bashrc"
+    bash_completion_path = Path.home() / ".bashrc"
+    bash_profile = Path.home() / ".bash_profile"
+    if platform.system() == "Darwin" and bash_profile.exists():
+        bash_completion_path = bash_profile
     text = ""
     if bash_completion_path.is_file():
         text = bash_completion_path.read_text()


### PR DESCRIPTION
## Description

`.bash_profile` seems to ship as a default in some MacOS systems. If the user hasn't sourced the `.bashrc` file in the `.bash_profle` the tab completion scripts my not be activated in the current session. To remedy that we can append to `~/.bash_profile` on Darwin systems instead.

## Related links:
- #643 

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?