### PR TITLE
Support kart commit --convert-to-dataset-format

### DIFF
--- a/kart/point_cloud/pdal_convert.py
+++ b/kart/point_cloud/pdal_convert.py
@@ -1,0 +1,73 @@
+import json
+
+from kart.exceptions import InvalidOperation, INVALID_FILE_FORMAT
+from kart.point_cloud.metadata_util import is_copc, get_las_version
+
+
+def convert_tile_to_format(source, dest, target_format):
+    """
+    Converts some sort of a .las/.laz file at source to a tile of the given format at dest.
+    """
+    if is_copc(target_format):
+        return convert_tile_to_copc(source, dest)
+    else:
+        return convert_tile_to_laz(source, dest, target_format)
+
+
+def convert_tile_to_copc(source, dest):
+    """
+    Converts some sort of a .las/.laz file at source to a .copc.laz file at dest.
+    """
+    import pdal
+
+    config = [
+        {
+            "type": "readers.las",
+            "filename": str(source),
+        },
+        {
+            "type": "writers.copc",
+            "filename": str(dest),
+            "forward": "all",
+        },
+    ]
+    pipeline = pdal.Pipeline(json.dumps(config))
+    try:
+        pipeline.execute()
+    except RuntimeError as e:
+        raise InvalidOperation(
+            f"Error converting {source}\n{e}", exit_code=INVALID_FILE_FORMAT
+        )
+    assert dest.is_file()
+
+
+def convert_tile_to_laz(source, dest, target_format):
+    """
+    Converts some sort of .las/.laz at source to some sort of .laz file at dest.
+    """
+    import pdal
+
+    major_version, minor_version = get_las_version(target_format).split(".", maxsplit=1)
+
+    config = [
+        {
+            "type": "readers.las",
+            "filename": str(source),
+        },
+        {
+            "type": "writers.las",
+            "filename": str(dest),
+            "forward": "all",
+            "compression": True,
+            "major_version": major_version,
+            "minor_version": minor_version,
+        },
+    ]
+    pipeline = pdal.Pipeline(json.dumps(config))
+    try:
+        pipeline.execute()
+    except RuntimeError as e:
+        raise InvalidOperation(
+            f"Error converting {source}\n{e}", exit_code=INVALID_FILE_FORMAT
+        )
+    assert dest.is_file()


### PR DESCRIPTION
<img src="https://media0.giphy.com/media/14y3bdRzH8aT0k/giphy.gif"/>

Finds the "(TBD)" placeholders in the generated diff and uses them as a signal
that it has to convert what's in the working copy to the specified format. 

Still TODO:
- The working copy isn't reset properly after the commit - it is only
"soft reset". That means any tiles that were converted during the commit
will still be in the wrong format in the working copy.

- Need more work on matching tilenames despite changing extensions.
Probably this means storing tilenames without their extensions, but
could just mean taking some extra care in the case where a single
conceptual tile may have more than one extension (such as during
--convert-to-dataset-format)

- Nothing is output while the user waits during the conversion

https://github.com/koordinates/kart/issues/565