### PR TITLE
Support `kart diff COMMIT1 COMMIT2` [#666]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Changed format of feature IDs in GeoJSON output to be more informative and consistent. [#135](https://github.com/koordinates/kart/issues/135)
 - Fixed primary key issues for shapefile import - now generates an `auto_pk` by default, but uses an existing field if specified (doesn't use the FID). [#646](https://github.com/koordinates/kart/pull/646)
 - Add `--with-dataset-types` option to `kart meta get` which is informative now that there is more than one type of dataset. [#649](https://github.com/koordinates/kart/pull/649)
+- Support `kart diff COMMIT1 COMMIT2` as an alternative to typing `kart diff COMMIT1...COMMIT2` [#666](https://github.com/koordinates/kart/issues/666)
 
 ## 0.11.3
 

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1092,12 +1092,14 @@ def test_diff_rev_rev(head_sha, head1_sha, data_archive_readonly, cli_runner):
         f"{head1_sha}...{head_sha}",
         f"{head1_sha}...",
         "HEAD^1...HEAD",
+        ["HEAD^1", "HEAD"],
     )
 
     R_SPECS = (
         f"{head_sha}...{head1_sha}",
         f"...{head1_sha}",
         "HEAD...HEAD^1",
+        ["HEAD", "HEAD^1"],
     )
 
     CHANGE_IDS = {
@@ -1111,7 +1113,9 @@ def test_diff_rev_rev(head_sha, head1_sha, data_archive_readonly, cli_runner):
     with data_archive_readonly("points"):
         for spec in F_SPECS:
             print(f"fwd: {spec}")
-            r = cli_runner.invoke(["diff", "--exit-code", "-o", "json", spec])
+            if isinstance(spec, str):
+                spec = [spec]
+            r = cli_runner.invoke(["diff", "--exit-code", "-o", "json", *spec])
             assert r.exit_code == 1, r
             odata = json.loads(r.stdout)["kart.diff/v1+hexwkb"]
             assert len(odata[H.POINTS.LAYER]["feature"]) == 5
@@ -1134,7 +1138,9 @@ def test_diff_rev_rev(head_sha, head1_sha, data_archive_readonly, cli_runner):
 
         for spec in R_SPECS:
             print(f"rev: {spec}")
-            r = cli_runner.invoke(["diff", "--exit-code", "-o", "json", spec])
+            if isinstance(spec, str):
+                spec = [spec]
+            r = cli_runner.invoke(["diff", "--exit-code", "-o", "json", *spec])
             assert r.exit_code == 1, r
             odata = json.loads(r.stdout)["kart.diff/v1+hexwkb"]
             assert len(odata[H.POINTS.LAYER]["feature"]) == 5


### PR DESCRIPTION
Support `kart diff COMMIT1 COMMIT2` as an alternative to typing `kart diff COMMIT1...COMMIT2`

Fixes https://github.com/koordinates/kart/issues/666)

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
