### PR TITLE
Set capture=fd so that passing tests are less noisy

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -14,6 +14,9 @@ addopts = -ra
           # Override this with `-n 0` to use breakpoints
           --numprocesses=auto
 
+          # Less noise from subprocesses writing to stdout
+          --capture=fd
+
 testpaths = tests
 norecursedirs = .* build dist CVS _darcs *.egg venv *.git data tests/data
 


### PR DESCRIPTION
Subprocesses writing to stdout write to the same FD as kart writes to.
However, our capture mode only captures kart output, not subprocess
output. From the user's point of view, both appear the same, but during
tests, the subprocess output will clutter up the test output.