### PR TITLE
Support conflict resolution using the working copy

### DIFF
--- a/kart/merge.py
+++ b/kart/merge.py
@@ -183,6 +183,9 @@ def abort_merging_state(ctx):
         )
         raise InvalidOperation(message)
 
+    # In case the user has modified the working copy during the merging state.
+    repo.working_copy.reset_to_head()
+
 
 def complete_merging_state(ctx):
     """
@@ -311,14 +314,10 @@ def merge(ctx, ff, ff_only, dry_run, message, output_format, commit):
     no_op = jdict.get("noOp", False) or jdict.get("dryRun", False)
     conflicts = jdict.get("conflicts", None)
 
-    if not no_op and not conflicts:
-        # Update working copy.
-        # TODO - maybe lock the working copy during a merge?
-        repo.working_copy.reset_to_head(quiet=do_json)
-
     if do_json:
         dump_json_output({"kart.merge/v1": jdict}, sys.stdout)
     else:
         click.echo(merge_status_to_text(jdict, fresh=True))
     if not no_op and not conflicts:
         repo.gc("--auto")
+        repo.working_copy.reset_to_head(quiet=do_json)

--- a/kart/merge_util.py
+++ b/kart/merge_util.py
@@ -651,6 +651,7 @@ class RichConflict:
     @functools.lru_cache(maxsize=1)
     def has_multiple_paths(self):
         """True if the conflict involves renames and has more than one path."""
+        # Note: this never returns True in practise since we don't do rename detection during merges.
         paths = set(v.path for v in self.true_versions)
         return len(paths) > 1
 
@@ -677,6 +678,7 @@ class RichConflict:
         ("datasetA", "feature", "ancestor=5,ours=6,theirs=7")
         """
         if self.has_multiple_paths:
+            # Note: this never happens in practise since we don't do rename detection during merges.
             return self._multiversion_decoded_path()
         else:
             return self.any_true_version.decoded_path

--- a/kart/point_cloud/import_.py
+++ b/kart/point_cloud/import_.py
@@ -39,6 +39,7 @@ from kart.point_cloud.metadata_util import (
 )
 from kart.point_cloud.tilename_util import remove_tile_extension
 from kart.point_cloud.pdal_convert import convert_tile_to_copc
+from kart.point_cloud.tilename_util import remove_tile_extension
 from kart.serialise_util import hexhash, json_pack, ensure_bytes
 from kart.tabular.version import (
     SUPPORTED_VERSIONS,

--- a/kart/resolve.py
+++ b/kart/resolve.py
@@ -171,11 +171,7 @@ def _load_workingcopy_resolve_for_tile(rich_conflict):
     return _load_file_resolve_for_tile(rich_conflict, matching_files[0])
 
 
-CHOICE_ALIASES = {"working-copy": "workingcopy"}
-CONTEXT_SETTINGS = dict(token_normalize_func=lambda x: CHOICE_ALIASES.get(x, x))
-
-
-@click.command(context_settings=CONTEXT_SETTINGS)
+@click.command()
 @click.pass_context
 @click.option(
     "--with",

--- a/kart/tabular/v3.py
+++ b/kart/tabular/v3.py
@@ -2,8 +2,6 @@ import functools
 import os
 import re
 
-import click
-
 from kart.base_dataset import (
     BaseDataset,
     MetaItemDefinition,

--- a/kart/workdir.py
+++ b/kart/workdir.py
@@ -22,10 +22,7 @@ from kart.exceptions import NotFound, NO_WORKING_COPY, translate_subprocess_exit
 from kart.lfs_util import get_local_path_from_lfs_hash
 from kart.key_filters import RepoKeyFilter
 from kart.point_cloud.v1 import PointCloudV1
-from kart.point_cloud.tilename_util import (
-    remove_tile_extension,
-    get_tile_path_pattern,
-)
+from kart.point_cloud.tilename_util import remove_tile_extension, get_tile_path_pattern
 from kart.sqlalchemy.sqlite import sqlite_engine
 from kart.sqlalchemy.upsert import Upsert as upsert
 from kart.working_copy import WorkingCopyPart


### PR DESCRIPTION
<img src="https://media3.giphy.com/media/l3V0x6kdXUW9M4ONq/giphy.gif"/>

Adds --with=workingcopy to `kart resolve` in which case,
Kart will take the feature or tile from the WC as the resolution
to the specified conflict.

Note that the WC is not currently not kept in sync with the
merge - it continues to track the branch HEAD labelled "ours".
Nor is there currently a way to actually see the merge-conflicts
of PC tiles. This means the following is still needed in further PRs:

- keep the WC up to date with the merge as conflicts are resolved
- require that meta conflicts are resolved before other types of conflicts
- write all versions of conflicting tiles to the working copy, remove
them as they are resolved
- clean up any merge-state that remains - files or folders containing
conflicts - when the merge state is exited using `--continue` or `--abort`

https://github.com/koordinates/kart/issues/565