### PR TITLE
Add a working-copy-merger that updates the WC during a merge

### DIFF
--- a/kart/point_cloud/v1.py
+++ b/kart/point_cloud/v1.py
@@ -115,7 +115,8 @@ class PointCloudV1(BaseDataset):
     def tilename_from_path(cls, tile_path):
         return remove_tile_extension(tile_path.rsplit("/", maxsplit=1)[-1])
 
-    def get_tile_summary_from_pointer_blob(self, tile_pointer_blob):
+    @classmethod
+    def get_tile_summary_from_pointer_blob(cls, tile_pointer_blob):
         result = pointer_file_bytes_to_dict(
             tile_pointer_blob, {"name": tile_pointer_blob.name}
         )

--- a/kart/repo.py
+++ b/kart/repo.py
@@ -629,10 +629,12 @@ class KartRepo(pygit2.Repository):
         if key in config:
             del config[key]
 
-    def invoke_git(self, *args):
+    def invoke_git(self, *args, **kwargs):
         try:
             args = ["git", *args]
-            subprocess.check_call(args, env=tool_environment(), cwd=self.workdir_path)
+            subprocess.check_call(
+                args, env=tool_environment(), cwd=self.workdir_path, **kwargs
+            )
         except subprocess.CalledProcessError as e:
             sys.exit(translate_subprocess_exit_code(e.returncode))
 

--- a/kart/tabular/working_copy/base.py
+++ b/kart/tabular/working_copy/base.py
@@ -1115,6 +1115,7 @@ class TableWorkingCopy(WorkingCopyPart):
         repo_key_filter=RepoKeyFilter.MATCH_ALL,
         track_changes_as_dirty=False,
         rewrite_full=False,
+        quiet=False,
     ):
         """
         Resets the working copy to the given target-tree (or the tree pointed to by the given target-commit).

--- a/kart/working_copy.py
+++ b/kart/working_copy.py
@@ -311,6 +311,7 @@ class WorkingCopy:
                 repo_key_filter=repo_key_filter,
                 track_changes_as_dirty=track_changes_as_dirty,
                 rewrite_full=rewrite_full,
+                quiet=quiet,
             )
 
     def soft_reset_after_commit(
@@ -407,6 +408,7 @@ class WorkingCopyPart:
         repo_key_filter=RepoKeyFilter.MATCH_ALL,
         track_changes_as_dirty=False,
         rewrite_full=False,
+        quiet=False,
     ):
         raise NotImplementedError()
 

--- a/tests/point_cloud/test_conflicts.py
+++ b/tests/point_cloud/test_conflicts.py
@@ -61,6 +61,19 @@ def test_merge_and_resolve_conflicts(
             "",
         ]
 
+        # Check the conflict versions were written to the working copy for the user to compare:
+        assert get_hash_and_size_of_file(
+            repo_path / "auckland" / "auckland_0_0.ancestor.copc.laz"
+        ) == ("1ad630a7b3acd8d678984831181688f82471a25ad6e93b2a2a5a253c9ffb1849", 69437)
+        assert get_hash_and_size_of_file(
+            repo_path / "auckland" / "auckland_0_0.ours.copc.laz"
+        ) == ("858757799b09743b4b58627d2cfabd7d2c0359d658c060b195c8ac932c279ef3", 22671)
+        assert get_hash_and_size_of_file(
+            repo_path / "auckland" / "auckland_0_0.theirs.copc.laz"
+        ) == ("9aa44b101a0e3461a25b94d747057b0dd20e737ac2a344f788085f062ac7c312", 24480)
+
+        # TODO - clean up these files as conflicts are resolved.
+
         r = cli_runner.invoke(
             ["resolve", "auckland:tile:auckland_0_0", "--with=theirs"]
         )


### PR DESCRIPTION
<img src="https://media2.giphy.com/media/3o7ZeAiCICH5bj1Esg/giphy-downsized-medium.gif"/>

In particular, this writes all versions of a tile conflict to the
working copy, but it also writes objects (meta items, features, tiles)
to the working copy if they merge cleanly - so that the user can
inspect those things, but also for consistency: it doesn't make sense
to write only the conflicts to the WC and leave everything else as
"ours" version for simply since that how it was before the merge.

Still TODO in further PRs:
- Further update objects in the WC as they are resolved, including
tidying up any (ancestor / ours / theirs) conflicting versions.
- Use the as-merged-so-far version of the dataset to serialise any
resolves - this is relevant for feature conflicts in the case that
the schema changes during the merge.

https://github.com/koordinates/kart/issues/565
