### PR TITLE
Save MERGED_TREE to repo.

### DIFF
--- a/kart/merge.py
+++ b/kart/merge.py
@@ -165,9 +165,12 @@ def move_repo_to_merging_state(
     merge_context.write_to_repo(repo)
     repo.write_gitdir_file(KartRepoFiles.MERGE_MSG, merge_message)
 
+    working_copy_merger = WorkingCopyMerger(repo, merge_context)
+    # The merged_tree is used mostly for updating the working copy, but is also used for
+    # serialising feature resolves, so we write it even if there's no WC.
+    merged_tree = working_copy_merger.write_merged_tree(merged_index)
     if repo.working_copy.exists():
-        working_copy_merger = WorkingCopyMerger(repo, merge_context)
-        working_copy_merger.update_working_copy(merged_index)
+        working_copy_merger.update_working_copy(merged_index, merged_tree)
 
     assert repo.state == KartRepoState.MERGING
 

--- a/kart/repo.py
+++ b/kart/repo.py
@@ -52,6 +52,8 @@ class KartRepoFiles:
     MERGE_BRANCH = "MERGE_BRANCH"  # The branch name that we merged with, if any.
     # An index file containing the current state of the merge, including cleanly merged items, conflicts, and resolutions.
     MERGED_INDEX = "MERGED_INDEX"
+    # A tree containing the current state of the merge - or near enough - it can't store unresolved conflicts:
+    MERGED_TREE = "MERGED_TREE"
     # A sqlite table that maps each feature SHA to its EPSG:4326 envelope. Used for spatial filtered clones.
     FEATURE_ENVELOPES = "feature_envelopes.db"
 

--- a/kart/resolve.py
+++ b/kart/resolve.py
@@ -45,10 +45,15 @@ def write_feature_to_dataset_entry(feature, dataset, repo):
 
 
 def load_dataset(rich_conflict):
-    # TODO - this works perfectly as long as the dataset hasn't changed structure over the course of the confict.
-    # The correct behaviour is to load a dataset based not on a commit, but on the current merge index, and use this for
-    # serialising resolved features etc - and, to enforce that meta changes for a dataset are resolved before feature changes.
-    return rich_conflict.any_true_version.dataset
+    """
+    This loads the dataset as merged-so-far. We use this to serialise feature resolves, since
+    they will need to be serialised in a way that is consistent with however the dataset it merged -
+    ie, if we decide to accept their new schema, there's no point serialising features with our schema instead.
+    """
+    # TODO - we need to keep MERGED_TREE up to date with any schema.json resolves, and we need to force the user to
+    # resolve meta conflicts before they resolve feature conflicts.
+    sample_ds = rich_conflict.any_true_version.dataset
+    return sample_ds.repo.datasets("MERGED_TREE")[sample_ds.path]
 
 
 def load_file_resolve(rich_conflict, file_path):


### PR DESCRIPTION
<img src="https://media0.giphy.com/media/dllaWjCf0MV0nSNf8y/giphy.gif"/>

We use a MERGED_TREE to update the working-copy during a merge.
We need to keep track of this, otherwise working-copy diffs don't work.
It is also more likely to work if we use this to serialise feature
resolves than the current behavior, which is to use whichever version of the
dataset we find first (ancestor, ours theirs). 

(When the TODOs below are completed, then using the MERGE_TREE to serialise
features resolves will work well even if there are meta conflicts, since this will essentially
mean using the new, merged version of the dataset to serialise feature resolves.)

Still TODO in further PRs:
- cleanup WC conflicts when they are resolved / when the merge is completed / aborted.
- require that meta conflicts are resolved before feature conflicts
- update MERGED_TREE when the user resolves a meta conflict, particularly schema.json

https://github.com/koordinates/kart/issues/565