### PR TITLE
Don't ship duplicate libraries in packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Add `--with-dataset-types` option to `kart meta get` which is informative now that there is more than one type of dataset. [#649](https://github.com/koordinates/kart/pull/649)
 - Support `kart diff COMMIT1 COMMIT2` as an alternative to typing `kart diff COMMIT1...COMMIT2` [#666](https://github.com/koordinates/kart/issues/666)
 - Add `kart helper` which starts a long running process to reduce the overhead of Python startup.
+- Honour symlinks for shared libraries rather than including copies created by PyInstaller.
+- Strip shared libraries on Linux to reduce package size.
 
 ## 0.11.3
 

--- a/platforms/Makefile
+++ b/platforms/Makefile
@@ -98,6 +98,15 @@ pyapp-Darwin: $(pyinstaller) $(SRC)/vendor/dist/vendor-Darwin.tar.gz
 
 	-$(RM) -r $(SRC)/vendor/dist/env/
 
+	# fix up dylibs which should be symlinks
+	(cd $(SRC)/platforms/macos/dist/Kart.app/Contents/MacOS/ \
+		&& for library in `find . -name \*.dylib  | xargs basename`; do \
+		if [ -L $(SRC)/venv/lib/$$library ]; then \
+			ln -sf `readlink $(SRC)/venv/lib/$$library` $$library; \
+		fi; \
+	done)
+
+
 ifdef CODESIGN
 	$(MAKE) app-sign
 endif

--- a/platforms/linux/pyinstaller.sh
+++ b/platforms/linux/pyinstaller.sh
@@ -46,5 +46,18 @@ pyinstaller \
     --distpath platforms/linux/dist/ \
     kart.spec
 
+# # fix up .so files which should be symlinks
+VENDOR_LIB=/src/vendor/dist/env/lib/
+(cd platforms/linux/dist/kart/ \
+    && for library in `ls *.so*`; do 
+    if [ -e $VENDOR_LIB/$library ] ; then 
+        if [ -L $VENDOR_LIB/$library ]; then 
+            ln -sf `readlink $VENDOR_LIB/$library` $library
+        else 
+            strip $library; 
+        fi; 
+    fi; 
+done)
+
 { echo ">> Post-bundle Smoke Test ..."; } 2> /dev/null
 platforms/linux/dist/kart/kart_cli --version


### PR DESCRIPTION

## Description

Pyinstaller will copy any file (shared library) in the source virtual env rather than honouring symlinks - the end result is that versioned symlinks for shared libraries get copied.

Additionally strip shared libraries on Linux to reduce their size.

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
