### PR TITLE
Remove parallel import code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Add `--with-dataset-types` option to `kart meta get` which is informative now that there is more than one type of dataset. [#649](https://github.com/koordinates/kart/pull/649)
 - Support `kart diff COMMIT1 COMMIT2` as an alternative to typing `kart diff COMMIT1...COMMIT2` [#666](https://github.com/koordinates/kart/issues/666)
 - Add `kart helper` which starts a long running process to reduce the overhead of Python startup.
+- the `--num-processes` option to `init` and `import` commands is now deprecated and does nothing. In most situations it offered no performance gain. [#692](https://github.com/koordinates/kart/issues/692)
 
 ## 0.11.3
 

--- a/kart/cli_util.py
+++ b/kart/cli_util.py
@@ -370,3 +370,7 @@ def parse_output_format(output_format, json_style):
 
 class RemovalInKart012Warning(UserWarning):
     pass
+
+
+class RemovalInKart013Warning(UserWarning):
+    pass

--- a/kart/init.py
+++ b/kart/init.py
@@ -1,10 +1,11 @@
 import os
+import warnings
 from pathlib import Path
 
 import click
 
 
-from .cli_util import StringFromFile
+from .cli_util import StringFromFile, RemovalInKart013Warning
 from .core import check_git_user
 from .dataset_util import validate_dataset_paths
 from .exceptions import InvalidOperation
@@ -72,8 +73,9 @@ from .working_copy import PartType
 )
 @click.option(
     "--num-processes",
-    type=click.INT,
-    help="How many git-fast-import processes to use. Defaults to the number of available CPU cores.",
+    help="Deprecated (no longer used)",
+    default=None,
+    hidden=True,
 )
 @click.option(
     "--spatial-filter",
@@ -98,6 +100,12 @@ def init(
     Initialise a new repository and optionally import data.
     DIRECTORY must be empty. Defaults to the current directory.
     """
+    if num_processes is not None:
+        warnings.warn(
+            "--num-processes is deprecated and will be removed in Kart 0.13.",
+            RemovalInKart013Warning,
+        )
+
     if directory is None:
         directory = os.curdir
     repo_path = Path(directory).resolve()
@@ -138,9 +146,7 @@ def init(
         fast_import_tables(
             repo,
             sources,
-            settings=FastImportSettings(
-                num_processes=num_processes, max_delta_depth=max_delta_depth
-            ),
+            settings=FastImportSettings(max_delta_depth=max_delta_depth),
             from_commit=None,
             message=message,
         )

--- a/kart/tabular/import_.py
+++ b/kart/tabular/import_.py
@@ -1,8 +1,15 @@
+import warnings
 import click
 from osgeo import gdal
 
 from kart import is_windows
-from kart.cli_util import JsonFromFile, MutexOption, StringFromFile, call_and_exit_flag
+from kart.cli_util import (
+    JsonFromFile,
+    MutexOption,
+    StringFromFile,
+    call_and_exit_flag,
+    RemovalInKart013Warning,
+)
 from kart.core import check_git_user
 from kart.dataset_util import validate_dataset_paths
 from kart.exceptions import InvalidOperation
@@ -181,8 +188,9 @@ def any_at_all(iterable):
 )
 @click.option(
     "--num-processes",
-    type=click.INT,
-    help="How many git-fast-import processes to use. Defaults to the number of available CPU cores.",
+    help="Deprecated (no longer used)",
+    default=None,
+    hidden=True,
 )
 def import_(
     ctx,
@@ -218,6 +226,12 @@ def import_(
 
     $ kart import --list GPKG:my.gpkg
     """
+
+    if num_processes is not None:
+        warnings.warn(
+            "--num-processes is deprecated and will be removed in Kart 0.13.",
+            RemovalInKart013Warning,
+        )
 
     if output_format == "json" and not do_list:
         raise click.UsageError(
@@ -319,9 +333,7 @@ def import_(
     fast_import_tables(
         repo,
         import_sources,
-        settings=FastImportSettings(
-            num_processes=num_processes, max_delta_depth=max_delta_depth
-        ),
+        settings=FastImportSettings(max_delta_depth=max_delta_depth),
         verbosity=ctx.obj.verbosity + 1,
         message=message,
         replace_existing=replace_existing_enum,

--- a/kart/upgrade/__init__.py
+++ b/kart/upgrade/__init__.py
@@ -300,7 +300,6 @@ def _upgrade_commit(
         fast_import_tables(
             dest_repo,
             source_datasets,
-            settings=FastImportSettings(num_processes=1),
             replace_existing=replace_existing,
             from_commit=from_commit,
             replace_ids=replace_ids,

--- a/kart/utils.py
+++ b/kart/utils.py
@@ -1,8 +1,5 @@
 import functools
 import itertools
-import os
-import platform
-from pathlib import Path
 
 
 def ungenerator(cast_function):
@@ -37,34 +34,3 @@ def chunk(iterable, size):
         if not chunk:
             return
         yield chunk
-
-
-def get_num_available_cores():
-    """
-    Returns the number of available CPU cores (best effort)
-      * uses cgroup quotas on Linux if available
-      * uses processor affinity on Windows/Linux if available
-      * otherwise, uses total number of CPU cores
-
-    The result is a float which may or may not be a round number, and may be less than 1.
-    """
-    if platform.system() == "Linux":
-        try:
-            quota = float(Path("/sys/fs/cgroup/cpu/cpu.cfs_quota_us").read_text())
-            period = float(Path("/sys/fs/cgroup/cpu/cpu.cfs_period_us").read_text())
-        except FileNotFoundError:
-            pass
-        else:
-            if quota == -1:
-                # no quota set
-                pass
-            else:
-                # note: this is a float, and may not be a round number
-                # (it's possible to allocate half-cores)
-                return quota / period
-    try:
-        return float(len(os.sched_getaffinity(0)))
-    except AttributeError:
-        # sched_getaffinity isn't available on some platforms (macOS mostly I think)
-        # Fallback to total machine CPUs
-        return float(os.cpu_count())


### PR DESCRIPTION

## Description

This code adds complexity and doesn't help since the repo layout
optimisations were introduced in Datasets V3, although
it probably does speed up datasets with string primary keys.

With sequential integer primary keys, it just results in idle processes
since features from a sequence are consistently fed into the same
process, resulting in no efficiency gain.

Since this code is quite complex, it doesn't make sense to keep it

On my laptop, I got these results:

`--num-processes=10`:
```
Added 2,328,809 Features to index in 87.5s
Overall rate: 26607 features/s)
Closed in 0s
Joining 10 parallel-imported trees...
Joined trees in 0s
```

`--num-processes=1`:
```
Added 2,328,809 Features to index in 88.4s
Overall rate: 26344 features/s)
Closed in 0s
```

The idle processes can be seen in Activity Monitor:

<img width="905" alt="Screen Shot 2022-08-10 at 11 41 15 AM" src="https://user-images.githubusercontent.com/32112/183784838-b533e791-1ca0-488f-ae4f-1af1e48b4d0e.png">



## Related links:

.

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
