### PR TITLE
point-cloud import: Reject empty commits

### DIFF
--- a/tests/point_cloud/test_imports.py
+++ b/tests/point_cloud/test_imports.py
@@ -8,6 +8,7 @@ from kart.exceptions import (
     INVALID_FILE_FORMAT,
     WORKING_COPY_OR_IMPORT_CONFLICT,
     UNCOMMITTED_CHANGES,
+    NO_CHANGES,
 )
 from kart.repo import KartRepo
 from .fixtures import requires_pdal, requires_git_lfs  # noqa
@@ -424,6 +425,23 @@ def test_import_update_existing(cli_runner, data_archive, requires_pdal):
             assert inserts == 1
             assert updates == 1
             assert deletes == 1
+
+
+def test_import_empty_commit_error(cli_runner, data_archive, requires_pdal):
+    with data_archive("point-cloud/laz-auckland.tgz") as src:
+        with data_archive("point-cloud/auckland.tgz"):
+            # Update an existing tile from the same source (ie no changes)
+            r = cli_runner.invoke(
+                [
+                    "point-cloud-import",
+                    "--dataset-path=auckland",
+                    "--update-existing",
+                    "--convert-to-copc",
+                    f"{src}/auckland_0_0.laz",
+                ]
+            )
+            assert r.exit_code == NO_CHANGES, r.stderr
+            assert "No changes to commit" in r.stderr
 
 
 def test_import_single_las_no_convert(


### PR DESCRIPTION

## Description

For consistency with `commit` and `import` commands, `point-cloud
import` should reject empty commits by default. This can be overridden
with `--allow-empty`.

An empty commit can happen when replacing existing tiles from the same
source tiles

## Related links:

<!-- If you have links to [issues](https://github.com/koordinates/kart/issues) etc, link them here. -->

## Checklist:

- [ ] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
