### PR TITLE
tests: fix Date for commands passed to git

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -714,6 +714,12 @@ class TestHelpers:
         subprocess.check_call(cmd + list(paths))
 
     @classmethod
+    def get_git_datetime(cls, sha: str) -> str:
+        cmd = ["git", "show", "-s", "--format=%cd", sha]
+        date = subprocess.check_output(cmd)
+        return date.decode("utf-8").strip()
+
+    @classmethod
     def parameter_ids(cls, request):
         """Get an array of parameter IDs"""
         # nodeid = 'test_import_feature_performance[0.2.0-spec-counties-table]'

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -17,13 +17,13 @@ def test_log(output_format, data_archive_readonly, cli_runner):
             assert r.stdout.splitlines() == [
                 f"commit {H.POINTS.HEAD_SHA}",
                 "Author: Robert Coup <robert@coup.net.nz>",
-                f"Date:   {H.POINTS.DATE_TIME}",
+                f"Date:   {H.get_git_datetime(H.POINTS.HEAD_SHA)}",
                 "",
                 "    Improve naming on Coromandel East coast",
                 "",
                 f"commit {H.POINTS.HEAD1_SHA}",
                 "Author: Robert Coup <robert@coup.net.nz>",
-                f"Date:   {H.POINTS.DATE_TIME1}",
+                f"Date:   {H.get_git_datetime(H.POINTS.HEAD1_SHA)}",
                 "",
                 "    Import from nz-pa-points-topo-150k.gpkg",
             ]
@@ -121,7 +121,7 @@ def test_log_shallow_clone(
             assert r.stdout.splitlines() == [
                 f"commit {H.POINTS.HEAD_SHA}",
                 "Author: Robert Coup <robert@coup.net.nz>",
-                f"Date:   {H.POINTS.DATE_TIME}",
+                f"Date:   {H.get_git_datetime(H.POINTS.HEAD_SHA)}",
                 "",
                 "    Improve naming on Coromandel East coast",
             ]

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -11,20 +11,6 @@ from kart.repo import KartRepo
 
 H = pytest.helpers.helpers()
 
-POINTS_UPGRADE_RESULT = [
-    f"commit {H.POINTS.HEAD_SHA}",
-    "Author: Robert Coup <robert@coup.net.nz>",
-    f"Date:   {H.POINTS.DATE_TIME}",
-    "",
-    "    Improve naming on Coromandel East coast",
-    "",
-    f"commit {H.POINTS.HEAD1_SHA}",
-    "Author: Robert Coup <robert@coup.net.nz>",
-    f"Date:   {H.POINTS.DATE_TIME1}",
-    "",
-    "    Import from nz-pa-points-topo-150k.gpkg",
-]
-
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
@@ -59,6 +45,19 @@ def test_upgrade_v0(archive, layer, data_archive_readonly, cli_runner, tmp_path,
         assert r.exit_code == 0, r.stderr
 
         if layer == H.POINTS.LAYER:
+            POINTS_UPGRADE_RESULT = [
+                f"commit {H.POINTS.HEAD_SHA}",
+                "Author: Robert Coup <robert@coup.net.nz>",
+                f"Date:   {H.get_git_datetime(H.POINTS.HEAD_SHA)}",
+                "",
+                "    Improve naming on Coromandel East coast",
+                "",
+                f"commit {H.POINTS.HEAD1_SHA}",
+                "Author: Robert Coup <robert@coup.net.nz>",
+                f"Date:   {H.get_git_datetime(H.POINTS.HEAD1_SHA)}",
+                "",
+                "    Import from nz-pa-points-topo-150k.gpkg",
+            ]
             assert r.stdout.splitlines() == POINTS_UPGRADE_RESULT
 
 
@@ -95,6 +94,19 @@ def test_upgrade_v1(archive, layer, data_archive_readonly, cli_runner, tmp_path,
         assert r.exit_code == 0, r.stderr
 
         if layer == H.POINTS.LAYER:
+            POINTS_UPGRADE_RESULT = [
+                f"commit {H.POINTS.HEAD_SHA}",
+                "Author: Robert Coup <robert@coup.net.nz>",
+                f"Date:   {H.get_git_datetime(H.POINTS.HEAD_SHA)}",
+                "",
+                "    Improve naming on Coromandel East coast",
+                "",
+                f"commit {H.POINTS.HEAD1_SHA}",
+                "Author: Robert Coup <robert@coup.net.nz>",
+                f"Date:   {H.get_git_datetime(H.POINTS.HEAD1_SHA)}",
+                "",
+                "    Import from nz-pa-points-topo-150k.gpkg",
+            ]
             assert r.stdout.splitlines() == POINTS_UPGRADE_RESULT
 
         r = cli_runner.invoke(["status", "--output-format=json"])
@@ -141,6 +153,19 @@ def test_upgrade_v2(
         assert r.exit_code == 0, r.stderr
 
         if layer == H.POINTS.LAYER:
+            POINTS_UPGRADE_RESULT = [
+                f"commit {H.POINTS.HEAD_SHA}",
+                "Author: Robert Coup <robert@coup.net.nz>",
+                f"Date:   {H.get_git_datetime(H.POINTS.HEAD_SHA)}",
+                "",
+                "    Improve naming on Coromandel East coast",
+                "",
+                f"commit {H.POINTS.HEAD1_SHA}",
+                "Author: Robert Coup <robert@coup.net.nz>",
+                f"Date:   {H.get_git_datetime(H.POINTS.HEAD1_SHA)}",
+                "",
+                "    Import from nz-pa-points-topo-150k.gpkg",
+            ]
             assert r.stdout.splitlines() == POINTS_UPGRADE_RESULT
 
         r = cli_runner.invoke(["status", "--output-format=json"])
@@ -184,6 +209,19 @@ def test_upgrade_v2_in_place(archive, layer, data_archive, cli_runner, tmp_path,
         assert r.exit_code == 0, r.stderr
 
         if layer == H.POINTS.LAYER:
+            POINTS_UPGRADE_RESULT = [
+                f"commit {H.POINTS.HEAD_SHA}",
+                "Author: Robert Coup <robert@coup.net.nz>",
+                f"Date:   {H.get_git_datetime(H.POINTS.HEAD_SHA)}",
+                "",
+                "    Improve naming on Coromandel East coast",
+                "",
+                f"commit {H.POINTS.HEAD1_SHA}",
+                "Author: Robert Coup <robert@coup.net.nz>",
+                f"Date:   {H.get_git_datetime(H.POINTS.HEAD1_SHA)}",
+                "",
+                "    Import from nz-pa-points-topo-150k.gpkg",
+            ]
             assert r.stdout.splitlines() == POINTS_UPGRADE_RESULT
 
 


### PR DESCRIPTION
## Description

`git log` has a different way of parsing `%c` in dates. This PR gets dates from `git show`  and asserts the new date in tests for `kart log` and `kart upgrade`.  

## Related links:

- #685 