### PR TITLE
Re-implement git-lfs pre-push in Kart.

### DIFF
--- a/kart/cli.py
+++ b/kart/cli.py
@@ -32,6 +32,7 @@ MODULE_COMMANDS = {
     "fsck": {"fsck"},
     "helper": {"helper"},
     "init": {"init"},
+    "lfs_commands": {"lfs+"},
     "log": {"log"},
     "merge": {"merge"},
     "meta": {"commit-files", "meta"},
@@ -46,14 +47,17 @@ MODULE_COMMANDS = {
     "point_cloud.import_": {"point-cloud-import"},
 }
 
+# These commands aren't valid Python symbols, even when we change dash to underscore.
+COMMAND_TO_FUNCTION_NAME = {
+    "import": "import_",
+    "lfs+": "lfs_plus",
+}
+
 
 def _load_commands_from_module(mod_name):
     mod = importlib.import_module(f".{mod_name}", "kart")
     for k in MODULE_COMMANDS[mod_name]:
-        k = k.replace("-", "_")
-        if k == "import":
-            # a special case
-            k = "import_"
+        k = COMMAND_TO_FUNCTION_NAME.get(k) or k.replace("-", "_")
         command = getattr(mod, k)
         cli.add_command(command)
 
@@ -125,7 +129,7 @@ def print_version(ctx):
     )
 
     # report on whether this was run through helper mode
-    helper_pid = os.environ.get('KART_HELPER_PID')
+    helper_pid = os.environ.get("KART_HELPER_PID")
     if helper_pid:
         click.echo(f"Executed via helper, PID: {helper_pid}")
 
@@ -237,7 +241,6 @@ def push(ctx, do_progress, args):
             *args,
         ],
     )
-
 
 
 @cli.command(context_settings=dict(ignore_unknown_options=True))

--- a/kart/lfs_commands/__init__.py
+++ b/kart/lfs_commands/__init__.py
@@ -1,0 +1,86 @@
+import os
+import subprocess
+import sys
+
+import click
+
+from kart.cli_util import add_help_subcommand
+from kart.lfs_util import get_hash_from_pointer_file
+from kart.rev_list_objects import rev_list_tile_pointer_files
+from kart.repo import KartRepoState
+
+EMPTY_SHA = "0" * 40
+
+
+@add_help_subcommand
+@click.group("lfs+", hidden=True)
+@click.pass_context
+def lfs_plus(ctx, **kwargs):
+    """Git-LFS commands re-implemented in Kart to allow for spatial filtering."""
+
+
+@lfs_plus.command()
+@click.pass_context
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Don't push anything, just show what would be pushed",
+)
+@click.argument("remote_name", required=False)
+@click.argument("remote_url", required=False)
+def pre_push(ctx, remote_name, remote_url, dry_run):
+    """
+    Re-implementation of git-lfs pre-push - but, only searches for pointer blobs at **/.point-cloud-dataset.v?/tile/**
+    This means it won't encounter any features that are missing due to spatial filtering, which git-lfs stumbles over.
+    """
+
+    if not remote_url and not remote_url:
+        raise RuntimeError(
+            "kart lfs+ pre-push should be run through Kart's pre-push hook."
+        )
+
+    if os.environ.get("GIT_LFS_SKIP_PUSH", False):
+        return
+
+    dry_run = dry_run or os.environ.get("GIT_LFS_DRY_RUN_PUSH", False)
+
+    repo = ctx.obj.get_repo(allowed_states=KartRepoState.ALL_STATES)
+
+    start_commits, stop_commits = get_start_and_stop_commits(sys.stdin)
+
+    lfs_oids = set()
+    for (commit_id, path_match_result, pointer_blob) in rev_list_tile_pointer_files(
+        repo, start_commits, stop_commits
+    ):
+        lfs_oids.add(get_hash_from_pointer_file(pointer_blob))
+
+    if dry_run:
+        click.echo(
+            f"Running pre-push with --dry-run: pushing {len(lfs_oids)} LFS blobs"
+        )
+        for lfs_oid in lfs_oids:
+            click.echo(lfs_oid)
+        return
+
+    if lfs_oids:
+        # TODO - chunk lfs_oids so that we don't overflow the maximum argument size.
+        # TODO - capture chunk progress and report our own overall progress
+        subprocess.check_call(
+            ["git-lfs", "push", remote_name, "--object-id", *lfs_oids]
+        )
+
+
+def get_start_and_stop_commits(input_iter):
+    start_commits = set()
+    stop_commits = set()
+    for line in input_iter:
+        if not line:
+            continue
+        local_ref, local_sha, remote_ref, remote_sha = line.split()
+        start_commits.add(local_sha)
+        stop_commits.add(remote_sha)
+
+    start_commits.discard(EMPTY_SHA)
+    stop_commits.discard(EMPTY_SHA)
+    start_commits -= stop_commits
+    return start_commits, stop_commits

--- a/kart/lfs_util.py
+++ b/kart/lfs_util.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 import re
 import shutil
-import subprocess
+import stat
 import uuid
 
 import pygit2
@@ -21,10 +21,15 @@ _STANDARD_LFS_KEYS = set(("version", "oid", "size"))
 _EMPTY_SHA256 = "sha256:" + ("0" * 64)
 
 
+PRE_PUSH_HOOK = "\n".join(["#!/bin/sh", 'kart lfs+ pre-push "$@"', ""])
+
+
 def install_lfs_hooks(repo):
-    if not (repo.gitdir_path / "hooks" / "pre-push").is_file():
-        subprocess.check_call(
-            ["git", "-C", str(repo.gitdir_path), "lfs", "install", "hooks"]
+    pre_push_hook = repo.gitdir_path / "hooks" / "pre-push"
+    if not pre_push_hook.is_file():
+        pre_push_hook.write_text(PRE_PUSH_HOOK)
+        pre_push_hook.chmod(
+            pre_push_hook.stat().st_mode | stat.S_IXOTH | stat.S_IXGRP | stat.S_IXUSR
         )
 
 

--- a/kart/rev_list_objects.py
+++ b/kart/rev_list_objects.py
@@ -96,6 +96,21 @@ def rev_list_feature_blobs(repo, start_commits, stop_commits):
     )
 
 
+TILE_POINTER_FILES_PATTERN = re.compile(r"(.+)/\.point-cloud-dataset[^/]*/tile/.+")
+
+
+def rev_list_tile_pointer_files(repo, start_commits, stop_commits):
+    """
+    Yield all the blobs with a path identifying them as features (or rows) of a "table-dataset".
+    (commit_id, match_result, blob).
+    To get the entire path, use match_result.group(0) - this can be decoded if necessary.
+    To get the dataset-path, use match_result.group(1)
+    """
+    return rev_list_matching_blobs(
+        repo, start_commits, stop_commits, TILE_POINTER_FILES_PATTERN
+    )
+
+
 def _parse_revlist_output(repo, line_iter):
     commit_id = None
     for line in line_iter:

--- a/tests/point_cloud/test_imports.py
+++ b/tests/point_cloud/test_imports.py
@@ -1,6 +1,5 @@
 from glob import glob
 import json
-import re
 import subprocess
 import pytest
 
@@ -105,12 +104,15 @@ def test_import_single_las(
             assert r.exit_code == 0, r.stderr
             repo.config[f"lfs.{DUMMY_REPO}/info/lfs.locksverify"] = False
 
+            head_sha = repo.head_commit.hex
             stdout = subprocess.check_output(
-                ["kart", "lfs", "push", "origin", "--all", "--dry-run"], encoding="utf8"
+                ["kart", "lfs+", "pre-push", "origin", "DUMMY_REPO", "--dry-run"],
+                input=f"main {head_sha} main 0000000000000000000000000000000000000000\n",
+                encoding="utf8",
             )
-            assert re.match(
-                r"push [0-9a-f]{64} => autzen/.point-cloud-dataset.v1/tile/60/autzen",
-                stdout.splitlines()[0],
+            assert (
+                stdout.splitlines()[0]
+                == "Running pre-push with --dry-run: pushing 1 LFS blobs"
             )
 
             assert (repo_path / "autzen" / "autzen.copc.laz").is_file()
@@ -172,15 +174,16 @@ def test_import_several_laz(
             assert r.exit_code == 0, r.stderr
             repo.config[f"lfs.{DUMMY_REPO}/info/lfs.locksverify"] = False
 
+            head_sha = repo.head_commit.hex
             stdout = subprocess.check_output(
-                ["kart", "lfs", "push", "origin", "--all", "--dry-run"], encoding="utf8"
+                ["kart", "lfs+", "pre-push", "origin", "DUMMY_REPO", "--dry-run"],
+                input=f"main {head_sha} main 0000000000000000000000000000000000000000\n",
+                encoding="utf8",
             )
-            lines = stdout.splitlines()
-            for i in range(16):
-                assert re.match(
-                    r"push [0-9a-f]{64} => auckland/.point-cloud-dataset.v1/tile/[0-9a-f]{2}/auckland_\d_\d",
-                    lines[i],
-                )
+            assert (
+                stdout.splitlines()[0]
+                == "Running pre-push with --dry-run: pushing 16 LFS blobs"
+            )
 
             for x in range(4):
                 for y in range(4):


### PR DESCRIPTION
<img src="https://media3.giphy.com/media/Hluq5ybFMlnfa/giphy-downsized-medium.gif"/>

It turned out not to be very complicated, since we can still delegate
to git-lfs to do the push itself.
The re-implementation only scans for PC tiles, so, there's no chance
of it encountering missing+promised spatial filtered features - so this
fixes the issue where X_KART_POINT_CLOUDS breaks spatial filtered repos.
(However, it means if we add more dataset types that use LFS, we'll need
to modify what is scanned).

Still TODO in further PRs:
Better chunking and progress while pushing.
Re-implement git-lfs fetch in Kart too, including spatial filtering.

https://github.com/koordinates/kart/issues/565
