### PR TITLE
Use kart lfs+ fetch instead of git-lfs fetch

### DIFF
--- a/kart/lfs_commands/__init__.py
+++ b/kart/lfs_commands/__init__.py
@@ -1,4 +1,6 @@
 import os
+import itertools
+import pygit2
 import subprocess
 import sys
 
@@ -6,7 +8,8 @@ import click
 
 from kart.cli_util import add_help_subcommand, tool_environment
 from kart.exceptions import SubprocessError
-from kart.lfs_util import get_hash_from_pointer_file
+from kart.lfs_util import get_hash_from_pointer_file, get_local_path_from_lfs_hash
+from kart.object_builder import ObjectBuilder
 from kart.rev_list_objects import rev_list_tile_pointer_files
 from kart.repo import KartRepoState
 
@@ -96,3 +99,121 @@ def get_start_and_stop_commits(input_iter):
     stop_commits.discard(EMPTY_SHA)
     start_commits -= stop_commits
     return start_commits, stop_commits
+
+
+@lfs_plus.command()
+@click.pass_context
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Don't fetch anything, just show what would be fetched",
+)
+@click.option("--remote", help="Remote to fetch the LFS blobs from")
+@click.argument("commits", nargs=-1)
+def fetch(ctx, remote, commits, dry_run):
+    """Fetch LFS files referenced by the given commit(s) from a remote."""
+    repo = ctx.obj.get_repo(allowed_states=KartRepoState.ALL_STATES)
+
+    if not commits:
+        commits = ["HEAD"]
+
+    fetch_lfs_blobs_for_commits(repo, commits, remote_name=remote, dry_run=dry_run)
+
+
+def fetch_lfs_blobs_for_commits(
+    repo, commits, *, remote_name=None, dry_run=False, quiet=False
+):
+    """
+    Given a list of commits (or commit OIDS), fetch all the tiles from those commits that
+    are not already present in the local cache.
+    """
+    if not commits:
+        return
+
+    if not remote_name:
+        remote_name = repo.head_remote_name_or_default
+    if not remote_name:
+        return
+
+    pointer_file_oids = set()
+    for commit in commits:
+        for dataset in repo.datasets(commit, filter_dataset_type="point-cloud"):
+            pointer_file_oids.update(blob.hex for blob in dataset.tile_pointer_blobs())
+
+    fetch_lfs_blobs_for_pointer_files(
+        repo, pointer_file_oids, dry_run=dry_run, quiet=quiet
+    )
+
+
+def fetch_lfs_blobs_for_pointer_files(
+    repo, pointer_files, *, remote_name=None, dry_run=False, quiet=False
+):
+    """
+    Given a list of pointer files (or OIDs of pointer files themselves - not the OIDs they point to)
+    fetch all the tiles that those pointer files point to that are not already present in the local cache.
+    """
+    if not pointer_files:
+        return
+
+    if not remote_name:
+        remote_name = repo.head_remote_name_or_default
+    if not remote_name:
+        return
+
+    next_blob_name = (str(i) for i in itertools.count(start=0, step=1))
+
+    # TODO - directly instruct Git-LFS to fetch blobs instead of creating a tree to point Git-LFS to,
+    # as and when Git-LFS supports this.
+    object_builder = ObjectBuilder(repo, None)
+    dry_run_output = []
+
+    for pointer_file in pointer_files:
+        if isinstance(pointer_file, str):
+            pointer_blob = repo[pointer_file]
+        elif getattr(pointer_file, "type", None) == pygit2.GIT_OBJ_BLOB:
+            pointer_blob = pointer_file
+        else:
+            raise TypeError("pointer_file should be an OID or a blob object")
+        lfs_oid = get_hash_from_pointer_file(pointer_blob)
+        lfs_path = get_local_path_from_lfs_hash(repo, lfs_oid)
+        if lfs_path.is_file():
+            continue  # Already fetched.
+
+        # TODO - don't fetch tiles that are outside the spatial filter.
+
+        object_builder.insert(next(next_blob_name), pointer_blob)
+        if dry_run:
+            dry_run_output.append(f"{lfs_oid} ({pointer_blob.hex})")
+
+    if dry_run:
+        click.echo(
+            f"Running fetch with --dry-run: fetching {len(dry_run_output)} LFS blobs"
+        )
+        if dry_run_output:
+            click.echo(
+                "LFS blob OID:                                                    (Pointer file OID):"
+            )
+            for line in sorted(dry_run_output):
+                click.echo(line)
+        return
+
+    tree = object_builder.flush()
+    if not tree:
+        return
+
+    try:
+        # TODO - capture progress reporting and do our own.
+        extra_kwargs = {"stdout": subprocess.DEVNULL} if quiet else {}
+        subprocess.check_call(
+            ["git-lfs", "fetch", remote_name, tree.hex],
+            env=tool_environment(),
+            cwd=repo.workdir_path,
+            **extra_kwargs,
+        )
+        if not quiet:
+            # git-lfs fetch generally leaves the cursor at the start of a line which it has already written on.
+            click.echo()
+    except subprocess.CalledProcessError as e:
+        raise SubprocessError(
+            f"There was a problem with git-lfs fetch: {e}", called_process_error=e
+        )

--- a/kart/merge_util.py
+++ b/kart/merge_util.py
@@ -13,6 +13,7 @@ from .repo import KartRepoFiles
 from .structs import CommitWithReference
 from .tabular.feature_output import feature_as_geojson, feature_as_json, feature_as_text
 from .utils import ungenerator
+from kart.lfs_commands import fetch_lfs_blobs_for_commits
 from kart.point_cloud.tilename_util import set_tile_extension
 
 
@@ -888,8 +889,7 @@ class WorkingCopyMerger:
             return
 
         commit_ids = set(v.commit_id for v in self.merge_context.versions if v)
-        for commit_id in commit_ids:
-            workdir.fetch_lfs_blobs(self.repo[commit_id], quiet=True)
+        fetch_lfs_blobs_for_commits(self.repo, commit_ids)
 
     def resolve_conflict(self, conflict):
         """

--- a/tests/point_cloud/test_workingcopy.py
+++ b/tests/point_cloud/test_workingcopy.py
@@ -1002,3 +1002,33 @@ def test_working_copy_mtime_updated(
         # Finally, check that the point cloud tiles themselves are not found in the ODB:
         for laz_file in repo.workdir_path.glob("auckland/*.laz"):
             assert pygit2.hashfile(laz_file) not in repo.odb
+
+
+def test_lfs_fetch(cli_runner, data_archive, monkeypatch):
+    monkeypatch.setenv("X_KART_POINT_CLOUDS", "1")
+    with data_archive("point-cloud/auckland.tgz") as repo_path:
+        # Delete everything in the local LFS cache.
+        shutil.rmtree(repo_path / ".kart" / "lfs")
+
+        r = cli_runner.invoke(["lfs+", "fetch", "HEAD", "--dry-run"])
+        assert r.exit_code == 0, r.stderr
+        assert r.stdout.splitlines() == [
+            "Running fetch with --dry-run: fetching 16 LFS blobs",
+            "LFS blob OID:                                                    (Pointer file OID):",
+            "11ba773069c7e935735f7076b2fa44334d0bb41c4742d8cd8111f575359a773c (9e46ecc5d5503a77d6b8604a92b1da1372f39c03)",
+            "23c4bb0642bf467bb35ece586f5460f7f4d32288832796458bcbe1a928b32fb4 (8b5c7ceaad04b6c459ee4b090c77069a07374f84)",
+            "3ba3a4bd4629af7c934c61fa132021bf2b3bdd1a52d981315ce5ecb09d71e10a (194ffbeaafc7f19be592fdd434baf3126189e3b7)",
+            "467dbced134249ad341e762737ca42e731f92dadd2d290cf093b68c788aa0067 (d0cc8a1cacb1f9dd1d79542324fd0f3551de2ec3)",
+            "64895828ea03ce9cafaef4f387338aab8d498c8eccaef1503b8b3bd97e57c5a3 (ba01f6e0d8a64b920e1d8dbaa563a7a641c164b6)",
+            "7041a3ee11a33d750289d44ef4096fd7efcc195958d52f56ab363415f9363e61 (847a284d68b10387ac85ff1aae000f712677b8e4)",
+            "7d160940ad3087f610ccf6d41f5b7a49a4425bae61bf0ca59e3693910b5b11d4 (adbbcfa66956fa01cca20e0df97da0f8a40a63b0)",
+            "817b6ddadd95166012143df55fa73dd6c5a8b42b603c33d1b6c38f187261096e (364046ba21d4a0154c77a2544348bea9fd6baa93)",
+            "9c49d1b59f33fa3f46ca6caf8cfc26e13e7e951758b41d811a9b734918ad1711 (7dcc82fd2e182075b6ece5599aca915ce2df8faf)",
+            "a1862450841dede2759af665825403e458dfa551c095d9a65ea6e6765aeae0f7 (8bb24273e1fc68e68dbe40b2e182f6e743af74cf)",
+            "a968f575322d6de93ebc10f972a4b20a36f918f4f8f76891da4d67232f3976e4 (3ce5e7e1006946fd03cc9b870a1a70bb73f81901)",
+            "add2d011a19b39c0c8d70ed2313ad4955b1e0faf9a24394ab1a103930580a267 (5d62415f8d4d1c314a78ff0725534a3633343cbb)",
+            "bf4210be91ea2013ff13961a885cc9b16cb631a5b54cc89276010d1e4adf74e2 (0b89060b81491a2ade1448417ba1509aa73a0a51)",
+            "c7874972e856eaff4d28fa851b9abc72be9056caa41187211de0258b5ac30f28 (4d79b37fdfdb80166965c4f7d65ffec5f8ed0f86)",
+            "d380a98414ab209f36c7fba4734b02f67de519756e341837217716c5b4768339 (f866ac0ecf4326931d10aaa16140e2240eeada90)",
+            "ec80af6cae31be5318f9380cd953b25469bd8ecda25086deca2b831bbb89168a (c76e89f23f512214063d31e7a9c85657f0cf8fb6)",
+        ]


### PR DESCRIPTION
<img src="https://media0.giphy.com/media/XBEoaajXTXaALzawSn/giphy.gif"/>

More precisely:
- Kart code never actually runs "kart lfs+ fetch" since it can always
directly call a function that would have the same result - calling
kart from within kart is generally unnecessary.
But, the function is exposed as a command for completeness / testing. 

- The function that implements kart lfs+ fetch gathers a list of pointer
files and then - forwards them on to git-lfs fetch. So, we're still
using git-lfs fetch. But, we no longer ever use it to scan commits
directly - we always point it at a tree that contains exactly the
pointer files we want it to fetch, no more and no less.

This means two things:
- we won't hit any problems with missing+promised blobs, since git-lfs
never encounters them
- we can modify our scanning logic to take the current spatial filter
into account (not yet done).

Still TODO in further PRs:
- improve git-lfs output (ie, by capturing it and outputting our own)
- implement spatial filtering for PC tiles

https://github.com/koordinates/kart/issues/565