### PR TITLE
Basic spatial-filter support for point clouds

### DIFF
--- a/kart/base_diff_writer.py
+++ b/kart/base_diff_writer.py
@@ -475,12 +475,12 @@ class BaseDiffWriter:
         )
         sf = self.spatial_filter
         old_spatial_filter = (
-            sf.transform_for_schema_and_crs(old_schema, old_crs, ds_path)
+            sf.transform_for_table_schema_and_crs(old_schema, old_crs, ds_path)
             if old_schema
             else SpatialFilter.MATCH_ALL
         )
         new_spatial_filter = (
-            sf.transform_for_schema_and_crs(new_schema, new_crs, ds_path)
+            sf.transform_for_table_schema_and_crs(new_schema, new_crs, ds_path)
             if new_schema
             else SpatialFilter.MATCH_ALL
         )

--- a/kart/geometry.py
+++ b/kart/geometry.py
@@ -223,6 +223,10 @@ class Geometry(bytes):
     def from_hex_ewkb(cls, hex_ewkb):
         return hex_ewkb_to_gpkg_geom(hex_ewkb)
 
+    @classmethod
+    def from_bbox(cls, min_x, max_x, min_y, max_y):
+        return cls.from_wkt(bbox_as_wkt_polygon(min_x, max_x, min_y, max_y))
+
 
 def _validate_gpkg_geom(gpkg_geom):
     """
@@ -698,3 +702,21 @@ def geom_envelope(gpkg_geom, only_2d=False, calculate_if_missing=False):
         return None
     else:
         return envelope
+
+
+def ring_as_wkt(*points):
+    return "(" + ",".join(f"{x} {y}" for x, y in points) + ")"
+
+
+def bbox_as_wkt_polygon(min_x, max_x, min_y, max_y):
+    return (
+        "POLYGON("
+        + ring_as_wkt(
+            (min_x, min_y),
+            (max_x, min_y),
+            (max_x, max_y),
+            (min_x, max_y),
+            (min_x, min_y),
+        )
+        + ")"
+    )

--- a/kart/working_copy.py
+++ b/kart/working_copy.py
@@ -356,6 +356,13 @@ class WorkingCopy:
                 committed_diff=committed_diff,
             )
 
+    def matches_spatial_filter_hash(self, spatial_filter_hash):
+        """Returns True iff the spatial-filter-hash stored in every part matches the given hash."""
+        for p in self.parts():
+            if p.get_spatial_filter_hash() != spatial_filter_hash:
+                return False
+        return True
+
 
 class WorkingCopyPart:
     """Abstract base class for a particular part of a working copy - eg the tabular part, or the file-based part."""

--- a/tests/point_cloud/test_spatial_filters.py
+++ b/tests/point_cloud/test_spatial_filters.py
@@ -1,0 +1,154 @@
+from .fixtures import requires_pdal  # noqa
+
+from kart.geometry import ring_as_wkt
+from kart.repo import KartRepo
+
+CRS = "EPSG:4326"
+
+SOUTH_EAST_TRIANGLE = (
+    "POLYGON("
+    + ring_as_wkt(
+        (174.738, -36.851),
+        (174.782, -36.821),
+        (174.782, -36.851),
+        (174.738, -36.851),
+    )
+    + ")"
+)
+
+SOUTH_WEST_TRIANGLE = (
+    "POLYGON("
+    + ring_as_wkt(
+        (174.738, -36.851),
+        (174.738, -36.821),
+        (174.782, -36.851),
+        (174.738, -36.851),
+    )
+    + ")"
+)
+
+SOUTH_EAST_TILES = {
+    "auckland_0_0.copc.laz",
+    "auckland_1_0.copc.laz",
+    "auckland_1_1.copc.laz",
+    "auckland_2_0.copc.laz",
+    "auckland_2_1.copc.laz",
+    "auckland_2_2.copc.laz",
+    "auckland_3_0.copc.laz",
+    "auckland_3_1.copc.laz",
+    "auckland_3_2.copc.laz",
+    "auckland_3_3.copc.laz",
+}
+
+SOUTH_WEST_TILES = {
+    "auckland_0_0.copc.laz",
+    "auckland_0_1.copc.laz",
+    "auckland_0_2.copc.laz",
+    "auckland_0_3.copc.laz",
+    "auckland_1_0.copc.laz",
+    "auckland_1_1.copc.laz",
+    "auckland_1_2.copc.laz",
+    "auckland_2_0.copc.laz",
+    "auckland_2_1.copc.laz",
+    "auckland_3_0.copc.laz",
+}
+
+
+def _tile_filenames_in_workdir(repo, ds_path):
+    return set(f.name for f in (repo.workdir_path / ds_path).iterdir())
+
+
+def _count_files_in_lfs_cache(repo):
+    return sum(1 for f in (repo.gitdir_path / "lfs").glob("**/*") if f.is_file())
+
+
+def test_clone_pc_with_spatial_filter(
+    data_archive, cli_runner, tmp_path, monkeypatch, requires_pdal
+):
+    monkeypatch.setenv("X_KART_POINT_CLOUDS", "1")
+
+    file_path = (tmp_path / "spatialfilter.txt").resolve()
+    file_path.write_text(f"{CRS}\n\n{SOUTH_EAST_TRIANGLE}\n", encoding="utf-8")
+
+    with data_archive("point-cloud/auckland.tgz") as repo1_path:
+        repo1_url = f"file://{repo1_path.resolve()}"
+        # Clone repo using spatial filter
+        repo2_path = tmp_path / "repo2"
+        r = cli_runner.invoke(
+            [
+                "clone",
+                repo1_url,
+                repo2_path,
+                f"--spatial-filter=@{file_path}",
+                # spatial-filter-after-clone doesn't affect point-cloud datasets,
+                # which never apply a filter to the initial clone operation anyway -
+                # but it means running this test doesn't need git filter extensions
+                "--spatial-filter-after-clone",
+            ]
+        )
+        assert r.exit_code == 0, r.stderr
+
+        # The resulting repo has the spatial filter configured locally.
+        repo2 = KartRepo(repo2_path)
+        assert repo2.config["kart.spatialfilter.geometry"].startswith(
+            "POLYGON ((174.738 -36.851,"
+        )
+        assert repo2.config["kart.spatialfilter.crs"] == CRS
+
+        assert _tile_filenames_in_workdir(repo2, "auckland") == SOUTH_EAST_TILES
+        assert _count_files_in_lfs_cache(repo2) == len(SOUTH_EAST_TILES)
+
+
+def test_reclone_pc_with_larger_spatial_filter(
+    data_archive, cli_runner, tmp_path, monkeypatch, requires_pdal
+):
+    monkeypatch.setenv("X_KART_POINT_CLOUDS", "1")
+
+    with data_archive("point-cloud/auckland.tgz") as repo1_path:
+        repo1_url = f"file://{repo1_path.resolve()}"
+        # Clone repo using spatial filter
+        repo2_path = tmp_path / "repo2"
+
+        EMPTY_SPATIAL_FILTER = "EPSG:4326;POLYGON((0 0,0 1,1 1,1 0,0 0))"
+        r = cli_runner.invoke(
+            [
+                "clone",
+                repo1_url,
+                repo2_path,
+                f"--spatial-filter={EMPTY_SPATIAL_FILTER}",
+                # spatial-filter-after-clone doesn't affect point-cloud datasets,
+                # which never apply a filter to the initial clone operation anyway -
+                # but it means running this test doesn't need git filter extensions
+                "--spatial-filter-after-clone",
+            ]
+        )
+        assert r.exit_code == 0, r.stderr
+
+        repo2 = KartRepo(repo2_path)
+        assert _tile_filenames_in_workdir(repo2, "auckland") == set()
+        assert _count_files_in_lfs_cache(repo2) == 0
+
+        file_path = (tmp_path / "spatialfilter.txt").resolve()
+        file_path.write_text(f"{CRS}\n\n{SOUTH_EAST_TRIANGLE}\n", encoding="utf-8")
+
+        r = cli_runner.invoke(
+            ["-C", repo2_path, "checkout", f"--spatial-filter=@{file_path}"]
+        )
+        assert r.exit_code == 0, r.stderr
+
+        assert _tile_filenames_in_workdir(repo2, "auckland") == SOUTH_EAST_TILES
+        assert _count_files_in_lfs_cache(repo2) == len(SOUTH_EAST_TILES)
+
+        file_path = (tmp_path / "spatialfilter.txt").resolve()
+        file_path.write_text(f"{CRS}\n\n{SOUTH_WEST_TRIANGLE}\n", encoding="utf-8")
+
+        r = cli_runner.invoke(
+            ["-C", repo2_path, "checkout", f"--spatial-filter=@{file_path}"]
+        )
+        assert r.exit_code == 0, r.stderr
+
+        assert _tile_filenames_in_workdir(repo2, "auckland") == SOUTH_WEST_TILES
+        # Both sets of tiles are still in the LFS cache:
+        assert _count_files_in_lfs_cache(repo2) == len(
+            SOUTH_EAST_TILES | SOUTH_WEST_TILES
+        )


### PR DESCRIPTION
<img src="https://media2.giphy.com/media/xT8qBhrlNooHBYR9f2/giphy.gif"/>

Spatial filters are now respected by point clouds:
- when fetching LFS blobs
- when populating the working copy

They are not yet respected by show or diff - the diff is not filtered to
only contain PC deltas that match the spatial filter.

Still TODO: filter PC diffs to match the spatial filter.

https://github.com/koordinates/kart/issues/565