### PR TITLE
cmake: add cli helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please note that compatibility for 0.x releases (software or repositories) isn't
 
 _When adding new entries to the changelog, please include issue/PR numbers wherever possible._
 
+ ## 0.11.6 (UNRELEASED)
+
+- Add CMake support for the CLI helper. [#700](https://github.com/koordinates/kart/pull/700)
+
 ## 0.11.5
 
 ### Major changes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ include(CCache)
 option(IS_HERMETIC "Isolated build where Kart builds all dependencies")
 message("Hermetic build? ${IS_HERMETIC}")
 
+option(USE_HELPER "Use kart_cli_helper by default")
+
 set(VENDOR_ARCHIVE
     ""
     CACHE
@@ -88,10 +90,37 @@ set(DOCS "docs/pages/commands")
 file(COPY ${DOCS} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 set(DOCS "scripts")
 file(COPY ${DOCS} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
 #
 # main build targets
 #
 include(KartPy)
+
+if(NOT WIN32)
+  # Build the CLI helper
+  add_subdirectory(cli_helper)
+  set_target_properties(kart_cli_helper PROPERTIES RUNTIME_OUTPUT_DIRECTORY
+                                                   ${CMAKE_CURRENT_BINARY_DIR})
+
+  if(USE_HELPER)
+    # Make kart a symlink to kart_cli_helper
+    add_custom_target(
+      kart
+      DEPENDS kart_cli_helper
+      COMMAND ${CMAKE_COMMAND} -E create_symlink kart_cli_helper kart
+      COMMENT "Setting kart symlink...")
+  else()
+    # Make kart a symlink to kart_cli
+    add_custom_target(
+      kart
+      DEPENDS ${KART_EXE_BUILD}
+      COMMAND ${CMAKE_COMMAND} -E create_symlink kart_cli kart
+      COMMENT "Setting kart symlink...")
+  endif()
+
+  # cli is our general target
+  add_dependencies(cli kart)
+endif()
 
 # install
 

--- a/cli_helper/CMakeLists.txt
+++ b/cli_helper/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_executable(kart_cli_helper EXCLUDE_FROM_ALL kart.c cJSON.c)

--- a/cmake/KartPy.cmake
+++ b/cmake/KartPy.cmake
@@ -14,7 +14,7 @@ else()
   set(VENV_EXEC_ENV ${CMAKE_COMMAND} -E env "PATH=${VENV_BIN}:$ENV{PATH}")
   set(VENV_PY ${VENV_EXEC_ENV} ${VENV_BIN}/python)
   cmake_path(SET KART_EXE_VENV ${VENV_BIN}/kart)
-  cmake_path(SET KART_EXE_BUILD ${CMAKE_CURRENT_BINARY_DIR}/kart)
+  cmake_path(SET KART_EXE_BUILD ${CMAKE_CURRENT_BINARY_DIR}/kart_cli)
 endif()
 
 set(VENV_PIP_INSTALL ${VENV_PY} -m pip install --isolated --disable-pip-version-check)
@@ -56,9 +56,9 @@ add_custom_command(
   DEPENDS pydeps.stamp setup.py
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   COMMAND ${VENV_PIP_INSTALL} --force-reinstall --no-deps --editable "${CMAKE_CURRENT_SOURCE_DIR}"
-  COMMAND ${CMAKE_COMMAND} "-DTARGET:FILEPATH=${KART_EXE_VENV}" "-DLINK_NAME:FILEPATH=kart" -P
-          ${CMAKE_CURRENT_SOURCE_DIR}/cmake/link.cmake
-  COMMENT "Installing Kart...")
+  COMMAND ${CMAKE_COMMAND} "-DTARGET:FILEPATH=${KART_EXE_VENV}"
+          "-DLINK_NAME:FILEPATH=${KART_EXE_BUILD}" -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/link.cmake
+  COMMENT "Setting executable...")
 
 add_custom_command(
   OUTPUT ${VENV_DOCS}

--- a/cmake/link.cmake
+++ b/cmake/link.cmake
@@ -1,16 +1,20 @@
-# create a symlink on Unix or a .cmd file on Windows
-# LINK_NAME -> TARGET
+# create a symlink on Unix or a .cmd file on Windows LINK_NAME -> TARGET
 #
 # invoke via ${CMAKE_COMMAND} -DTARGET:FILEPATH=... -DLINK_NAME:FILEPATH=... -P link.cmake
 
+# cmake-lint: disable=E1126
 if(WIN32)
-  # Windows does mostly support symlinks, but Python entrypoints
-  # don't work when symlinked
+  # Windows does mostly support symlinks, but Python entrypoints don't work when symlinked
+  cmake_path(REPLACE_EXTENSION LINK_NAME LAST_ONLY ".cmd")
   cmake_path(NATIVE_PATH TARGET target_abs)
-  file(CONFIGURE
-    OUTPUT "${LINK_NAME}.cmd"
-    CONTENT "@echo off\n\"${target_abs}\" %*\n"
-    NEWLINE_STYLE WIN32)
+  file(
+    CONFIGURE
+    OUTPUT
+    "${LINK_NAME}"
+    CONTENT
+    "@echo off\n\"${target_abs}\" %*\n"
+    NEWLINE_STYLE
+    WIN32)
 else()
   file(CREATE_LINK ${TARGET} ${LINK_NAME} SYMBOLIC)
 endif()

--- a/kart/helper.py
+++ b/kart/helper.py
@@ -12,7 +12,7 @@ from .socket_utils import recv_fds
 from .cli import load_commands_from_args, cli, is_windows, is_darwin, is_linux
 
 
-@click.command(context_settings=dict(ignore_unknown_options=True))
+@click.command(context_settings=dict(ignore_unknown_options=True), hidden=True)
 @click.pass_context
 @click.option(
     "--socket",


### PR DESCRIPTION
## Description

Add CMake support for the cli helper on Unix.

Add a new CMake option `USE_HELPER`, since during dev often we won't want the helper working automatically since code changes won't get picked up automatically. Default is `OFF`. The helper is always built, the option controls whether `kart` invokes `kart_cli_helper` or the python entrypoint directly.

Changes the layout in the build directory — with `-DUSE_HELPER=ON`:

    build/kart_cli_helper
    build/kart_cli -> venv/bin/kart
    build/kart -> kart_cli_helper

With `-DUSE_HELPER=OFF`:

    build/kart_cli_helper
    build/kart_cli -> venv/bin/kart
    build/kart -> kart_cli

## Related links:

https://github.com/koordinates/kart/pull/661

## Checklist:

- [ ] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
