### PR TITLE
fix(config): move `--install-tab-completion` to its own command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## 0.11.6 (UNRELEASED)
 
+- Install tab completion using `kart install tab-completion` instead of `kart config --install-tab-completion`. [#701](https://github.com/koordinates/kart/issues/701)
 - "Primary key conflicts" - conflicts caused by reusing a primary key which is already assigned to a feature outside the spatial filter - are renamed to "spatial filter conflicts" for future proofing with other dataset types. Consequently, commit option `--allow-pk-conflicts` is renamed to `--allow-spatial-filter-conflicts`.
 - Bugfix: directing geojson diff output to the console didn't work in a multi-dataset repo, even if only one dataset had changed. [#702](https://github.com/koordinates/kart/issues/702)
 

--- a/kart/cli.py
+++ b/kart/cli.py
@@ -23,7 +23,6 @@ from .cli_util import (
 )
 from .context import Context
 from .exec import run_and_wait
-from kart.completion import Shells, install_callback
 
 MODULE_COMMANDS = {
     "annotations.cli": {"build-annotations"},
@@ -51,6 +50,7 @@ MODULE_COMMANDS = {
     "upgrade": {"upgrade"},
     "tabular.import_": {"import"},
     "point_cloud.import_": {"point-cloud-import"},
+    "install": {"install"},
 }
 
 # These commands aren't valid Python symbols, even when we change dash to underscore.
@@ -258,13 +258,6 @@ def reflog(ctx, args):
 
 @cli.command(context_settings=dict(ignore_unknown_options=True))
 @click.pass_context
-@click.option(
-    "--install-tab-completion",
-    type=click.Choice([s.value for s in Shells] + ["auto"]),
-    callback=install_callback,
-    expose_value=False,
-    help="Install tab completion for the specific or current shell",
-)
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def config(ctx, args):
     """Get and set repository or global options"""

--- a/kart/completion.py
+++ b/kart/completion.py
@@ -177,7 +177,7 @@ def install_powershell(*, prog_name: str, complete_var: str, shell: str) -> Path
     return path_obj
 
 
-def install(
+def install_tab_completion(
     shell: Optional[str] = None,
     prog_name: Optional[str] = None,
     complete_var: Optional[str] = None,
@@ -211,18 +211,6 @@ def install(
     else:
         click.echo(f"Shell {shell} is not supported.")
         raise click.exceptions.Exit(1)
-
-
-def install_callback(ctx: click.Context, param: click.Parameter, value: Any) -> Any:
-    if not value or ctx.resilient_parsing:
-        return value
-    if value == "auto":
-        shell, path = install()
-    else:
-        shell, path = install(shell=value)
-    click.secho(f"{shell} completion installed in {path}", fg="green")
-    click.echo("Completion will take effect once you restart the terminal")
-    sys.exit(0)
 
 
 @click.shell_completion.add_completion_class

--- a/kart/install.py
+++ b/kart/install.py
@@ -1,0 +1,29 @@
+import click
+
+from kart.completion import Shells, install_tab_completion
+from kart.cli_util import add_help_subcommand, KartGroup
+
+
+@add_help_subcommand
+@click.group(cls=KartGroup)
+@click.pass_context
+def install(ctx, **kwargs):
+    """Install tools and add-ons"""
+
+
+@install.command()
+@click.option(
+    "--shell",
+    nargs=1,
+    type=click.Choice([s.value for s in Shells] + ["auto"]),
+    default="auto",
+    help="Select a shell to install tab completion for. Defaults to auto for auto-detecting shell.",
+)
+def tab_completion(shell: str):
+    """Install tab completion for the specific or current shell"""
+    if shell == "auto":
+        shell, path = install_tab_completion()
+    else:
+        shell, path = install_tab_completion(shell=shell)
+    click.secho(f"{shell} completion installed in {path}", fg="green")
+    click.echo("Completion will take effect once you restart the terminal")

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -14,11 +14,6 @@ DIFF_OUTPUT_FORMATS = ["text", "geojson", "json", "json-lines", "quiet", "html"]
 SHOW_OUTPUT_FORMATS = DIFF_OUTPUT_FORMATS
 
 
-def test_completion_install_no_shell(cli_runner):
-    r = cli_runner.invoke(["config", "--install-tab-completion"])
-    assert "Error: Option '--install-tab-completion' requires an argument" in r.stderr
-
-
 def test_completion_install_bash(cli_runner):
     bash_completion_path = Path.home() / ".bashrc"
     bash_profile = Path.home() / ".bash_profile"
@@ -27,7 +22,7 @@ def test_completion_install_bash(cli_runner):
     text = ""
     if bash_completion_path.is_file():
         text = bash_completion_path.read_text()
-    r = cli_runner.invoke(["config", "--install-tab-completion", "bash"])
+    r = cli_runner.invoke(["install", "tab-completion", "--shell", "bash"])
     new_text = bash_completion_path.read_text()
     bash_completion_path.write_text(text)
     install_source = os.path.join(".bash_completions", "cli.sh")
@@ -49,7 +44,7 @@ def test_completion_install_zsh(cli_runner):
         completion_path.write_text('echo "custom .zshrc"')
     if completion_path.is_file():
         text = completion_path.read_text()
-    r = cli_runner.invoke(["config", "--install-tab-completion", "zsh"])
+    r = cli_runner.invoke(["install", "tab-completion", "--shell", "zsh"])
     new_text = completion_path.read_text()
     completion_path.write_text(text)
     zfunc_fragment = "fpath+=~/.zfunc"
@@ -67,7 +62,7 @@ def test_completion_install_fish(cli_runner):
     completion_path: Path = Path.home() / os.path.join(
         ".config", "fish", "completions", "cli.fish"
     )
-    r = cli_runner.invoke(["config", "--install-tab-completion", "fish"])
+    r = cli_runner.invoke(["install", "tab-completion", "--shell", "fish"])
     new_text = completion_path.read_text()
     completion_path.unlink()
     assert "complete --no-files --command cli" in new_text
@@ -154,7 +149,7 @@ def test_completion_install_powershell(cli_runner, mocker):
             ["pwsh"], returncode=0, stdout=str(completion_path)
         ),
     )
-    result = cli_runner.invoke(["config", "--install-tab-completion", "auto"])
+    result = cli_runner.invoke(["install", "tab-completion"])
     install_script = "Register-ArgumentCompleter -Native -CommandName mocked-typer-testing-app -ScriptBlock $scriptblock"
     parent: Path = completion_path.parent
     parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Description

The problem with the earlier approach is that the `--install-tab-completion` which should be an option is also trying to play the role of a command (also see [koordinates/kart#648 (review)](https://github.com/koordinates/kart/pull/648#discussion_r897457027)). This PR adds a new command instead of adding it as an option in a subcommand. 
```sh
kart install tab-completion # to auto-detect shell and install tab completion
```

## Related links:

- #701 
- #643 

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
