### PR TITLE
Support shell detection in helper mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 ## 0.11.6 (UNRELEASED)
 
 - "Primary key conflicts" - conflicts caused by reusing a primary key which is already assigned to a feature outside the spatial filter - are renamed to "spatial filter conflicts" for future proofing with other dataset types. Consequently, commit option `--allow-pk-conflicts` is renamed to `--allow-spatial-filter-conflicts`.
+- Support shell detection for tab completion installation when running in helper mode. [#704](https://github.com/koordinates/kart/pull/704)
 
 ## 0.11.5
 

--- a/kart.spec
+++ b/kart.spec
@@ -115,6 +115,7 @@ pyi_analysis = Analysis(
         '_cffi_backend',
         # via a cython module ???
         'csv',
+        'shellingham.posix',
         *collect_submodules('kart'),
         *collect_submodules('sqlalchemy'),
     ],

--- a/kart.spec
+++ b/kart.spec
@@ -116,6 +116,7 @@ pyi_analysis = Analysis(
         # via a cython module ???
         'csv',
         'shellingham.posix',
+        'shellingham.nt',
         *collect_submodules('kart'),
         *collect_submodules('sqlalchemy'),
     ],

--- a/kart/completion.py
+++ b/kart/completion.py
@@ -17,7 +17,7 @@ except ImportError:
 
 def provide_default_shell():
     if os.name == 'posix':
-        return os.environ['SHELL']
+        return os.environ.get('SHELL', '')
     raise NotImplementedError(f'OS {os.name!r} support not available')
 
 class Shells(str, Enum):

--- a/kart/completion.py
+++ b/kart/completion.py
@@ -18,6 +18,8 @@ except ImportError:
 def provide_default_shell():
     if os.name == 'posix':
         return os.environ.get('SHELL', '')
+    elif os.name == 'nt':
+        return os.environ.get('COMSPEC', '')
     raise NotImplementedError(f'OS {os.name!r} support not available')
 
 class Shells(str, Enum):

--- a/kart/completion.py
+++ b/kart/completion.py
@@ -15,6 +15,10 @@ try:
 except ImportError:
     shellingham = None
 
+def provide_default_shell():
+    if os.name == 'posix':
+        return os.environ['SHELL']
+    raise NotImplementedError(f'OS {os.name!r} support not available')
 
 class Shells(str, Enum):
     bash = "bash"
@@ -187,7 +191,10 @@ def install(
     if complete_var is None:
         complete_var = "_{}_COMPLETE".format(prog_name.replace("-", "_").upper())
     if shell is None and shellingham is not None:
-        shell, _ = shellingham.detect_shell()
+        try:
+            shell, _ = shellingham.detect_shell()
+        except shellingham.ShellDetectionFailure:
+            shell = os.path.basename(provide_default_shell())
     if shell == "bash":
         installed_path = install_bash(
             prog_name=prog_name, complete_var=complete_var, shell=shell

--- a/kart/helper.py
+++ b/kart/helper.py
@@ -204,11 +204,10 @@ def helper(ctx, socket_filename, timeout, args):
                         )
 
                     except Exception as e:
-                        print(os.environ)
                         print(
                             f"kart helper: unhandled exception"
                         )  # TODO - should ext-run capture/handle this?
-                        traceback.print_exc(file=sys.stdout)
+                        traceback.print_exc(file=sys.stderr)
                         libc.semctl(semid, 0, SETVAL, struct_semun(val=1001))
                     try:
                         # send a signal to caller that we are done

--- a/kart/helper.py
+++ b/kart/helper.py
@@ -5,6 +5,7 @@ import json
 import io
 import os
 import sys
+import traceback
 
 import click
 
@@ -203,9 +204,11 @@ def helper(ctx, socket_filename, timeout, args):
                         )
 
                     except Exception as e:
+                        print(os.environ)
                         print(
-                            f"kart helper: unhandled exception [{e}]"
+                            f"kart helper: unhandled exception"
                         )  # TODO - should ext-run capture/handle this?
+                        traceback.print_exc(file=sys.stdout)
                         libc.semctl(semid, 0, SETVAL, struct_semun(val=1001))
                     try:
                         # send a signal to caller that we are done

--- a/tests/scripts/e2e-1.ps1
+++ b/tests/scripts/e2e-1.ps1
@@ -50,6 +50,7 @@ $SQLITE=(Join-Path $KART_PREFIX 'sqlite3.exe')
 New-Item -ItemType Directory -Path "${TMP_PATH}\test"
 Push-Location "${TMP_PATH}\test"
 try {
+    Exec { kart -vvvv config --install-tab-completion auto }
     Exec { kart init --initial-branch=main . }
     Exec { kart -v config --local 'user.name' 'Kart E2E Test 1' }
     Exec { kart -v config --local 'user.email' 'kart-e2e-test-1@email.invalid' }

--- a/tests/scripts/e2e-1.ps1
+++ b/tests/scripts/e2e-1.ps1
@@ -50,7 +50,7 @@ $SQLITE=(Join-Path $KART_PREFIX 'sqlite3.exe')
 New-Item -ItemType Directory -Path "${TMP_PATH}\test"
 Push-Location "${TMP_PATH}\test"
 try {
-    Exec { kart -vvvv config --install-tab-completion auto }
+    Exec { kart -vvvv install tab-completion --shell auto }
     Exec { kart init --initial-branch=main . }
     Exec { kart -v config --local 'user.name' 'Kart E2E Test 1' }
     Exec { kart -v config --local 'user.email' 'kart-e2e-test-1@email.invalid' }

--- a/tests/scripts/e2e-1.sh
+++ b/tests/scripts/e2e-1.sh
@@ -33,7 +33,7 @@ set -x
 
 echo "Using helper mode: ${KART_USE_HELPER:-0}"
 
-kart -vvvv config --install-tab-completion auto
+kart -vvvv install tab-completion --shell auto
 
 kart init --initial-branch=main .
 kart config user.name "Kart E2E Test 1"

--- a/tests/scripts/e2e-1.sh
+++ b/tests/scripts/e2e-1.sh
@@ -33,6 +33,8 @@ set -x
 
 echo "Using helper mode: ${KART_USE_HELPER:-0}"
 
+kart -vvvv config --install-tab-completion auto
+
 kart init --initial-branch=main .
 kart config user.name "Kart E2E Test 1"
 kart config user.email "kart-e2e-test-1@email.invalid"


### PR DESCRIPTION
## Description

Shell detection in for command completion installation goes through a few hoops to determine the correct shell. If it can't, in this case due to double forking and detaching in the background of the helper if will fail.

Additionally shellingham.posix was not being picked up by the pyinstaller build.

Dump traceback for unhandled errors when running under helper

## Related links:
https://github.com/sarugaku/shellingham#notes-for-application-developers

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
