### PR TITLE
Merge -m should imply merge --no-ff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Support shell detection for tab completion installation when running in helper mode. [#704](https://github.com/koordinates/kart/pull/704)
 - Bugfix: directing geojson diff output to the console didn't work in a multi-dataset repo, even if only one dataset had changed. [#702](https://github.com/koordinates/kart/issues/702)
 - Improve argument parsing for `kart diff` and `kart show`. [#706](https://github.com/koordinates/kart/issues/706)
+- Bugfix: don't allow `kart merge` to fast-forward if the user specifies a merge message. [#705](https://github.com/koordinates/kart/issues/705)
 
 ## 0.11.5
 

--- a/kart/merge.py
+++ b/kart/merge.py
@@ -50,6 +50,12 @@ def do_merge(repo, ff, ff_only, dry_run, commit, commit_message, quiet=False):
         raise click.BadParameter(
             "Conflicting parameters: --no-ff & --ff-only", param_hint="--ff-only"
         )
+    if commit_message:
+        if ff_only:
+            raise click.BadParameter(
+                "Conflicting parameters: --message & --ff-only", param_hint="--ff-only"
+            )
+        ff = False
 
     # accept ref-ish things (refspec, branch, commit)
     theirs = CommitWithReference.resolve(repo, commit)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -19,14 +19,8 @@ H = pytest.helpers.helpers()
 @pytest.mark.parametrize(
     "data",
     [
-        pytest.param(
-            H.POINTS,
-            id="points",
-        ),
-        pytest.param(
-            H.POLYGONS,
-            id="polygons",
-        ),
+        pytest.param(H.POINTS, id="points"),
+        pytest.param(H.POLYGONS, id="polygons"),
         pytest.param(H.TABLE, id="table"),
     ],
 )
@@ -68,18 +62,14 @@ def test_merge_fastforward(data, data_working_copy, cli_runner, insert, request)
 @pytest.mark.parametrize(
     "data",
     [
-        pytest.param(
-            H.POINTS,
-            id="points",
-        ),
-        pytest.param(
-            H.POLYGONS,
-            id="polygons",
-        ),
+        pytest.param(H.POINTS, id="points"),
+        pytest.param(H.POLYGONS, id="polygons"),
         pytest.param(H.TABLE, id="table"),
     ],
 )
+@pytest.mark.parametrize("no_ff_method", ["--no-ff", "--message=custom message"])
 def test_merge_fastforward_noff(
+    no_ff_method,
     data,
     data_working_copy,
     cli_runner,
@@ -110,7 +100,7 @@ def test_merge_fastforward_noff(
         assert repo.head.target.hex != commit_id
 
         # force creation of a merge commit
-        r = cli_runner.invoke(["merge", "changes", "--no-ff", "-o", "json"])
+        r = cli_runner.invoke(["merge", "changes", no_ff_method, "-o", "json"])
         assert r.exit_code == 0, r
 
         H.git_graph(request, "post-merge")
@@ -123,7 +113,10 @@ def test_merge_fastforward_noff(
         assert len(c.parents) == 2
         assert c.parents[0].hex == h
         assert c.parents[1].hex == commit_id
-        assert c.message == 'Merge branch "changes" into main'
+        if no_ff_method == "--no-ff":
+            assert c.message == 'Merge branch "changes" into main'
+        else:
+            assert c.message == "custom message"
 
 
 @pytest.mark.parametrize(
@@ -236,14 +229,8 @@ def test_merge_shallow_clone(data_archive, tmp_path, cli_runner):
 @pytest.mark.parametrize(
     "data",
     [
-        pytest.param(
-            H.POINTS,
-            id="points",
-        ),
-        pytest.param(
-            H.POLYGONS,
-            id="polygons",
-        ),
+        pytest.param(H.POINTS, id="points"),
+        pytest.param(H.POLYGONS, id="polygons"),
         pytest.param(H.TABLE, id="table"),
     ],
 )


### PR DESCRIPTION
If the user supplies a merge message, then we shouldn't
allow kart merge to fast-forward - we should make a new
commit to store that message.

Fixes https://github.com/koordinates/kart/issues/705