### PR TITLE
Add `kart lfs+ gc` - cleans up unreferenced LFS tiles

### DIFF
--- a/kart/point_cloud/v1.py
+++ b/kart/point_cloud/v1.py
@@ -84,6 +84,11 @@ class PointCloudV1(BaseDataset):
         """The total number of features in this dataset."""
         return sum(1 for blob in self.tile_pointer_blobs())
 
+    def tile_lfs_hashes(self, spatial_filter=SpatialFilter.MATCH_ALL):
+        """Returns a generator that yields every LFS hash."""
+        for blob in self.tile_pointer_blobs(spatial_filter=spatial_filter):
+            yield get_hash_from_pointer_file(blob)
+
     def tilenames_with_lfs_hashes(
         self, spatial_filter=SpatialFilter.MATCH_ALL, fix_extensions=True
     ):


### PR DESCRIPTION
<img src="https://media1.giphy.com/media/xT0xehfxlptGeeIvEk/giphy.gif"/>

Very bare-bones - has a name which only makes sense to those who
understand our underlying technology, and simply deletes any LFS tiles that
are not currently in use.

Still TODO, but not in this PR:
A bit more design on how else we expose this - what to call it, how to make
sure users know about it.
Maybe more options for automatic garbage collection, or, inform the user
once they are wasting a certain amount of space...

https://github.com/koordinates/kart/issues/565
