### PR TITLE
A new "import-everything" command

### DIFF
--- a/kart/cli.py
+++ b/kart/cli.py
@@ -37,6 +37,7 @@ MODULE_COMMANDS = {
     "diff": {"diff"},
     "fsck": {"fsck"},
     "helper": {"helper"},
+    "import_": {"import"},
     "init": {"init"},
     "lfs_commands": {"lfs+"},
     "log": {"log"},
@@ -48,7 +49,7 @@ MODULE_COMMANDS = {
     "spatial_filter": {"spatial-filter"},
     "status": {"status"},
     "upgrade": {"upgrade"},
-    "tabular.import_": {"import"},
+    "tabular.import_": {"table-import"},
     "point_cloud.import_": {"point-cloud-import"},
     "install": {"install"},
 }

--- a/kart/import_.py
+++ b/kart/import_.py
@@ -1,0 +1,136 @@
+import click
+
+from kart.cli_util import (
+    StringFromFile,
+    call_and_exit_flag,
+    KartCommand,
+    find_param,
+)
+from kart.completion_shared import file_path_completer
+from kart.import_sources import from_spec, suggest_specs
+
+
+def list_import_formats(ctx):
+    """List the supported import formats."""
+    click.echo(suggest_specs())
+
+
+# Some options are defined here for since they are supported by this command directly,
+# but most are here so that they show up in the help text for this command.
+# Apart from causing them to show up in the help text, there is no need to define
+# most options here - defining them in the sub-variants that actually support them
+# is sufficient.
+# Options that are defined here should be defined exactly the same in any of the
+# sub-variants that support them, to avoid confusion.
+
+
+@click.command(
+    "import",
+    cls=KartCommand,
+    context_settings=dict(ignore_unknown_options=True),
+)
+@click.pass_context
+@click.option(
+    "--message",
+    "-m",
+    type=StringFromFile(encoding="utf-8"),
+    help="Commit message. By default this is auto-generated.",
+)
+@call_and_exit_flag(
+    "--list-formats",
+    callback=list_import_formats,
+    help="List available import formats, and then exit",
+)
+@click.option(
+    "--replace-existing",
+    is_flag=True,
+    help="Replace existing dataset(s) of the same name.",
+)
+@click.option(
+    "--checkout/--no-checkout",
+    "do_checkout",
+    is_flag=True,
+    default=True,
+    help="Whether to create a working copy once the import is finished, if no working copy exists yet.",
+)
+@click.option(
+    "--dataset-path", "--dataset", "ds_path", help="The dataset's path once imported"
+)
+@click.argument(
+    "args",
+    nargs=-1,
+    metavar="SOURCE [[SOURCES...] or [DATASETS...]]",
+    shell_complete=file_path_completer,
+)
+def import_(ctx, args, **kwargs):
+    """
+    Import data into a repository.
+    This is a one-size-fits-all command - look up the following commands for more
+    specific information, including more options that are not listed here:
+
+    \b
+    kart table-import
+    kart point-cloud-import
+
+    For more information on the supported types of import-sources and how to specify them,
+    try `kart import --list-formats`
+
+    There are two different forms of this command, depending on what is being imported.
+
+    \b
+    First form:
+    $ kart import SOURCE [DATASETS...]
+
+    This form imports one or more datasets that are found in a single import-source.
+    An import-source could be a file or a database location. This is the first argument.
+    This is sufficient if there is only one dataset to be found inside the import-source.
+    If there is more than one, then all subsequent arguments should be the names of
+    datasets to be imported that are found inside the import-source.
+
+    For example, to import two datasets called my_points and my_lines from my_data.gpkg:
+
+    $ kart import my_data.gpkg my_points my_lines
+
+    To rename datasets as they are imported, use the suffix :NEW_NAME on the DATASETS -
+    for example:
+
+    $ kart import my_data.gpkg my_points:points_renamed my_lines:lines_renamed
+
+    \b
+    Second form:
+    $ kart import --dataset=DATASET-PATH SOURCE [SOURCES...]
+
+    This form imports one dataset that is found in one or more import-sources.
+    The import-source in this case is generally a file that contains one piece
+    of the data of a large dataset that has been sharded / tiled into multiple files.
+    The dataset specified will be the name (ie, the path) of the dataset once
+    imported from all of the sources.
+
+    For example, to import all LAZ files from the my_point_clouds directory:
+
+    $ kart import --dataset=my_points_clouds my_point_clouds/*.laz
+
+    Note that --dataset can be ommitted if a reasonable name can be inferred from the sources.
+    """
+
+    args = [a for a in args if not a.startswith("-")]
+    if not args:
+        click.echo("At least one SOURCE is required for kart import.", err=True)
+        raise click.MissingParameter(param=find_param(ctx, "args"))
+
+    for arg in args:
+        import_source_type = from_spec(arg, allow_unrecognised=True)
+        if import_source_type is not None:
+            break
+
+    if import_source_type is None:
+        raise click.UsageError(
+            "Unrecognised import-source specification.\n"
+            f"Try one of the following:\n{suggest_specs()}"
+        )
+
+    import_cmd = import_source_type.import_cmd
+
+    subctx = import_cmd.make_context(import_cmd.name, ctx.unparsed_args)
+    subctx.obj = ctx.obj
+    subctx.forward(import_cmd)

--- a/kart/parse_args.py
+++ b/kart/parse_args.py
@@ -226,9 +226,10 @@ def parse_import_sources_and_datasets(args):
 
         if other_sources and datasets:
             raise click.UsageError(
-                "When importing, you may supply either more than one import-source:\n"
+                "Specifying multiple sources as well as datasets is not allowed.\n"
+                "When importing, you may either supply multiple import sources:\n"
                 "    kart import SOURCE [SOURCE] [SOURCE]\n"
-                "or you may supply datasets to import found within that one import-source:"
+                "OR you may supply datasets to import from a single source:"
                 "    kart import SOURCE [DATASET] [DATASET]\n"
                 "but this appears to be a mix of both:\n"
                 f"    {other_args[i - 1]}\n"

--- a/tests/point_cloud/test_imports.py
+++ b/tests/point_cloud/test_imports.py
@@ -119,8 +119,15 @@ def test_import_single_las(
 
 
 @pytest.mark.slow
+@pytest.mark.parametrize("command", ["point-cloud-import", "import"])
 def test_import_several_laz(
-    tmp_path, chdir, cli_runner, data_archive_readonly, requires_pdal, requires_git_lfs
+    command,
+    tmp_path,
+    chdir,
+    cli_runner,
+    data_archive_readonly,
+    requires_pdal,
+    requires_git_lfs,
 ):
     # Using postgres here because it has the best type preservation
     with data_archive_readonly("point-cloud/laz-auckland.tgz") as auckland:
@@ -132,7 +139,7 @@ def test_import_several_laz(
         with chdir(repo_path):
             r = cli_runner.invoke(
                 [
-                    "point-cloud-import",
+                    command,
                     *glob(f"{auckland}/auckland_*.laz"),
                     "--dataset-path=auckland",
                 ]
@@ -192,8 +199,15 @@ def test_import_several_laz(
                     ).is_file()
 
 
+@pytest.mark.parametrize("command", ["point-cloud-import", "import"])
 def test_import_single_laz_no_convert(
-    tmp_path, chdir, cli_runner, data_archive_readonly, requires_pdal, requires_git_lfs
+    command,
+    tmp_path,
+    chdir,
+    cli_runner,
+    data_archive_readonly,
+    requires_pdal,
+    requires_git_lfs,
 ):
     with data_archive_readonly("point-cloud/laz-auckland.tgz") as auckland:
         repo_path = tmp_path / "point-cloud-repo"
@@ -203,7 +217,7 @@ def test_import_single_laz_no_convert(
         with chdir(repo_path):
             r = cli_runner.invoke(
                 [
-                    "point-cloud-import",
+                    command,
                     f"{auckland}/auckland_0_0.laz",
                     "--message=test_import_single_laz_no_convert",
                     "--dataset-path=auckland",
@@ -241,7 +255,9 @@ def test_import_single_laz_no_convert(
             ]
 
 
+@pytest.mark.parametrize("command", ["point-cloud-import", "import"])
 def test_import_replace_existing(
+    command,
     cli_runner,
     data_archive,
     data_archive_readonly,
@@ -251,7 +267,7 @@ def test_import_replace_existing(
         with data_archive("point-cloud/auckland.tgz"):
             r = cli_runner.invoke(
                 [
-                    "point-cloud-import",
+                    command,
                     f"{src}/auckland_0_0.laz",
                     "--message=Import again but don't convert to COPC this time",
                     "--dataset-path=auckland",


### PR DESCRIPTION
<img src="https://media1.giphy.com/media/8wJMT7QnKwwxcDpfcf/giphy.gif"/>

Rename current "import" to "table-import",
and add a new thin import command that delegates to either "table-import" or "point-cloud-import"

Without changing any tests, all existing table-import tests now use the new command (since they call "import" and not "table-import".)

Switched some point-cloud-import tests to use both the new command, and the old command to make sure it's working.

## Related links:

https://github.com/koordinates/kart/issues/565

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
Changelog is as yet unchanged - running `kart import` will appear to work as before, will add a full explanation of how to import point clouds in the PC release