### PR TITLE
Add a kart lfs+ ls-files command for listing LFS tiles

### DIFF
--- a/kart/rev_list_objects.py
+++ b/kart/rev_list_objects.py
@@ -1,13 +1,19 @@
 # Utility for scanning through all the objects in the commit graph, or in a particular part of the commit graph.
 # For example, reachable from commits A, B, C, but not from D, E, F (which have already been taken care of).
 
+import os
 import re
 import subprocess
 
 import pygit2
 
+from kart.core import all_trees_with_paths_in_tree
 from kart.cli_util import tool_environment
 from kart.exceptions import SubprocessError
+
+
+def _rev_list_commits_command(repo):
+    return ["git", "-C", repo.path, "rev-list"]
 
 
 def _rev_list_objects_command(repo):
@@ -28,24 +34,32 @@ def _rev_list_objects_command(repo):
 DS_PATH_PATTERN = r"(.+)/\.(sno|table)-dataset/"
 
 
-def rev_list_object_oids(repo, start_commits, stop_commits):
+def rev_list_object_oids(repo, start_commits, stop_commits, pathspecs):
     """
-    Yield all the objects referenced between the start and stop commits as tuples (commit_id, path, object_id).
+    Yield all the objects referenced between the start and stop commits as tuples (commit_id, path, object_id),
+    and which match at least one of the given pathspecs.
     Each object will only be yielded once, so not necessarily at all paths and commits where it can be found.
     """
+    if not pathspecs:
+        return
+
     cmd = [
         *_rev_list_objects_command(repo),
         *start_commits,
         "--not",
         *stop_commits,
+        "--stdin",
     ]
     try:
         p = subprocess.Popen(
             cmd,
+            stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             encoding="utf8",
             env=tool_environment(),
         )
+        p.stdin.write(os.linesep.join(["--", *pathspecs]))
+        p.stdin.close()
         yield from _parse_revlist_output(repo, p.stdout)
     except subprocess.CalledProcessError as e:
         raise SubprocessError(
@@ -53,26 +67,66 @@ def rev_list_object_oids(repo, start_commits, stop_commits):
         )
 
 
-def rev_list_blobs(repo, start_commits, stop_commits):
+def get_dataset_pathspecs(repo, start_commits, stop_commits, dirname_filter):
+    """
+    Get the list of dataset paths we need to search in for the objects we are insterested in.
+    Without this, all datasets are searched - even irrelevant ones - which could waste a lot of time.
+    """
+    # TODO - if git rev-list --objects pathspec filtering is fixed, there would be other approaches
+    # we could take, some potentially using only a single call to rev-list.
+    # See https://public-inbox.org/git/CAPJmHpWWJ4sssfG2oym7K=MsT3+KTHQP-QK88nfXNOtfcv07ew@mail.gmail.com/
+    cmd = [
+        *_rev_list_commits_command(repo),
+        *start_commits,
+        "--not",
+        *stop_commits,
+    ]
+    result = set()
+    try:
+        p = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            encoding="utf8",
+            env=tool_environment(),
+        )
+        for line in p.stdout:
+            commit = repo[line.strip()]
+            for tree_path, tree in all_trees_with_paths_in_tree(commit.tree):
+                if tree_path in result:
+                    continue
+                for child in tree:
+                    if dirname_filter(child.name):
+                        result.add(tree_path)
+                        break
+
+        return result
+
+    except subprocess.CalledProcessError as e:
+        raise SubprocessError(
+            f"There was a problem with git rev-list: {e}", called_process_error=e
+        )
+
+
+def rev_list_blobs(repo, start_commits, stop_commits, pathspecs):
     """
     Yield all the blobs referenced between the start and stop commits as tuples (commit_id, path, blob).
     Each blob will only be yielded once, so not necessarily at all paths and commits where it can be found.
     """
     for (commit_id, path, oid) in rev_list_object_oids(
-        repo, start_commits, stop_commits
+        repo, start_commits, stop_commits, pathspecs
     ):
         obj = repo[oid]
         if obj.type == pygit2.GIT_OBJ_BLOB:
             yield commit_id, path, obj
 
 
-def rev_list_matching_blobs(repo, start_commits, stop_commits, path_pattern):
+def rev_list_matching_blobs(repo, start_commits, stop_commits, pathspecs, path_pattern):
     """
     Yield all the blobs with a path matching the given pattern referenced between the start and stop commits as tuples
     (commit_id, match_result, blob). To get the entire path, use match_result.group(0).
     """
     for (commit_id, path, oid) in rev_list_object_oids(
-        repo, start_commits, stop_commits
+        repo, start_commits, stop_commits, pathspecs
     ):
         m = path_pattern.fullmatch(path)
         if m:
@@ -91,8 +145,14 @@ def rev_list_feature_blobs(repo, start_commits, stop_commits):
     To get the entire path, use match_result.group(0) - this can be decoded if necessary.
     To get the dataset-path, use match_result.group(1)
     """
+    pathspecs = get_dataset_pathspecs(
+        repo,
+        start_commits,
+        stop_commits,
+        dirname_filter=lambda d: d.startswith(".table-dataset") or d == ".sno-dataset",
+    )
     return rev_list_matching_blobs(
-        repo, start_commits, stop_commits, FEATURE_BLOBS_PATTERN
+        repo, start_commits, stop_commits, pathspecs, FEATURE_BLOBS_PATTERN
     )
 
 
@@ -106,8 +166,14 @@ def rev_list_tile_pointer_files(repo, start_commits, stop_commits):
     To get the entire path, use match_result.group(0) - this can be decoded if necessary.
     To get the dataset-path, use match_result.group(1)
     """
+    pathspecs = get_dataset_pathspecs(
+        repo,
+        start_commits,
+        stop_commits,
+        dirname_filter=lambda d: d.startswith(".point-cloud-dataset"),
+    )
     return rev_list_matching_blobs(
-        repo, start_commits, stop_commits, TILE_POINTER_FILES_PATTERN
+        repo, start_commits, stop_commits, pathspecs, TILE_POINTER_FILES_PATTERN
     )
 
 

--- a/tests/point_cloud/test_lfs_commands.py
+++ b/tests/point_cloud/test_lfs_commands.py
@@ -1,0 +1,49 @@
+ALL_TILES = [
+    "bf4210be91ea2013ff13961a885cc9b16cb631a5b54cc89276010d1e4adf74e2 * auckland/.point-cloud-dataset.v1/tile/08/auckland_1_3",
+    "ec80af6cae31be5318f9380cd953b25469bd8ecda25086deca2b831bbb89168a * auckland/.point-cloud-dataset.v1/tile/36/auckland_3_0",
+    "467dbced134249ad341e762737ca42e731f92dadd2d290cf093b68c788aa0067 * auckland/.point-cloud-dataset.v1/tile/51/auckland_2_1",
+    "c7874972e856eaff4d28fa851b9abc72be9056caa41187211de0258b5ac30f28 * auckland/.point-cloud-dataset.v1/tile/56/auckland_2_0",
+    "a968f575322d6de93ebc10f972a4b20a36f918f4f8f76891da4d67232f3976e4 * auckland/.point-cloud-dataset.v1/tile/6e/auckland_2_2",
+    "3ba3a4bd4629af7c934c61fa132021bf2b3bdd1a52d981315ce5ecb09d71e10a * auckland/.point-cloud-dataset.v1/tile/72/auckland_1_2",
+    "a1862450841dede2759af665825403e458dfa551c095d9a65ea6e6765aeae0f7 * auckland/.point-cloud-dataset.v1/tile/8b/auckland_0_0",
+    "817b6ddadd95166012143df55fa73dd6c5a8b42b603c33d1b6c38f187261096e * auckland/.point-cloud-dataset.v1/tile/91/auckland_3_1",
+    "11ba773069c7e935735f7076b2fa44334d0bb41c4742d8cd8111f575359a773c * auckland/.point-cloud-dataset.v1/tile/92/auckland_0_3",
+    "64895828ea03ce9cafaef4f387338aab8d498c8eccaef1503b8b3bd97e57c5a3 * auckland/.point-cloud-dataset.v1/tile/96/auckland_3_3",
+    "d380a98414ab209f36c7fba4734b02f67de519756e341837217716c5b4768339 * auckland/.point-cloud-dataset.v1/tile/9b/auckland_3_2",
+    "9c49d1b59f33fa3f46ca6caf8cfc26e13e7e951758b41d811a9b734918ad1711 * auckland/.point-cloud-dataset.v1/tile/9c/auckland_0_1",
+    "7d160940ad3087f610ccf6d41f5b7a49a4425bae61bf0ca59e3693910b5b11d4 * auckland/.point-cloud-dataset.v1/tile/c5/auckland_2_3",
+    "23c4bb0642bf467bb35ece586f5460f7f4d32288832796458bcbe1a928b32fb4 * auckland/.point-cloud-dataset.v1/tile/c7/auckland_0_2",
+    "add2d011a19b39c0c8d70ed2313ad4955b1e0faf9a24394ab1a103930580a267 * auckland/.point-cloud-dataset.v1/tile/d5/auckland_1_1",
+    "7041a3ee11a33d750289d44ef4096fd7efcc195958d52f56ab363415f9363e61 * auckland/.point-cloud-dataset.v1/tile/e8/auckland_1_0",
+]
+
+
+def test_ls_files(cli_runner, data_archive):
+    with data_archive("point-cloud/auckland.tgz") as repo_path:
+        # Add an extra commit at HEAD with no tiles added.
+        r = cli_runner.invoke(["commit-files", "foo=bar", "-m", "Extra commit"])
+        assert r.exit_code == 0, r.stderr
+
+        r = cli_runner.invoke(["lfs+", "ls-files", "--all"])
+        assert r.exit_code == 0, r.stderr
+        assert r.stdout.splitlines() == ALL_TILES
+
+        # Current branch has all tiles
+        r = cli_runner.invoke(["lfs+", "ls-files"])
+        assert r.exit_code == 0, r.stderr
+        assert r.stdout.splitlines() == ALL_TILES
+
+        # Current commit has no tiles.
+        r = cli_runner.invoke(["lfs+", "ls-files", "HEAD"])
+        assert r.exit_code == 0, r.stderr
+        assert r.stdout.splitlines() == []
+
+        # Prev commit has all tiles.
+        r = cli_runner.invoke(["lfs+", "ls-files", "HEAD^"])
+        assert r.exit_code == 0, r.stderr
+        assert r.stdout.splitlines() == ALL_TILES
+
+        # No tiles committed between this commit and previous.
+        r = cli_runner.invoke(["lfs+", "ls-files", "HEAD", "HEAD^"])
+        assert r.exit_code == 0, r.stderr
+        assert r.stdout.splitlines() == []


### PR DESCRIPTION
<img src="https://media4.giphy.com/media/SuEFqeWxlLcvm/giphy.gif"/>

More efficient than git-lfs command since it only looks in relevant datasets. Also improves efficiency of `kart lfs+ pre-push`

TODO: Revisit this if and when git rev-list --objects pathspec behaviour is fixed, so we can make more use of it.

https://github.com/koordinates/kart/issues/565

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)? Part of point cloud changes, CHANGELOG yet to be updated with documentation for that release
