### PR TITLE
Help the user fix their working copy if it gets into a bad state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Bugfix: don't allow `kart diff` to diff to/from HEAD if HEAD does not yet point to a commit.
 - Improved progress reporting during working-copy checkout. [#738](https://github.com/koordinates/kart/pull/738)
 - Support for changing the primary key column of an existing dataset. [#238](https://github.com/koordinates/kart/issues/238)
+- Help for the user get the working copy back into a valid state if a crash or similar causes it to become out of sync with the Kart repo. [#751](https://github.com/koordinates/kart/pull/751)
 
 ## 0.11.5
 

--- a/kart/exceptions.py
+++ b/kart/exceptions.py
@@ -43,6 +43,8 @@ NO_SPATIAL_FILTER_INDEX = 53
 
 CONNECTION_ERROR = 60
 
+BAD_WORKING_COPY_STATE = 70
+
 SUBPROCESS_ERROR_FLAG = 128
 DEFAULT_SUBPROCESS_ERROR = 129
 
@@ -112,6 +114,10 @@ class DbConnectionError(BaseException):
 
     def __init__(self, message, db_error):
         super().__init__(f"{message}\nCaused by error:\n{db_error}")
+
+
+class BadStateError(BaseException):
+    pass
 
 
 class SubprocessError(BaseException):

--- a/kart/fsck.py
+++ b/kart/fsck.py
@@ -7,7 +7,6 @@ from .cli_util import tool_environment, KartCommand
 from .exceptions import NO_WORKING_COPY, NotFound
 from .geometry import normalise_gpkg_geom
 from .sqlalchemy.gpkg import Db_GPKG
-from kart.working_copy import WorkingCopyTreeMismatch
 
 
 def _fsck_reset(repo, working_copy, dataset_paths):
@@ -64,18 +63,11 @@ def fsck(ctx, reset_datasets, fsck_args):
         tree = repo.head_tree
 
         # compare repo tree id to what's in the DB
-        try:
-            table_wc.assert_matches_tree(repo.head_tree)
-            click.secho(
-                f"✔︎ Working Copy tree id matches repository: {repo.head_tree}",
-                fg="green",
-            )
-        except WorkingCopyTreeMismatch as e:
-            # try and find the tree we _do_ have
-            click.secho(f"✘ Repository tree is: {tree.id}", fg="red")
-            click.secho(f"✘ Working Copy tree is: {e.working_copy_tree_id}", fg="red")
-            click.echo("This might be fixable via `checkout --force`")
-            raise click.Abort()
+        table_wc.assert_matches_tree(repo.head_tree)
+        click.secho(
+            f"✔︎ Working Copy tree id matches repository: {repo.head_tree}",
+            fg="green",
+        )
 
         has_err = False
         for dataset in repo.datasets():

--- a/kart/working_copy.py
+++ b/kart/working_copy.py
@@ -471,8 +471,11 @@ def handle_working_copy_tree_mismatch(wc_type_name, actual_tree_id, expected_tre
         f"tree {expected_tree_id}" if expected_tree_id else "the empty tree"
     )
 
+    summary = (
+        f"The {wc_type_name} working copy appears to be out of sync with the repository"
+    )
     message = [
-        f"The {wc_type_name} working copy appears to be out of sync with the repository:",
+        f"{summary}:",
         f"  * The working copy's own records show it is tracking {actual_tree_id};",
         f"  * Based on the repository it should be tracking {expected_tree_id}.",
         "The simplest fix is generally to recreate the working copy (losing any uncommitted changes in the process.)",
@@ -486,7 +489,7 @@ def handle_working_copy_tree_mismatch(wc_type_name, actual_tree_id, expected_tre
     click.echo("\n".join(message))
     click.echo()
     if not click.confirm("Do you want to recreate the working copy?"):
-        raise BadStateError(message[0], exit_code=BAD_WORKING_COPY_STATE)
+        raise BadStateError(f"{summary}.", exit_code=BAD_WORKING_COPY_STATE)
 
     from kart.create_workingcopy import create_workingcopy
 
@@ -497,9 +500,4 @@ def handle_working_copy_tree_mismatch(wc_type_name, actual_tree_id, expected_tre
     subctx.invoke(create_workingcopy, delete_existing=True, discard_changes=True)
 
     orig_command = f"{ctx.command_path} {' '.join(ctx.unparsed_args)}"
-    click.echo(f"\nThe original command was: {orig_command}")
-
-    if not click.confirm("Do you want to continue running the original command?"):
-        sys.exit(0)
-
-    click.echo()
+    click.echo(f"\nContinuing with the original command: {orig_command}\n")

--- a/kart/working_copy.py
+++ b/kart/working_copy.py
@@ -472,22 +472,20 @@ def handle_working_copy_tree_mismatch(wc_type_name, actual_tree_id, expected_tre
     )
 
     message = [
-        f"The {wc_type_name} working copy appears to be out of sync with the repository.",
-        f"The working copy's own records show it is tracking {actual_tree_id};",
-        f"based on the repository it should be tracking {expected_tree_id}.",
-        "The most straight-forward fix is generally to recreate the working copy from the ground up (losing any uncommitted changes in the process.)",
+        f"The {wc_type_name} working copy appears to be out of sync with the repository:",
+        f"  * The working copy's own records show it is tracking {actual_tree_id};",
+        f"  * Based on the repository it should be tracking {expected_tree_id}.",
+        "The simplest fix is generally to recreate the working copy (losing any uncommitted changes in the process.)",
     ]
 
     if get_input_mode() != InputMode.INTERACTIVE:
-        message.append("To do so, try the following command:")
-        message.append("kart create-workingcopy --delete-existing --discard-changes")
+        message.append("\nTo do so, try the following command:")
+        message.append("\tkart create-workingcopy --delete-existing --discard-changes")
         raise BadStateError("\n".join(message), exit_code=BAD_WORKING_COPY_STATE)
 
     click.echo("\n".join(message))
     click.echo()
-    if not click.confirm(
-        "Do you want to recreate the working copy from the ground up?"
-    ):
+    if not click.confirm("Do you want to recreate the working copy?"):
         raise BadStateError(message[0], exit_code=BAD_WORKING_COPY_STATE)
 
     from kart.create_workingcopy import create_workingcopy
@@ -497,4 +495,11 @@ def handle_working_copy_tree_mismatch(wc_type_name, actual_tree_id, expected_tre
     subctx = click.Context(ctx.command, parent=ctx)
     subctx.obj = ctx.obj
     subctx.invoke(create_workingcopy, delete_existing=True, discard_changes=True)
-    sys.exit(0)
+
+    orig_command = f"{ctx.command_path} {' '.join(ctx.unparsed_args)}"
+    click.echo(f"\nThe original command was: {orig_command}")
+
+    if not click.confirm("Do you want to continue running the original command?"):
+        sys.exit(0)
+
+    click.echo()

--- a/kart/working_copy.py
+++ b/kart/working_copy.py
@@ -2,16 +2,20 @@ import click
 from enum import Enum, auto
 import pygit2
 import os
+import sys
 
 from kart.exceptions import (
     InvalidOperation,
     NotFound,
     NotYetImplemented,
+    BadStateError,
     UNCOMMITTED_CHANGES,
     NO_DATA,
     NO_WORKING_COPY,
+    BAD_WORKING_COPY_STATE,
 )
 from kart.key_filters import RepoKeyFilter
+from kart.output_util import get_input_mode, InputMode
 
 # General code for working copies.
 # Nothing specific to tabular working copies, nor file-based working copies.
@@ -31,17 +35,6 @@ class WorkingCopyDirty(Exception):
     """Exception to abort immediately if working copy is dirty."""
 
     pass
-
-
-class WorkingCopyTreeMismatch(ValueError):
-    """Error for if the tree id stored in state table doesn't match the one at HEAD."""
-
-    def __init__(self, working_copy_tree_id, expected_tree_id):
-        self.working_copy_tree_id = working_copy_tree_id
-        self.expected_tree_id = expected_tree_id
-
-    def __str__(self):
-        return f"Working Copy is tree {self.working_copy_tree_id}; expecting {self.expected_tree_id}"
 
 
 class WorkingCopy:
@@ -96,14 +89,14 @@ class WorkingCopy:
     def assert_matches_head_tree(self):
         """
         Checks that all parts of the working copy are based on the HEAD tree, according to their kart-state tables.
-        Otherwise, raises WorkingCopyTreeMismatch.
+        Otherwise, tries to help the user fix the problem and/or raises BadStateError.
         """
         self.assert_matches_tree(self.repo.head_tree)
 
     def assert_matches_tree(self, tree):
         """
         Checks that all parts of the working copy are based on the given tree, according to their kart-state tables.
-        Otherwise, raises WorkingCopyTreeMismatch.
+        Otherwise, tries to help the user fix the problem and/or raises BadStateError.
         """
         for p in self.parts():
             p.assert_matches_tree(tree)
@@ -384,11 +377,17 @@ class WorkingCopyPart:
         raise NotImplementedError()
 
     def assert_matches_head_tree(self):
-        """Raises a WorkingCopyTreeMismatch if kart_state refers to a different tree and not the HEAD tree."""
+        """
+        Checks that this part of the working copy is based on the HEAD tree, according to the kart-state table.
+        Otherwise, tries to help the user fix the problem and/or raises BadStateError.
+        """
         self.assert_matches_tree(self.repo.head_tree)
 
     def assert_matches_tree(self, expected_tree):
-        """Raises a WorkingCopyTreeMismatch if kart_state refers to a different tree and not the given tree."""
+        """
+        Checks that this part of the working copy is based on the given tree, according to the kart-state table.
+        Otherwise, tries to help the user fix the problem and/or raises BadStateError.
+        """
         if expected_tree is None or isinstance(expected_tree, str):
             expected_tree_id = expected_tree
         else:
@@ -396,7 +395,9 @@ class WorkingCopyPart:
         actual_tree_id = self.get_tree_id()
 
         if actual_tree_id != expected_tree_id:
-            raise WorkingCopyTreeMismatch(actual_tree_id, expected_tree_id)
+            handle_working_copy_tree_mismatch(
+                self.WORKING_COPY_TYPE_NAME, actual_tree_id, expected_tree_id
+            )
 
     def get_tree_id(self):
         return self.get_kart_state_value("*", "tree")
@@ -462,3 +463,38 @@ class WorkingCopyPart:
                 "Sorry, this type of filter is not yet supported when there are structural changes."
                 f" Unfilterable structural changes are affecting:\n{unsupported_filters}"
             )
+
+
+def handle_working_copy_tree_mismatch(wc_type_name, actual_tree_id, expected_tree_id):
+    actual_tree_id = f"tree {actual_tree_id}" if actual_tree_id else "the empty tree"
+    expected_tree_id = (
+        f"tree {expected_tree_id}" if expected_tree_id else "the empty tree"
+    )
+
+    message = [
+        f"The {wc_type_name} working copy appears to be out of sync with the repository.",
+        f"The working copy's own records show it is tracking {actual_tree_id};",
+        f"based on the repository it should be tracking {expected_tree_id}.",
+        "The most straight-forward fix is generally to recreate the working copy from the ground up (losing any uncommitted changes in the process.)",
+    ]
+
+    if get_input_mode() != InputMode.INTERACTIVE:
+        message.append("To do so, try the following command:")
+        message.append("kart create-workingcopy --delete-existing --discard-changes")
+        raise BadStateError("\n".join(message), exit_code=BAD_WORKING_COPY_STATE)
+
+    click.echo("\n".join(message))
+    click.echo()
+    if not click.confirm(
+        "Do you want to recreate the working copy from the ground up?"
+    ):
+        raise BadStateError(message[0], exit_code=BAD_WORKING_COPY_STATE)
+
+    from kart.create_workingcopy import create_workingcopy
+
+    click.echo("Recreating working copy ...")
+    ctx = click.get_current_context()
+    subctx = click.Context(ctx.command, parent=ctx)
+    subctx.obj = ctx.obj
+    subctx.invoke(create_workingcopy, delete_existing=True, discard_changes=True)
+    sys.exit(0)


### PR DESCRIPTION
If Kart crashes or otherwise is aborted partway through a checkout operation, it is possible for the contents of the working copy or individual working copy parts to end up out of sync with what should be checked out based on the git file `.kart/HEAD`.

Until now, this caused an internal error to be raised - WorkingCopyTreeMismatch, which gave some clues as to what had gone wrong but no real help on how to fix it. Since Kart checks the WC state is valid as a precondition to many commands, arriving in this state with no clear idea of how to get out of it makes a Kart repo feel pretty broken, as most commands will simply raise the same internal error.

This change adds an external error including error code (which also suppresses the stack trace). The error message
contains instructions on how to fix the repo so that it can be used again, and if run in an interactive terminal, prompts
the user to decide if they want to try this remedy immediately.