### PR TITLE
Use reflink to checkout tiles using copy-on-write

### DIFF
--- a/kart/workdir.py
+++ b/kart/workdir.py
@@ -447,7 +447,8 @@ class FileSystemWorkingCopy(WorkingCopyPart):
                     )
                     continue
                 try:
-                    _copy(lfs_path, wc_tiles_dir / tilename)
+                    # reflink doesn't like pathlib.Path
+                    _copy(str(lfs_path), str(wc_tiles_dir / tilename))
                 except ReflinkImpossibleError:  # CoW not supported
                     _copy = shutil.copy
                     _copy(lfs_path, wc_tiles_dir / tilename)

--- a/kart/workdir.py
+++ b/kart/workdir.py
@@ -449,7 +449,10 @@ class FileSystemWorkingCopy(WorkingCopyPart):
                 try:
                     # reflink doesn't like pathlib.Path
                     _copy(str(lfs_path), str(wc_tiles_dir / tilename))
-                except ReflinkImpossibleError:  # CoW not supported
+                except (
+                    ReflinkImpossibleError,
+                    NotImplementedError,
+                ):  # CoW not supported
                     _copy = shutil.copy
                     _copy(lfs_path, wc_tiles_dir / tilename)
 

--- a/kart/workdir.py
+++ b/kart/workdir.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import shutil
 import subprocess
 import sys
+from reflink import reflink, ReflinkImpossibleError
 
 import pygit2
 import sqlalchemy as sa
@@ -424,6 +425,7 @@ class FileSystemWorkingCopy(WorkingCopyPart):
 
     def write_full_datasets_to_workdir(self, datasets, track_changes_as_dirty=False):
         dataset_count = len(datasets)
+        _copy = reflink  # assume CoW filesystem
         for i, dataset in enumerate(datasets):
             assert isinstance(dataset, PointCloudV1)
 
@@ -444,7 +446,11 @@ class FileSystemWorkingCopy(WorkingCopyPart):
                         f"Couldn't find tile {tilename} locally - skipping...", err=True
                     )
                     continue
-                shutil.copy(lfs_path, wc_tiles_dir / tilename)
+                try:
+                    _copy(lfs_path, wc_tiles_dir / tilename)
+                except ReflinkImpossibleError:  # CoW not supported
+                    _copy = shutil.copy
+                    _copy(lfs_path, wc_tiles_dir / tilename)
 
         if not track_changes_as_dirty:
             self._reset_workdir_index_for_datasets(datasets)

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -13,6 +13,7 @@ rst2txt
 shellingham
 sqlalchemy
 tqdm
+reflink
 
 # jsonschema>=4.2 pulls in importlib_resources, which breaks PyInstaller<4.8
 # https://github.com/pyinstaller/pyinstaller/pull/6195

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -15,6 +15,7 @@ certifi==2022.12.7
     #   -r requirements.in
     #   cryptography
     #   pygit2
+    #   reflink
 click==8.1.3
     # via -r requirements.in
 colorama==0.4.6
@@ -53,6 +54,8 @@ pyodbc==4.0.32
     # via -r requirements.in
 pyrsistent==0.19.2
     # via jsonschema
+reflink==0.2.1
+    # via -r requirements.in
 #pysqlite3==0.4.5
     # via -r requirements.in
 rst2txt==1.1.0


### PR DESCRIPTION
Rebased and slightly fixed up version of [709](https://github.com/koordinates/kart/pull/709)

Use [pyreflink](https://gitlab.com/rubdos/pyreflink) to take advantage of copy-on-write capable filesystem when creating the working copy.

No changelog update - PC section is yet to be written.
Existing tests pass