### PR TITLE
vendor: tidy/speed up externalproject builds

### DIFF
--- a/vcpkg-vendor/CMakeLists.txt
+++ b/vcpkg-vendor/CMakeLists.txt
@@ -121,6 +121,7 @@ set(CFFI_WHEEL_VER 1.15.1)
 ExternalProject_Add(
   cffi
   URL https://files.pythonhosted.org/packages/2b/a8/050ab4f0c3d4c1b8aaa805f70e26e84d0e27004907c5b8ecc1d31815f92a/cffi-1.15.1.tar.gz
+  URL_HASH SHA256=d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9
   DOWNLOAD_NO_PROGRESS ON
   BUILD_IN_SOURCE ON
   DEPENDS wheelBuildEnv libffi
@@ -226,6 +227,7 @@ set(PYSCOPG2_WHEEL_VER 2.8.5)
 ExternalProject_Add(
   psycopg2
   URL https://files.pythonhosted.org/packages/a8/8f/1c5690eebf148d1d1554fc00ccf9101e134636553dbb75bdfef4f85d7647/psycopg2-2.8.5.tar.gz
+  URL_HASH SHA256=f7d46240f7a1ae1dd95aab38bd74f7428d46531f69219954266d669da60c0818
   DOWNLOAD_NO_PROGRESS ON
   BUILD_IN_SOURCE ON
   DEPENDS wheelBuildEnv PostgreSQL::PostgreSQL
@@ -297,6 +299,7 @@ ExternalProject_Add(
   pyodbc
   # if you build from a git repository, pyodbc adds +commit0c0ffee to the wheel version
   URL https://files.pythonhosted.org/packages/d1/21/755f5fa373d01d1803d992c7611799dc4e9fcbb5db7d0852990d6ab3c9ad/pyodbc-4.0.32.tar.gz
+  URL_HASH SHA256=9be5f0c3590655e1968488410fe3528bb8023d527e7ccec1f663d64245071a6b
   DOWNLOAD_NO_PROGRESS ON
   BUILD_IN_SOURCE ON
   DEPENDS wheelBuildEnv ${PYODBC_BUILD_DEPENDS}
@@ -474,7 +477,7 @@ endif()
 ExternalProject_Add(
   git-lfs
   GIT_REPOSITORY https://github.com/git-lfs/git-lfs
-  GIT_TAG main
+  GIT_TAG 02ac3de0e19fbfeea7f8ddb079cfe074367a48d3 # main @ 2023-01-06 (>v3.3.0)
   GIT_SHALLOW ON
   BUILD_IN_SOURCE ON
   EXCLUDE_FROM_ALL ON
@@ -496,7 +499,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   ExternalProject_Add(
     git
     URL https://github.com/koordinates/git/releases/download/kart-0.11.0-windows/MinGit-v2.34.0.windows.1.13-64-bit.zip
-    URL_HASH MD5=abe020e6ac70c6a6c2566d2c1b2b3d8a
+    URL_HASH SHA256=7dcbf2826721bde668bdc809539bf8cdaf49c11d5a66dd3a003949e95e992687
     DOWNLOAD_NO_PROGRESS ON
     BUILD_IN_SOURCE 1 # avoid creation of a build directory
     INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/git


### PR DESCRIPTION
## Description

* add SHA256 hashes to URLs
* git-lfs: resolve branch name to specific commit hash

Before: `cmake --build build`: 13.8s
After: `cmake --build build`: 12.9s

Not much different yet, but better approach :-) CMake's docs previously said that GIT_TAG should be a sha1, but that doesn't appear to be the current case (and makes no difference to speed)

> `GIT_TAG <tag>`
> Git branch name, tag or commit hash. Note that branch names and tags should generally be specified as remote names (i.e. origin/myBranch rather than simply myBranch). This ensures that if the remote end has its tag moved or branch rebased or history rewritten, the local clone will still be updated correctly. In general, however, specifying a commit hash should be preferred for a number of reasons:
> 
> If the local clone already has the commit corresponding to the hash, no git fetch needs to be performed to check for changes each time CMake is re-run. This can result in a significant speed up if many external projects are being used.
> 
> Using a specific git hash ensures that the main project's own history is fully traceable to a specific point in the external project's evolution. If a branch or tag name is used instead, then checking out a specific commit of the main project doesn't necessarily pin the whole build to a specific point in the life of the external project. The lack of such deterministic behavior makes the main project lose traceability and repeatability.
>
> If GIT_SHALLOW is enabled then GIT_TAG works only with branch names and tags. A commit hash is not allowed.

## Todo 
- [ ] prevent actually rebuilding the various wheels if the source hasn't changed. Which appears to be https://gitlab.kitware.com/cmake/cmake/-/issues/16419

## Related links:

#752 

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
