### PR TITLE
Implement `log --decorate-refs`

### DIFF
--- a/kart/log.py
+++ b/kart/log.py
@@ -224,6 +224,16 @@ def convert_user_patterns_to_raw_paths(paths, repo, commits):
     default=False,
     help="Doesn't print out the ref names of any commits that are shown. The option --no-decorate is short-hand for --decorate=no.",
 )
+@click.option(
+    "--decorate-refs",
+    multiple=True,
+    help=(
+        "Overrides the default list of refs to decorate commits with.\n"
+        "By default, references are used as decoration if they match "
+        "HEAD, refs/heads/, refs/remotes/, refs/stash/, or refs/tags/. "
+        "Can be used multiple times."
+    ),
+)
 @click.argument(
     "args",
     metavar="[REVISIONS] [--] [FILTERS]",
@@ -236,6 +246,7 @@ def log(
     json_style,
     dataset_changes,
     with_feature_count,
+    decorate_refs,
     args,
     **kwargs,
 ):
@@ -255,6 +266,9 @@ def log(
 
     paths = convert_user_patterns_to_raw_paths(filters, repo, commits)
     output_type, fmt = parse_output_format(output_format, json_style)
+
+    if decorate_refs:
+        options += [f"--decorate-refs={r}" for r in decorate_refs]
 
     # TODO: should we check paths exist here? git doesn't!
     if output_type == "text":

--- a/kart/log.py
+++ b/kart/log.py
@@ -246,7 +246,6 @@ def log(
     json_style,
     dataset_changes,
     with_feature_count,
-    decorate_refs,
     args,
     **kwargs,
 ):
@@ -266,9 +265,6 @@ def log(
 
     paths = convert_user_patterns_to_raw_paths(filters, repo, commits)
     output_type, fmt = parse_output_format(output_format, json_style)
-
-    if decorate_refs:
-        options += [f"--decorate-refs={r}" for r in decorate_refs]
 
     # TODO: should we check paths exist here? git doesn't!
     if output_type == "text":


### PR DESCRIPTION
## Description

Git 2.38 changed the refs that are included in `log` decorations.

Since i need something akin to the old behaviour (showing certain refs that aren't branches/tags/HEAD), I added this option to ask kart/git to decorate commits with refs matching specific patterns.

Git supports `--decorate-refs`, which can take (multiple) patterns to override the default list of refs with.

I implemented only the `--decorate-refs=<pattern>` option, but not `--clear-decorations` or `--decorate-refs-exclude`, and didn't implement any of the config options. The order-sensitive nature of those other options makes them hard to implement cleanly with Click, and I didn't need them right now.

⚠️ @olsen232 I haven't actually tested this PR as I can't get Kart building locally at present. We need to test it before merging obviously
## Related links:



https://www.git-scm.com/docs/git-log#Documentation/git-log.txt---decorate-refsltpatterngt

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
