### PR TITLE
Remove some things which were deprecated for removal in v0.12

### DIFF
--- a/kart/cli_util.py
+++ b/kart/cli_util.py
@@ -485,18 +485,6 @@ class OutputFormatType(click.ParamType):
         ]
 
 
-def parse_output_format(output_format, json_style):
-    output_type, fmt = output_format
-    if json_style is not None:
-        warnings.warn(
-            f"--json-style is deprecated and will be removed in Kart 0.12. use --output-format={output_type}:{json_style} instead",
-            RemovalInKart012Warning,
-        )
-        if output_type in ("json", "json-lines", "geojson"):
-            fmt = json_style
-    return output_type, fmt
-
-
 def find_param(ctx_or_params, name):
     """Given the click context / command / list of params - find the param with the given name."""
     ctx = ctx_or_params

--- a/kart/conflicts.py
+++ b/kart/conflicts.py
@@ -1,6 +1,6 @@
 import click
 from .conflicts_writer import BaseConflictsWriter
-from .cli_util import OutputFormatType, parse_output_format, KartCommand
+from .cli_util import OutputFormatType, KartCommand
 from .crs_util import CoordinateReferenceString
 from .repo import KartRepoState
 
@@ -27,11 +27,6 @@ from .repo import KartRepoState
     "--exit-code",
     is_flag=True,
     help="Make the program exit with 1 if there are conflicts and 0 means no conflicts.",
-)
-@click.option(
-    "--json-style",
-    type=click.Choice(["extracompact", "compact", "pretty"]),
-    help="[deprecated] How to format the output. Only used with `-o json` and `-o geojson`",
 )
 @click.option(
     "--exit-code",
@@ -62,7 +57,6 @@ def conflicts(
     output_format,
     output_path,
     exit_code,
-    json_style,
     summarise,
     flat,
     crs,
@@ -74,7 +68,7 @@ def conflicts(
     To list only particular conflicts, supply one or more FILTERS of the form [DATASET[:PRIMARY_KEY]]
     """
     repo = ctx.obj.get_repo(allowed_states=KartRepoState.MERGING)
-    output_type, fmt = parse_output_format(output_format, json_style)
+    output_type, fmt = output_format
 
     conflicts_writer_class = BaseConflictsWriter.get_conflicts_writer_class(output_type)
     conflicts_writer = conflicts_writer_class(

--- a/kart/diff.py
+++ b/kart/diff.py
@@ -92,11 +92,6 @@ def feature_count_diff(
     type=click.Path(writable=True, allow_dash=True),
 )
 @click.option(
-    "--json-style",
-    type=click.Choice(["extracompact", "compact", "pretty"]),
-    help="[deprecated] How to format the output. Only used with -o json or -o geojson",
-)
-@click.option(
     "--only-feature-count",
     default=None,
     type=click.Choice(diff_estimation.ACCURACY_CHOICES),
@@ -141,7 +136,6 @@ def diff(
     crs,
     output_path,
     exit_code,
-    json_style,
     only_feature_count,
     add_feature_count_estimate,
     convert_to_dataset_format,
@@ -168,7 +162,7 @@ def diff(
     """
     repo = ctx.obj.get_repo(allowed_states=KartRepoState.ALL_STATES)
     options, commits, filters = parse_revisions_and_filters(repo, args)
-    output_type, fmt = parse_output_format(output_format, json_style)
+    output_type, fmt = output_format
 
     assert len(commits) <= 2
     if len(commits) == 2:

--- a/kart/log.py
+++ b/kart/log.py
@@ -137,11 +137,6 @@ def convert_user_patterns_to_raw_paths(paths, repo, commits):
     default="text",
 )
 @click.option(
-    "--json-style",
-    type=click.Choice(["extracompact", "compact", "pretty"]),
-    help="[deprecated] How to format the output. Only used with --output-format=json",
-)
-@click.option(
     "--dataset-changes",
     is_flag=True,
     help="Shows which datasets were changed at each commit. Only works with --output-format-json",
@@ -243,7 +238,6 @@ def convert_user_patterns_to_raw_paths(paths, repo, commits):
 def log(
     ctx,
     output_format,
-    json_style,
     dataset_changes,
     with_feature_count,
     args,
@@ -264,7 +258,7 @@ def log(
     )
 
     paths = convert_user_patterns_to_raw_paths(filters, repo, commits)
-    output_type, fmt = parse_output_format(output_format, json_style)
+    output_type, fmt = output_format
 
     # TODO: should we check paths exist here? git doesn't!
     if output_type == "text":

--- a/kart/meta.py
+++ b/kart/meta.py
@@ -49,11 +49,6 @@ def meta(ctx, **kwargs):
     ),
     default="text",
 )
-@click.option(
-    "--json-style",
-    type=click.Choice(["extracompact", "compact", "pretty"]),
-    help="[deprecated] How to format the JSON output. Only used with -o json",
-)
 @click.option("--ref", default="HEAD")
 @click.option(
     "--with-dataset-types",
@@ -63,7 +58,7 @@ def meta(ctx, **kwargs):
 @click.argument("dataset", required=False)
 @click.argument("keys", required=False, nargs=-1)
 @click.pass_context
-def meta_get(ctx, output_format, json_style, ref, with_dataset_types, dataset, keys):
+def meta_get(ctx, output_format, ref, with_dataset_types, dataset, keys):
     """
     Prints the value of meta keys.
 
@@ -94,7 +89,7 @@ def meta_get(ctx, output_format, json_style, ref, with_dataset_types, dataset, k
                 **all_items[ds.path],
             }
 
-    output_type, fmt = parse_output_format(output_format, json_style)
+    output_type, fmt = output_format
 
     if output_type == "text":
         for ds_path, items in all_items.items():

--- a/kart/parse_args.py
+++ b/kart/parse_args.py
@@ -17,24 +17,14 @@ class PreserveDoubleDash(KartCommand):
     """
 
     def parse_args(self, ctx, args):
-        from kart.cli import get_version_tuple
-
         args = list(args)
         for i in range(len(args)):
             arg = args[i]
             if arg == "--":
-                if "--" in args[i + 1 :] and get_version_tuple() <= ("0", "12"):
-                    # Before we added this shim, we had users using a workaround (adding the `--` twice themselves),
-                    # which ideally we'd like them to stop doing.
-                    warnings.warn(
-                        "Using '--' twice is no longer needed, and will behave differently or fail in Kart 0.12",
-                        RemovalInKart012Warning,
-                    )
-                else:
-                    # Insert a second `--` arg.
-                    # One of the `--` gets consumed by Click during super() below.
-                    # Then the second one gets left alone and we can pass it to git.
-                    args.insert(i + 1, "--")
+                # Insert a second `--` arg.
+                # One of the `--` gets consumed by Click during super() below.
+                # Then the second one gets left alone and we can pass it to git.
+                args.insert(i + 1, "--")
                 break
 
         return super(PreserveDoubleDash, self).parse_args(ctx, args)

--- a/kart/show.py
+++ b/kart/show.py
@@ -55,11 +55,6 @@ from kart.repo import KartRepoState
     type=click.Path(writable=True, allow_dash=True),
 )
 @click.option(
-    "--json-style",
-    type=click.Choice(["extracompact", "compact", "pretty"]),
-    help="[deprecated] How to format the output. Only used with -o json",
-)
-@click.option(
     "--only-feature-count",
     default=None,
     type=click.Choice(diff_estimation.ACCURACY_CHOICES),
@@ -88,7 +83,6 @@ def show(
     crs,
     output_path,
     exit_code,
-    json_style,
     only_feature_count,
     diff_files,
     args,
@@ -113,7 +107,7 @@ def show(
 
     commit_spec = f"{commit}^?...{commit}"
 
-    output_type, fmt = parse_output_format(output_format, json_style)
+    output_type, fmt = output_format
 
     if only_feature_count:
         from .diff import feature_count_diff

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -254,18 +254,6 @@ def test_log_arg_handling(data_archive, cli_runner, output_format):
             assert r.exit_code == 0, r.stderr
             assert "Reflog" in r.stdout
 
-        # NOTE: this will fail the 0.12 release ; at that point we need to remove the code that
-        # generates the warning.
-        with pytest.warns(
-            UserWarning,
-            match="Using '--' twice is no longer needed, and will behave differently or fail in Kart 0.12",
-        ):
-            r = cli_runner.invoke(
-                ["log", "-o", output_format, "--", "--", "nz_pa_points_topo_150k"]
-            )
-            assert r.exit_code == 0, r.stderr
-            assert num_commits(r) == 2
-
 
 @pytest.mark.parametrize("output_format", ["text", "json"])
 def test_path_handling(data_archive, cli_runner, output_format):


### PR DESCRIPTION
## Description

These features (see individual commits) were deprecated some time before Kart v.0.11.0 and need to be removed for v0.12.0. Since that's imminent, I removed them.


## Related links:

none

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
