### PR TITLE
improve startup time by lazy-importing jsonschema 

### DIFF
--- a/kart/cli_util.py
+++ b/kart/cli_util.py
@@ -11,7 +11,6 @@ import sys
 from pathlib import Path
 
 import click
-import jsonschema
 import pygit2
 from click.core import Argument
 from click.shell_completion import CompletionItem
@@ -382,6 +381,8 @@ class JsonFromFile(StringFromFile):
                 ctx,
             )
         if self.schema:
+            # jsonschema is quite a heavyweight import
+            import jsonschema
             try:
                 jsonschema.validate(instance=value, schema=self.schema)
             except jsonschema.ValidationError as e:

--- a/requirements/CMakeLists.txt
+++ b/requirements/CMakeLists.txt
@@ -19,7 +19,7 @@ set(WHEEL_DEPS cryptography psycopg2 pygit2 gdal cffi pysqlite3
 set(PIP_COMPILE_COMMAND
     ${CMAKE_COMMAND} -E env CUSTOM_COMPILE_COMMAND="cmake --build build --target py-requirements"
     ${requirementsEnv_EXEC} pip-compile -v --annotate --no-emit-index-url --no-emit-trusted-host
-    --allow-unsafe)
+    --allow-unsafe --find-links "${CMAKE_BINARY_DIR}/vendor-tmp/wheelhouse" --no-emit-find-links)
 
 # Strip out wheels we provide:
 string(JOIN "|" wheelDepRegex ${WHEEL_DEPS})

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,11 +18,8 @@ backcall==0.2.0
 colorama==0.4.6
     # via
     #   -c docs.txt
-    #   -c requirements.txt
     #   -c test.txt
     #   -r dev.in
-    #   ipython
-    #   pytest
 decorator==5.1.1
     # via
     #   ipdb
@@ -57,7 +54,9 @@ packaging==22.0
 parso==0.8.3
     # via jedi
 pexpect==4.8.0
-    # via -r dev.in
+    # via
+    #   -r dev.in
+    #   ipython
 pickleshare==0.7.5
     # via ipython
 pluggy==1.0.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -16,9 +16,7 @@ charset-normalizer==2.1.1
     # via requests
 colorama==0.4.6
     # via
-    #   -c requirements.txt
     #   -c test.txt
-    #   sphinx
     #   sphinx-autobuild
 docutils==0.17.1
     # via

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -24,15 +24,10 @@ jsonschema<4.2
 # these are only here for dependencies, we build them in vcpkg-vendor,
 # and they're removed by CMake from the final requirements.txt files.
 # versions come from vcpkg-vendor/CMakeLists.txt
-cffi==1.15.1
-cryptography==38.0.3
-gdal==3.6.2
-psycopg2==2.8.5
-pygit2==1.3.0
-pysqlite3==0.4.5
-pyodbc==4.0.32
+-r vendor-wheels.txt
 
 # SQLAlchemy on Windows
+# FIXME: the constraint seems to be dropped during pip-compile
 greenlet; os_name!="posix"
 
 # workaround weird import error with pyinstaller

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -14,12 +14,7 @@ shellingham
 sqlalchemy
 tqdm
 reflink
-
-# jsonschema>=4.2 pulls in importlib_resources, which breaks PyInstaller<4.8
-# https://github.com/pyinstaller/pyinstaller/pull/6195
-# https://github.com/koordinates/kart/issues/425
-jsonschema<4.2
-
+jsonschema>=4.3
 
 # these are only here for dependencies, we build them in vcpkg-vendor,
 # and they're removed by CMake from the final requirements.txt files.

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,44 +6,36 @@
 #
 attrs==22.1.0
     # via jsonschema
-cached-property==1.5.2
-    # via pygit2
 certifi==2022.12.7
     # via -r requirements.in
 #cffi==1.15.1
     # via
-    #   -r requirements.in
+    #   -r vendor-wheels.txt
     #   cryptography
     #   pygit2
     #   reflink
 click==8.1.3
     # via -r requirements.in
-colorama==0.4.6
-    # via
-    #   click
-    #   tqdm
 #cryptography==38.0.3
-    # via -r requirements.in
+    # via -r vendor-wheels.txt
 docutils==0.17.1
     # via
     #   -r requirements.in
     #   rst2txt
 #gdal==3.6.2
-    # via -r requirements.in
+    # via -r vendor-wheels.txt
 greenlet==2.0.1 ; os_name != "posix"
-    # via
-    #   -r requirements.in
-    #   sqlalchemy
+    # via sqlalchemy
 jsonschema==4.1.2
     # via -r requirements.in
 msgpack==0.6.2
     # via -r requirements.in
 #psycopg2==2.8.5
-    # via -r requirements.in
+    # via -r vendor-wheels.txt
 pycparser==2.21
     # via cffi
-#pygit2==1.3.0
-    # via -r requirements.in
+#pygit2==1.9.0
+    # via -r vendor-wheels.txt
 pygments==2.13.0
     # via
     #   -r requirements.in
@@ -51,12 +43,12 @@ pygments==2.13.0
 pymysql==1.0.2
     # via -r requirements.in
 pyodbc==4.0.32
-    # via -r requirements.in
+    # via -r vendor-wheels.txt
 pyrsistent==0.19.2
     # via jsonschema
-reflink==0.2.1
-    # via -r requirements.in
 #pysqlite3==0.4.5
+    # via -r vendor-wheels.txt
+reflink==0.2.1
     # via -r requirements.in
 rst2txt==1.1.0
     # via -r requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -26,7 +26,7 @@ docutils==0.17.1
     # via -r vendor-wheels.txt
 greenlet==2.0.1 ; os_name != "posix"
     # via sqlalchemy
-jsonschema==4.1.2
+jsonschema==4.17.3
     # via -r requirements.in
 msgpack==0.6.2
     # via -r requirements.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -13,10 +13,7 @@ attrs==22.1.0
     #   -c requirements.txt
     #   pytest
 colorama==0.4.6
-    # via
-    #   -c requirements.txt
-    #   -r test.in
-    #   pytest
+    # via -r test.in
 coverage[toml]==6.5.0
     # via pytest-cov
 exceptiongroup==1.0.4

--- a/requirements/vendor-wheels.txt
+++ b/requirements/vendor-wheels.txt
@@ -1,0 +1,7 @@
+cffi==1.15.1
+cryptography==38.0.3
+gdal==3.6.2
+psycopg2==2.8.5
+pygit2==1.9.0
+pyodbc==4.0.32
+pysqlite3==0.4.5


### PR DESCRIPTION
## Description

About 19% of kart initialisation relates to importing [jsonschema](https://github.com/python-jsonschema/jsonschema) (via `-X importtime` analysis). We only use it in a single place, so lazy-import it. In addition, versions 4.0-4.2 have significant performance issues, so upgrade to the latest release.

Fix some issues wrt py-requirements compilation to enable that upgrade.

## Related links:

<!-- If you have links to [issues](https://github.com/koordinates/kart/issues) etc, link them here. -->

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
