### PR TITLE
Remove IPython from PyInstaller bundle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,8 +68,8 @@ set(VENDOR_ARCHIVE
 )
 
 if(MACOS)
-  option(MACOS_SIGN_BUNDLE "Notarize macOS bundle")
-  option(MACOS_SIGN_PKG "Notarize macOS .pkg installer")
+  option(MACOS_SIGN_BUNDLE "Code-sign macOS bundle")
+  option(MACOS_SIGN_PKG "Code-sign macOS .pkg installer")
   option(MACOS_NOTARIZE "Notarize macOS bundle & installer")
   set(MACOS_NOTARIZE_TIMEOUT
       1h
@@ -335,53 +335,69 @@ if(MACOS)
   ")
   set(CPACK_INSTALL_SCRIPTS ${CMAKE_CURRENT_BINARY_DIR}/macos-pkg-pre-install.cmake)
 
-  if(MACOS_SIGN_BUNDLE
-     AND MACOS_SIGN_PKG
-     AND MACOS_NOTARIZE)
+  if(MACOS_SIGN_BUNDLE OR MACOS_SIGN_PKG)
     file(
-      WRITE ${CMAKE_CURRENT_BINARY_DIR}/macos-pkg-post-build.cmake
+      WRITE ${CMAKE_CURRENT_BINARY_DIR}/cpack-macos-post-build-20-check-signing.cmake
       "
-      if(\${CPACK_GENERATOR} STREQUAL \"productbuild\")
+      if(\"${MACOS_SIGN_PKG}\" AND \${CPACK_GENERATOR} STREQUAL \"productbuild\")
         message(STATUS \"Checking PKG signature...\")
-        set(CPACK_POST_BUILD_OUTPUT_FILE_PATH \"\${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/\${CPACK_SYSTEM_NAME}/\${CPACK_GENERATOR}/\${CPACK_OUTPUT_FILE_NAME}\")
         execute_process(
-          COMMAND ${XCODE_PKGUTIL} --check-signature \${CPACK_POST_BUILD_OUTPUT_FILE_PATH}
+          COMMAND ${XCODE_PKGUTIL} --check-signature \${CPACK_TEMPORARY_PACKAGE_FILE_NAME}
           COMMAND_ECHO STDERR
           COMMAND_ERROR_IS_FATAL ANY)
-        message(STATUS \"Notarizing PKG with notarytool...\")
+
+      elseif(\"${MACOS_SIGN_BUNDLE}\" AND \${CPACK_GENERATOR} STREQUAL \"ZIP\")
+        message(STATUS \"Checking ZIP Bundle signature...\")
+        set(CHECK_DIR \"\${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/\${CPACK_SYSTEM_NAME}/ZIP-codesigning-check\")
+        file(REMOVE_RECURSE \${CHECK_DIR})
+        file(ARCHIVE_EXTRACT INPUT \"\${CPACK_TEMPORARY_PACKAGE_FILE_NAME}\" DESTINATION \${CHECK_DIR})
         execute_process(
-          COMMAND ${XCODE_XCRUN} notarytool submit \${CPACK_POST_BUILD_OUTPUT_FILE_PATH}
-            --keychain-profile \"$ENV{MACOS_NOTARIZE_KEYCHAIN_PROFILE}\"
-            --wait --timeout ${MACOS_NOTARIZE_TIMEOUT}
-          COMMAND_ECHO NONE
-          COMMAND_ERROR_IS_FATAL ANY)
-        message(STATUS \"Stapling notarization to PKG...\")
-        execute_process(
-          COMMAND ${XCODE_XCRUN} stapler staple \${CPACK_POST_BUILD_OUTPUT_FILE_PATH}
+          COMMAND ${XCODE_CODESIGN} --display --verbose \"\${CHECK_DIR}/\${CPACK_PACKAGE_FILE_NAME}/Kart.app\"
           COMMAND_ECHO STDERR
           COMMAND_ERROR_IS_FATAL ANY)
-        message(STATUS \"Checking PKG notarization...\")
         execute_process(
-          COMMAND ${XCODE_SPCTL} --assess -vvv --type install \${CPACK_POST_BUILD_OUTPUT_FILE_PATH}
+          COMMAND ${XCODE_CODESIGN} --verify --verbose --deep --strict=all \"\${CHECK_DIR}/\${CPACK_PACKAGE_FILE_NAME}/Kart.app\"
           COMMAND_ECHO STDERR
           COMMAND_ERROR_IS_FATAL ANY)
+
       endif()
       ")
-    set(CPACK_POST_BUILD_SCRIPTS ${CMAKE_CURRENT_BINARY_DIR}/macos-pkg-post-build.cmake)
-  elseif(MACOS_SIGN_BUNDLE AND MACOS_SIGN_PKG)
-    file(
-      WRITE ${CMAKE_CURRENT_BINARY_DIR}/macos-pkg-post-build.cmake
-      "
-      if(\${CPACK_GENERATOR} STREQUAL \"productbuild\")
-        message(STATUS \"Checking PKG signature...\")
-        set(CPACK_POST_BUILD_OUTPUT_FILE_PATH \"\${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/\${CPACK_SYSTEM_NAME}/\${CPACK_GENERATOR}/\${CPACK_OUTPUT_FILE_NAME}\")
-        execute_process(
-          COMMAND ${XCODE_PKGUTIL} --check-signature \${CPACK_POST_BUILD_OUTPUT_FILE_PATH}
-          COMMAND_ECHO STDERR
-          COMMAND_ERROR_IS_FATAL ANY)
-      endif()
-      ")
-    set(CPACK_POST_BUILD_SCRIPTS ${CMAKE_CURRENT_BINARY_DIR}/macos-pkg-post-build.cmake)
+    list(APPEND CPACK_POST_BUILD_SCRIPTS
+         ${CMAKE_CURRENT_BINARY_DIR}/cpack-macos-post-build-20-check-signing.cmake)
+
+    if(MACOS_NOTARIZE)
+      file(
+        WRITE ${CMAKE_CURRENT_BINARY_DIR}/cpack-macos-post-build-30-notarize.cmake
+        "
+        if(\"${MACOS_SIGN_PKG}\" AND \${CPACK_GENERATOR} STREQUAL \"productbuild\")
+          message(STATUS \"Checking PKG signature...\")
+          execute_process(
+            COMMAND ${XCODE_PKGUTIL} --check-signature \${CPACK_TEMPORARY_PACKAGE_FILE_NAME}
+            COMMAND_ECHO STDERR
+            COMMAND_ERROR_IS_FATAL ANY)
+          message(STATUS \"Notarizing PKG with notarytool...\")
+          execute_process(
+            COMMAND ${XCODE_XCRUN} notarytool submit \${CPACK_TEMPORARY_PACKAGE_FILE_NAME}
+              --keychain-profile \"$ENV{MACOS_NOTARIZE_KEYCHAIN_PROFILE}\"
+              --wait --timeout ${MACOS_NOTARIZE_TIMEOUT}
+            COMMAND_ECHO NONE
+            COMMAND_ERROR_IS_FATAL ANY)
+          message(STATUS \"Stapling notarization to PKG...\")
+          execute_process(
+            COMMAND ${XCODE_XCRUN} stapler staple \${CPACK_TEMPORARY_PACKAGE_FILE_NAME}
+            COMMAND_ECHO STDERR
+            COMMAND_ERROR_IS_FATAL ANY)
+          message(STATUS \"Checking PKG notarization...\")
+          execute_process(
+            COMMAND ${XCODE_SPCTL} --assess -vvv --type install \${CPACK_TEMPORARY_PACKAGE_FILE_NAME}
+            COMMAND_ECHO STDERR
+            COMMAND_ERROR_IS_FATAL ANY)
+
+        endif()
+        ")
+      list(APPEND CPACK_POST_BUILD_SCRIPTS
+           ${CMAKE_CURRENT_BINARY_DIR}/cpack-macos-post-build-30-notarize.cmake)
+    endif()
   endif()
 
   set(CPACK_GENERATOR "ZIP;productbuild")
@@ -438,11 +454,10 @@ elseif(WIN32)
       "
       if(\${CPACK_GENERATOR} STREQUAL \"WIX\")
         message(STATUS \"Code-signing MSI installer...\")
-        set(CPACK_POST_BUILD_OUTPUT_FILE_PATH \"\${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/\${CPACK_SYSTEM_NAME}/\${CPACK_GENERATOR}/\${CPACK_OUTPUT_FILE_NAME}\")
         execute_process(
           COMMAND
             \"${CMAKE_COMMAND}\" \"-DSIGNTOOL=${WIN_SIGNTOOL}\" \"-DAZURESIGNTOOL=${WIN_AZURESIGNTOOL}\"
-            \"-DFILES=\${CPACK_POST_BUILD_OUTPUT_FILE_PATH}\" \"-DDESCRIPTION=Kart Installer\" -P
+            \"-DFILES=\${CPACK_TEMPORARY_PACKAGE_FILE_NAME}\" \"-DDESCRIPTION=Kart Installer\" -P
             \"${CMAKE_CURRENT_LIST_DIR}/cmake/win_codesign.cmake\"
           COMMAND_ECHO STDERR
           COMMAND_ERROR_IS_FATAL ANY)

--- a/kart.spec
+++ b/kart.spec
@@ -145,7 +145,7 @@ else:
 
             datas.append((str(fp), dr))
 
-
+# Python package names here appear to be case-sensitive
 pyi_analysis = Analysis(
     ['platforms/kart_cli.py'],
     pathex=[],
@@ -176,8 +176,9 @@ pyi_analysis = Analysis(
     hookspath=[],
     runtime_hooks=[],
     excludes=[
-        'ipdb',
         "_kart_env",
+        "IPython",
+        "ipdb",
     ],
     win_no_prefer_redirects=False,
     win_private_assemblies=False,

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -14,4 +14,3 @@ ipython
     pexpect>4.3
     appnope
     colorama
-pytest-xdist

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -2,6 +2,11 @@
 -c test.txt
 -c docs.txt
 
+# If new packages are added here, check they don't end up in the PyInstaller
+# bundle. If they do, add to Analysis().excludes in /kart.spec. The bundle
+# process prints out the included files as it runs, or you can check the
+# PYMODULE entries in /build/pyinstaller/kart/Analysis-00.toc
+
 ipdb
 ipython
     # dependencies of ipython on various platforms...

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,14 +5,11 @@
 #    "cmake --build build --target py-requirements"
 #
 appnope==0.1.3
-    # via -r dev.in
+    # via
+    #   -r dev.in
+    #   ipython
 asttokens==2.2.1
     # via stack-data
-attrs==22.1.0
-    # via
-    #   -c requirements.txt
-    #   -c test.txt
-    #   pytest
 backcall==0.2.0
     # via ipython
 colorama==0.4.6
@@ -24,18 +21,8 @@ decorator==5.1.1
     # via
     #   ipdb
     #   ipython
-exceptiongroup==1.0.4
-    # via
-    #   -c test.txt
-    #   pytest
-execnet==1.9.0
-    # via pytest-xdist
 executing==1.2.0
     # via stack-data
-iniconfig==1.1.1
-    # via
-    #   -c test.txt
-    #   pytest
 ipdb==0.13.11
     # via -r dev.in
 ipython==8.7.0
@@ -46,11 +33,6 @@ jedi==0.18.2
     # via ipython
 matplotlib-inline==0.1.6
     # via ipython
-packaging==22.0
-    # via
-    #   -c docs.txt
-    #   -c test.txt
-    #   pytest
 parso==0.8.3
     # via jedi
 pexpect==4.8.0
@@ -59,10 +41,6 @@ pexpect==4.8.0
     #   ipython
 pickleshare==0.7.5
     # via ipython
-pluggy==1.0.0
-    # via
-    #   -c test.txt
-    #   pytest
 prompt-toolkit==3.0.36
     # via ipython
 ptyprocess==0.7.0
@@ -74,12 +52,6 @@ pygments==2.13.0
     #   -c docs.txt
     #   -c requirements.txt
     #   ipython
-pytest==7.2.0
-    # via
-    #   -c test.txt
-    #   pytest-xdist
-pytest-xdist==3.1.0
-    # via -r dev.in
 six==1.16.0
     # via
     #   -c docs.txt
@@ -91,7 +63,6 @@ tomli==2.0.1
     # via
     #   -c test.txt
     #   ipdb
-    #   pytest
 traitlets==5.7.1
     # via
     #   ipython

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -5,11 +5,12 @@ pytest
     # So we add them explicitly
     atomicwrites>=1.0
     colorama
-pytest-cov
-pytest-sugar
-pytest-helpers-namespace
 pytest-benchmark[aspect]
+pytest-cov
+pytest-helpers-namespace
+pytest-mock
 pytest-profiling
 pytest-shard
-pytest-mock
+pytest-sugar
+pytest-xdist
 html5lib

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,6 +18,8 @@ coverage[toml]==6.5.0
     # via pytest-cov
 exceptiongroup==1.0.4
     # via pytest
+execnet==1.9.0
+    # via pytest-xdist
 fields==5.0.0
     # via aspectlib
 gprof2dot==2022.7.29
@@ -44,6 +46,7 @@ pytest==7.2.0
     #   pytest-profiling
     #   pytest-shard
     #   pytest-sugar
+    #   pytest-xdist
 pytest-benchmark[aspect]==4.0.0
     # via -r test.in
 pytest-cov==4.0.0
@@ -57,6 +60,8 @@ pytest-profiling==1.7.0
 pytest-shard==0.1.2
     # via -r test.in
 pytest-sugar==0.9.6
+    # via -r test.in
+pytest-xdist==3.1.0
     # via -r test.in
 six==1.16.0
     # via


### PR DESCRIPTION
## Description

Wasn't intended to be there (is a dev dependency), and causes code-signing issues on macOS because non-binary resource files end up in `Kart.app/Contents/MacOS/` which is a bad thing.

```
$ codesign -v --verify --deep --strict=all ./Kart.app
./Kart.app: code object is not signed at all
In subcomponent: /Users/rcoup/Downloads/Kart-0.12.0/Kart-0.12.0-macOS-x86_64/Kart.app/Contents/MacOS/IPython/extensions/tests/__pycache__/test_autoreload.cpython-310.pyc
```

On macOS, check the final CPack zip archive contents passes code-signing validation too.

## Related links:

<!-- If you have links to [issues](https://github.com/koordinates/kart/issues) etc, link them here. -->

## Checklist:

- [X] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
