### PR TITLE
Modified `point-cloud-import --replace-existing` to reuse tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Please note that compatibility for 0.x releases (software or repositories) isn't
 
 _When adding new entries to the changelog, please include issue/PR numbers wherever possible._
 
+
+## 0.12.1
+
+- Modified `point-cloud-import --replace-existing` to reuse previously imported tiles, rather than reimport them, if tiles that have already been imported are imported again - potentially saving time and disk space. Note that `point-cloud-import --update-existing` already had this optimization.
+
 ## 0.12.0
 
 ### Major changes

--- a/tests/point_cloud/test_imports.py
+++ b/tests/point_cloud/test_imports.py
@@ -478,6 +478,23 @@ def test_import_update_existing(cli_runner, data_archive, requires_pdal):
             assert deletes == 1
 
 
+def test_import_replace_existing_with_no_changes(
+    cli_runner, data_archive, requires_pdal
+):
+    with data_archive("point-cloud/laz-auckland.tgz") as src:
+        with data_archive("point-cloud/auckland.tgz"):
+            r = cli_runner.invoke(
+                [
+                    "point-cloud-import",
+                    "--dataset-path=auckland",
+                    "--replace-existing",
+                    "--convert-to-copc",
+                    *glob(f"{src}/*.laz"),
+                ]
+            )
+            assert r.exit_code == NO_CHANGES, r.stderr
+
+
 def test_import_empty_commit_error(cli_runner, data_archive, requires_pdal):
     with data_archive("point-cloud/laz-auckland.tgz") as src:
         with data_archive("point-cloud/auckland.tgz"):


### PR DESCRIPTION
<img src="https://media1.giphy.com/media/7zaPsodlQj8QX5QmtE/giphy.gif"/>

Modified `point-cloud-import --replace-existing` to reuse previously imported tiles, rather than reimport them, if tiles that have already been imported are imported again - potentially saving time and disk space.

This is particularly relevant when importing with convert-to-copc, since converting to COPC can make the hash differ each time and so cause the same points to be stored more than once in equivalent but not identical files, at different hashes.

Note that `point-cloud-import --update-existing` already had this optimization.

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
