### PR TITLE
Reintroduce support for `kart log --graph`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## 0.12.1
 
-- Modified `point-cloud-import --replace-existing` to reuse previously imported tiles, rather than reimport them, if tiles that have already been imported are imported again - potentially saving time and disk space. Note that `point-cloud-import --update-existing` already had this optimization.
+- Modified `point-cloud-import --replace-existing` to reuse previously imported tiles, rather than reimport them, if tiles that have already been imported are imported again - potentially saving time and disk space. Note that `point-cloud-import --update-existing` already had this optimization. [#783](https://github.com/koordinates/kart/pull/783)
+- Reintroduced support for `log --graph`.
 
 ## 0.12.0
 
@@ -32,6 +33,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Support for changing the primary key column of an existing dataset. [#238](https://github.com/koordinates/kart/issues/238)
 - Help for the user get the working copy back into a valid state if a crash or similar causes it to become out of sync with the Kart repo. [#751](https://github.com/koordinates/kart/pull/751)
 - Enable the background CLI helper on Linux & macOS in CI builds. The helper improves CLI performance significantly. [#776](https://github.com/koordinates/kart/pull/776)
+- Dropped support for a variety of `kart log` options that were previously being forwarded to Git. [#508](https://github.com/koordinates/kart/issues/508)
 
 ## 0.11.5
 

--- a/kart/log.py
+++ b/kart/log.py
@@ -225,6 +225,14 @@ def convert_user_patterns_to_raw_paths(paths, repo, commits):
         "Can be used multiple times."
     ),
 )
+@click.option(
+    "--graph",
+    is_flag=True,
+    help=(
+        "Draw a text-based graphical representation of the commit history on the left hand side of the output. "
+        "This may cause extra lines to be printed in between commits, in order for the graph history to be drawn properly. "
+    ),
+)
 @click.argument(
     "args",
     metavar="[REVISIONS] [--] [FILTERS]",
@@ -262,6 +270,9 @@ def log(
         run("git", git_args)
 
     elif output_type in ("json", "json-lines"):
+        if kwargs.get("graph"):
+            raise click.UsageError("JSON output and --graph and not compatible")
+
         try:
             cmd = [
                 "git",


### PR DESCRIPTION
<img src="https://media0.giphy.com/media/3og0IExSrnfW2kUaaI/giphy.gif"/>

Also update the CHANGELOG which was missing the fact that support for this among other options was dropped as part of the 0.12 release (sorry)
