### PR TITLE
Add check_git_user to more commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 - Modified `point-cloud-import --replace-existing` to reuse previously imported tiles, rather than reimport them, if tiles that have already been imported are imported again - potentially saving time and disk space. Note that `point-cloud-import --update-existing` already had this optimization. [#783](https://github.com/koordinates/kart/pull/783)
 - Reintroduced support for `log --graph`. [#784](https://github.com/koordinates/kart/pull/784)
+- Added checks to various commands to ensure user.name and user.email have been configured (ie to `kart merge`), to bring them in line with `kart commit` behaviour. [#785](https://github.com/koordinates/kart/pull/785)
 
 ## 0.12.0
 

--- a/kart/apply.py
+++ b/kart/apply.py
@@ -7,7 +7,7 @@ import click
 import pygit2
 
 from kart.completion_shared import ref_completer
-
+from kart.core import check_git_user
 from kart.cli_util import KartCommand
 from kart.diff_structs import (
     FILES_KEY,
@@ -303,6 +303,9 @@ def apply_patch(
 
     if amend and not do_commit:
         raise click.UsageError("--no-commit and --amend are incompatible")
+
+    if do_commit:
+        check_git_user(repo)
 
     allow_minimal_updates = bool(resolve_missing_values_from_rs)
 

--- a/kart/merge.py
+++ b/kart/merge.py
@@ -6,6 +6,7 @@ import click
 from . import commit
 from .cli_util import StringFromFile, call_and_exit_flag, KartCommand
 from .conflicts_writer import BaseConflictsWriter
+from .core import check_git_user
 from .diff_util import get_repo_diff
 from .exceptions import InvalidOperation
 from .merge_util import (
@@ -128,6 +129,8 @@ def do_merge(repo, ff, ff_only, dry_run, commit, commit_message, quiet=False):
         merge_jdict["commit"] = "(dryRun)"
         return merge_jdict
 
+    check_git_user(repo)
+
     with write_to_packfile(repo):
         merge_tree_id = index.write_tree(repo, write_merged_index_flags(repo))
         L.debug(f"Merge tree: {merge_tree_id}")
@@ -221,6 +224,8 @@ def complete_merging_state(ctx):
         raise InvalidOperation(
             "Merge cannot be completed until all conflicts are resolved - see `kart conflicts`."
         )
+
+    check_git_user(repo)
 
     merge_context = MergeContext.read_from_repo(repo)
     commit_ids = merge_context.versions.map(lambda v: v.commit_id)

--- a/kart/meta.py
+++ b/kart/meta.py
@@ -13,6 +13,7 @@ from .cli_util import (
     value_optionally_from_binary_file,
     value_optionally_from_text_file,
 )
+from .core import check_git_user
 from .exceptions import NO_CHANGES, InvalidOperation, NotFound, NotYetImplemented
 from .output_util import (
     dump_json_output,
@@ -177,6 +178,8 @@ def meta_set(ctx, message, amend, dataset, items):
             "This repo doesn't support meta changes, use `kart upgrade`"
         )
 
+    check_git_user(repo)
+
     if message is None and not amend:
         message = f"Update metadata for {dataset}"
 
@@ -271,6 +274,8 @@ def commit_files(ctx, message, ref, amend, allow_empty, remove_empty_files, item
 
     if amend and not message:
         message = parent_commit.message
+
+    check_git_user(repo)
 
     original_tree = parent_commit.peel(pygit2.Tree)
     with packfile_object_builder(repo, original_tree) as object_builder:


### PR DESCRIPTION
If we don't check_git_user, these commands will fail. With the check, we still fail, but with the appropriate error message and the appropriate error code, which the caller can pick up on.