### PR TITLE
Fix helper mode + editor incompatibility

### DIFF
--- a/.ackrc
+++ b/.ackrc
@@ -8,6 +8,7 @@
 --ignore-directory=is:tests/data
 --ignore-directory=is:vendor
 --ignore-directory=is:vcpkg-vendor/vcpkg
+--ignore-directory=is:vcpkg-vendor/build
 --ignore-directory=is:venv
 --ignore-directory=match:/\.pytest/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Please note that compatibility for 0.x releases (software or repositories) isn't
 
 _When adding new entries to the changelog, please include issue/PR numbers wherever possible._
 
+## 0.12.2 (UNRELEASED)
+
+- Fix for issue with launching an editor while using helper mode, affects macOS and Linux. [#788](https://github.com/koordinates/kart/issues/788)
 
 ## 0.12.1
 

--- a/cli_helper/kart.c
+++ b/cli_helper/kart.c
@@ -192,6 +192,30 @@ int is_helper_enabled()
 }
 
 /**
+ * @brief Check whether using the helper is allowed for this kart command.
+ * the helper is disallowed for certain commands since they need to be able to launch an editor.
+ * Launching an editor from the helper doesn't work since it's not properly attached to the terminal.
+ * @return 0 no, 1 yes
+ */
+int is_helper_allowed(char **argv) {
+    char **arg_ptr;
+    for (arg_ptr = argv; *arg_ptr != NULL; arg_ptr++) {
+        if (strncmp(*arg_ptr, "-", 1) == 0 || strcmp(*arg_ptr, "kart") == 0) {
+            // Skip options.
+            continue;
+        }
+        // kart commit, kart merge, and kart pull can all spawn an editor for the commit message.
+        if (strcmp(*arg_ptr, "commit") == 0 ||
+            strcmp(*arg_ptr, "merge") == 0 ||
+            strcmp(*arg_ptr, "pull") == 0) {
+            return 0;
+        }
+        return 1;
+    }
+    return 1;
+}
+
+/**
  * @brief Exit signal handler for SIGALRM
  */
 void exit_on_alarm(int sig)
@@ -217,7 +241,7 @@ int main(int argc, char **argv, char **environ)
         exit(1);
     }
 
-    if (is_helper_enabled())
+    if (is_helper_enabled() && is_helper_allowed(argv))
     {
         debug("enabled %s, pid=%d\n", cmd_path, getpid());
 


### PR DESCRIPTION
Fix is to not use helper mode for kart commit, merge or pull.
See https://github.com/koordinates/kart/issues/788