### PR TITLE
Fix spurious schema changes when re-importing shapefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please note that compatibility for 0.x releases (software or repositories) isn't
 
 _When adding new entries to the changelog, please include issue/PR numbers wherever possible._
 
+## 0.12.3 (UNRELEASED)
+
+- Fix the issue where re-importing the same shapefile with `--replace-existing` would show spurious schema changes (and therefore row changes). [#791](https://github.com/koordinates/kart/issues/791)
+
 ## 0.12.2
 
 - Fix for issue with launching an editor while using helper mode, affects macOS and Linux. [#788](https://github.com/koordinates/kart/issues/788)

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -15,7 +15,7 @@ from memory_repo import MemoryRepo
 from kart import init, fast_import
 from kart.tabular.v3 import TableV3
 from kart.tabular.v3_paths import IntPathEncoder, MsgpackHashPathEncoder
-from kart.exceptions import WORKING_COPY_OR_IMPORT_CONFLICT
+from kart.exceptions import WORKING_COPY_OR_IMPORT_CONFLICT, NO_CHANGES
 from kart.sqlalchemy.gpkg import Db_GPKG
 from kart.schema import Schema
 from kart.geometry import ogr_to_gpkg_geom, gpkg_geom_to_ogr
@@ -301,6 +301,10 @@ def test_import_from_shp(
                 cmd += [f"--primary-key={layer.LAYER_PK}"]
             r = cli_runner.invoke(cmd)
             assert r.exit_code == 0, r.stderr
+
+            # Make sure schema-alignment is working for SHP files including with auto-generated PK:
+            r = cli_runner.invoke([*cmd, "--replace-existing"])
+            assert r.exit_code == NO_CHANGES
 
         repo = KartRepo(repo_path)
         dataset = repo.datasets()[layer.LAYER]


### PR DESCRIPTION
<img src="https://media4.giphy.com/media/AvMJCeu1EMmhG/giphy.gif"/>

Fix for #791 - Kart import --replace-existing with identical shapefile results in schema change

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
