### PR TITLE
Commit new table to a kart repo  #249

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 - Fix the issue where re-importing the same shapefile with `--replace-existing` would show spurious schema changes (and therefore row changes). [#791](https://github.com/koordinates/kart/issues/791)
 
+- Added support for committing new layers to a kart repository. When adding a new layer to a working copy, you can now commit the layer to add it to your kart repository. Previously, you could only commit changes to existing layers that were already tracked by kart.
+To commit a new layer, use the `add-dataset` command with the name of the layer and a commit message. If the layer is not yet tracked by kart, it will be added to the repository as a new layer.
+
 ## 0.12.2
 
 - Fix for issue with launching an editor while using helper mode, affects macOS and Linux. [#788](https://github.com/koordinates/kart/issues/788)

--- a/kart/add_dataset.py
+++ b/kart/add_dataset.py
@@ -1,0 +1,98 @@
+import click
+import sys
+from .cli_util import StringFromFile
+from .commit import (
+    commit_obj_to_json,
+    commit_json_to_text,
+    get_commit_message,
+    CommitDiffWriter,
+)
+from .output_util import dump_json_output
+from .working_copy import WorkingCopyPart
+from .exceptions import NO_CHANGES, NotFound
+from .status import get_untracked_tables
+
+
+@click.command()
+@click.argument("table_name")
+@click.pass_context
+@click.option(
+    "--message",
+    "-m",
+    multiple=True,
+    help=(
+        "Use the given message as the commit message. If multiple `-m` options are given, their values are "
+        "concatenated as separate paragraphs."
+    ),
+    type=StringFromFile(encoding="utf-8"),
+)
+@click.option(
+    " /--no-editor",
+    "launch_editor",
+    is_flag=True,
+    default=True,
+    hidden=True,
+    help="Whether to launch an editor to let the user choose the commit message.",
+)
+@click.option(
+    "--output-format",
+    "-o",
+    type=click.Choice(["text", "json"]),
+    default="text",
+)
+def add_dataset(ctx, table_name, message, launch_editor, output_format):
+    repo = ctx.obj.repo
+    # Check that the table is in the list of untracked tables:
+    untracked_tables = get_untracked_tables(repo)
+    if table_name not in untracked_tables:
+        raise NotFound(
+            f"""Table {table_name} is either not found or already tracked by kart.\n\nTry running 'kart status --list-untracked-tables'\n""",
+            exit_code=NO_CHANGES,
+        )
+
+    meta_items = repo.working_copy.tabular.meta_items(table_name)
+    table_diff = repo.working_copy.tabular.get_diff_for_table_creation(
+        table_name, meta_items
+    )
+
+    commit_table(
+        repo, table_diff, message, launch_editor, output_format, allow_empty=False
+    )
+
+
+def commit_table(
+    repo, table_diff, message, launch_editor, output_format, allow_empty=False
+):
+    if not table_diff and not allow_empty:
+        raise NotFound("No changes to commit", exit_code=NO_CHANGES)
+
+    do_json = output_format == "json"
+    commit_msg = None
+    if message:
+        commit_msg = "\n\n".join([m.strip() for m in message]).strip()
+    elif launch_editor:
+        commit_msg = get_commit_message(repo, table_diff, quiet=do_json)
+
+    if not commit_msg:
+        raise click.UsageError("Aborting commit due to empty commit message.")
+
+    commit_diff_writer = CommitDiffWriter(repo)
+    new_commit = repo.structure().commit_diff(
+        table_diff, commit_msg, allow_empty=allow_empty
+    )
+
+    repo.working_copy.soft_reset_after_commit(
+        new_commit,
+        quiet=do_json,
+        mark_as_clean=commit_diff_writer.repo_key_filter,
+        now_outside_spatial_filter=commit_diff_writer.now_outside_spatial_filter,
+        committed_diff=table_diff,
+    )
+
+    jdict = commit_obj_to_json(new_commit, repo, table_diff)
+    if do_json:
+        dump_json_output(jdict, sys.stdout)
+    else:
+        click.echo(commit_json_to_text(jdict))
+
+    repo.gc("--auto")

--- a/kart/cli.py
+++ b/kart/cli.py
@@ -54,6 +54,7 @@ MODULE_COMMANDS = {
     "tabular.import_": {"table-import"},
     "point_cloud.import_": {"point-cloud-import"},
     "install": {"install"},
+    "add_dataset": {"add-dataset"},
 }
 
 # These commands aren't valid Python symbols, even when we change dash to underscore.

--- a/kart/commit.py
+++ b/kart/commit.py
@@ -178,7 +178,6 @@ def commit(
 
     if not commit_msg:
         raise click.UsageError("Aborting commit due to empty commit message.")
-
     new_commit = repo.structure().commit_diff(
         wc_diff, commit_msg, allow_empty=allow_empty
     )

--- a/kart/tabular/working_copy/base.py
+++ b/kart/tabular/working_copy/base.py
@@ -1,6 +1,7 @@
 import contextlib
 import functools
 import logging
+import operator
 import time
 
 import click
@@ -454,12 +455,37 @@ class TableWorkingCopy(WorkingCopyPart):
             repo_diff.prune()
             return repo_diff
 
+
     def _is_dataset_supported(self, dataset):
         """
         Returns False if the given dataset cannot be created in this working copy.
         Generally returns True since we do our best to create all datasets, even if not 100% accurately.
         """
         return True
+
+
+    def get_diff_for_table_creation(self, table, meta_items):
+        """
+        Generates a diff for a new table.
+        """
+        ds_meta_items = meta_items
+        wc_meta_items = {}
+        with self.session():
+            meta_diff = DeltaDiff.diff_dicts(
+            wc_meta_items, ds_meta_items, delta_flags=WORKING_COPY_EDIT
+            )
+            schema = meta_diff['schema.json']
+            schema_value = schema.new.value
+            feature_diff = self.all_features_diff(table, schema_value, delta_type=Delta.insert)
+
+        ds_diff = DatasetDiff()
+        ds_diff["meta"] = meta_diff
+        ds_diff["feature"] = feature_diff
+
+        repo_diff = RepoDiff()
+        repo_diff[table] = ds_diff
+
+        return repo_diff
 
     def diff_dataset_to_working_copy(
         self, dataset, ds_filter=DatasetKeyFilter.MATCH_ALL, raise_if_dirty=False
@@ -483,12 +509,15 @@ class TableWorkingCopy(WorkingCopyPart):
         ds_diff["feature"] = feature_diff
         return ds_diff
 
+
     def diff_dataset_to_working_copy_meta(self, dataset, raise_if_dirty=False):
         """
         Returns a DeltaDiff showing all the changes of metadata between the dataset and this working copy.
         """
+
+        table_name = dataset.table_name
         ds_meta_items = self.adapter.remove_empty_values(dataset.meta_items())
-        wc_meta_items = self.meta_items(dataset)
+        wc_meta_items = self.meta_items(table_name)
         self._remove_hidden_meta_diffs(dataset, ds_meta_items, wc_meta_items)
         result = DeltaDiff.diff_dicts(
             ds_meta_items, wc_meta_items, delta_flags=WORKING_COPY_EDIT
@@ -591,7 +620,7 @@ class TableWorkingCopy(WorkingCopyPart):
         """
         return False
 
-    def meta_items(self, dataset):
+    def meta_items(self, table_name):
         """
         Extract all the metadata for this table and convert to dataset V2 format.
         Note that the extracted schema will not be aligned to any existing schema
@@ -603,20 +632,24 @@ class TableWorkingCopy(WorkingCopyPart):
         # That way, they don't vary at random if the same command is run twice in a row, but
         # they will vary as the repo state changes so that we don't accidentally generate the same ID twice
         # for two unrelated columns.
-        id_salt = f"{self.engine.url} {self.db_schema} {dataset.table_name} {self.get_tree_id()}"
+
+
+        id_salt = f"{self.engine.url} {self.db_schema} {table_name} {self.get_tree_id()}"
 
         with self.session() as sess:
             return self.adapter.all_v2_meta_items(
                 sess,
                 self.db_schema,
-                dataset.table_name,
+                table_name,
                 id_salt=id_salt,
             )
+
 
     def diff_dataset_to_working_copy_feature(
         self, dataset, feature_filter, meta_diff, raise_if_dirty=False
     ):
         schema_delta = meta_diff.get("schema.json")
+        schema = self._get_dataset_schema(dataset, meta_diff)
 
         if schema_delta and schema_delta.type == "delete":
             # The entire table has been deleted - add delete deltas for every feature.
@@ -630,7 +663,7 @@ class TableWorkingCopy(WorkingCopyPart):
         ):
             return dataset.all_features_diff(
                 delta_type=Delta.delete, flags=WORKING_COPY_EDIT
-            ) + self.all_features_diff(dataset, meta_diff, delta_type=Delta.delete)
+            ) + self.all_features_diff(dataset.table_name, schema, delta_type=Delta.delete)
 
         pk_field = dataset.schema.pk_columns[0].name
         find_renames = self.can_find_renames(meta_diff)
@@ -680,13 +713,17 @@ class TableWorkingCopy(WorkingCopyPart):
 
         return feature_diff
 
-    def all_features_diff(self, dataset, meta_diff, delta_type=Delta.insert):
+
+    def all_features_diff(self, table, schema, delta_type=Delta.insert):
+        """
+        Returns a diff containing all the features in the working copy.
+        """
         assert delta_type in (Delta.insert, Delta.delete)
-        pk_field = self._get_dataset_schema(dataset, meta_diff).pk_columns[0].name
+        pk_field = schema.pk_columns[0].name
 
         feature_diff = DeltaDiff()
         with self.session() as sess:
-            r = self._execute_all_rows_query(sess, dataset, meta_diff)
+            r = self._execute_all_rows_query(sess, table, schema)
             for row in r:
                 db_obj = {k: row[k] for k in row.keys()}
                 delta = Delta.insert((db_obj[pk_field], db_obj))
@@ -694,6 +731,7 @@ class TableWorkingCopy(WorkingCopyPart):
                 feature_diff.add_delta(delta)
 
         return feature_diff
+
 
     def _get_dataset_feature_and_fetch_if_needed(self, dataset, feature_pk):
         try:
@@ -779,14 +817,15 @@ class TableWorkingCopy(WorkingCopyPart):
 
         return sess.execute(query)
 
-    def _execute_all_rows_query(self, sess, dataset, meta_diff=None):
+
+    def _execute_all_rows_query(self, sess, table_name, schema):
         """
         Does a join on the tracking table and the table for the given dataset, and returns a result
         containing all the rows that have been inserted / updated / deleted.
         """
-        schema = self._get_dataset_schema(dataset, meta_diff)
-        table = self._table_def_for_schema(schema, dataset.table_name)
+        table = self._table_def_for_schema(schema, table_name)
         return sess.execute(sa.select(table.columns).select_from(table))
+
 
     def get_dirty_pks(self, dataset):
         kart_track = self.kart_tables.kart_track


### PR DESCRIPTION
## Description

- Added support for committing new layers to a kart repository. When adding a new layer to a working copy, you can now commit the layer to add it to your kart repository. Previously, you could only commit changes to existing layers that were already tracked by kart.
To commit a new layer, use the `add-dataset` command with the name of the layer and a commit message. If the layer is not yet tracked by kart, it will be added to the repository as a new layer.

## Related links:

[Issue 249](https://github.com/koordinates/kart/issues/249)

## Checklist:

- [X] Have you reviewed your own change?
- [X] Have you included test(s)?
- [X] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
