### PR TITLE
Start of PAM sidecar support

### DIFF
--- a/kart/point_cloud/tilename_util.py
+++ b/kart/point_cloud/tilename_util.py
@@ -64,5 +64,5 @@ def get_tile_path_pattern(
     version_pattern = (
         r"(?:\.ancestor|\.ours|\.theirs)?" if include_conflict_versions else ""
     )
-    ext_pattern = r"(?i:\.copc)?(?i:\.la[sz])"
+    ext_pattern = r"(?i:\.copc\.laz|\.la[sz])"
     return re.compile(parent_pattern + tile_pattern + version_pattern + ext_pattern)

--- a/kart/point_cloud/tilename_util.py
+++ b/kart/point_cloud/tilename_util.py
@@ -64,5 +64,5 @@ def get_tile_path_pattern(
     version_pattern = (
         r"(?:\.ancestor|\.ours|\.theirs)?" if include_conflict_versions else ""
     )
-    ext_pattern = r"(?:\.[Cc][Oo][Pp][Cc])?\.[Ll][Aa][SsZz]"
+    ext_pattern = r"(?i:\.copc)?(?i:\.la[sz])"
     return re.compile(parent_pattern + tile_pattern + version_pattern + ext_pattern)

--- a/kart/raster/import_.py
+++ b/kart/raster/import_.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import logging
 
 import click
@@ -163,3 +164,10 @@ class RasterImporter(TileImporter):
             source_oid = "sha256:" + source_oid
 
         return existing_summary.get("oid") == source_oid
+
+    def sidecar_files(self, source):
+        source = str(source)
+        if self.DATASET_CLASS.remove_tile_extension(source) != source:
+            sidecar_path = source + ".aux.xml"
+            if Path(sidecar_path).is_file():
+                yield sidecar_path

--- a/kart/raster/import_.py
+++ b/kart/raster/import_.py
@@ -5,10 +5,12 @@ import click
 
 from kart.cli_util import StringFromFile, MutexOption, KartCommand
 from kart.completion_shared import file_path_completer
+from kart.exceptions import InvalidOperation, INVALID_FILE_FORMAT
 from kart.parse_args import parse_import_sources_and_datasets
 from kart.raster.metadata_util import rewrite_and_merge_metadata
 from kart.raster.v1 import RasterV1
 from kart.tile.importer import TileImporter
+from kart.tile.tilename_util import find_similar_files_case_insensitive
 
 L = logging.getLogger(__name__)
 
@@ -167,7 +169,16 @@ class RasterImporter(TileImporter):
 
     def sidecar_files(self, source):
         source = str(source)
-        if self.DATASET_CLASS.remove_tile_extension(source) != source:
-            sidecar_path = source + ".aux.xml"
-            if Path(sidecar_path).is_file():
-                yield sidecar_path
+        if self.DATASET_CLASS.remove_tile_extension(source) == source:
+            return
+
+        pam_path = source + ".aux.xml"
+        pams = find_similar_files_case_insensitive(pam_path)
+        if len(pams) == 1:
+            yield pams[0], ".aux.xml"
+        if len(pams) > 1:
+            detail = "\n".join(str(p) for p in pams)
+            raise InvalidOperation(
+                f"More than one PAM file found for {source}:\n{detail}",
+                exit_code=INVALID_FILE_FORMAT,
+            )

--- a/kart/raster/metadata_util.py
+++ b/kart/raster/metadata_util.py
@@ -6,6 +6,7 @@ from xml.dom.minidom import Node
 from kart.crs_util import normalise_wkt
 from kart.geometry import ring_as_wkt
 from kart.list_of_conflicts import ListOfConflicts
+from kart.tile.tilename_util import find_similar_files_case_insensitive
 from kart.schema import Schema, ColumnSchema
 
 
@@ -93,10 +94,12 @@ def extract_raster_tile_metadata(raster_tile_path):
 
     try:
         raster_tile_path = Path(raster_tile_path)
-        aux_xml_path = raster_tile_path.with_name(raster_tile_path.name + ".aux.xml")
-        if aux_xml_path.is_file():
-            result.update(extract_aux_xml_metadata(aux_xml_path))
+        pam_path = raster_tile_path.with_name(raster_tile_path.name + ".aux.xml")
+        pams = find_similar_files_case_insensitive(pam_path)
+        if len(pams) == 1:
+            result.update(extract_aux_xml_metadata(pams[0]))
     except Exception as e:
+        # TODO - how to handle corrupted PAM file.
         L.warn("Error extracting aux-xml metadata", e)
 
     return result

--- a/kart/raster/tilename_util.py
+++ b/kart/raster/tilename_util.py
@@ -3,11 +3,15 @@ import re
 from kart.tile.tilename_util import TILE_BASENAME_PATTERN
 
 
-def remove_tile_extension(filename):
+def remove_tile_extension(filename, remove_pam_suffix=False):
     """Given a tile filename, removes the suffix .tif or .tiff"""
-    match = re.fullmatch(r"(.+?)\.tiff?", filename, re.IGNORECASE)
+    match = re.fullmatch(r"(.+?)(\.tiff?)?(\.aux\.xml)?", filename, re.IGNORECASE)
     if match:
-        return match.group(1)
+        return (
+            match.group(1)
+            if remove_pam_suffix
+            else match.group(1) + (match.group(3) or "")
+        )
     return filename
 
 
@@ -17,9 +21,9 @@ def set_tile_extension(filename, ext=None, tile_format=None):
     # Not much to do here since we only support one tile-format currently: a GeoTIFF that may or may not be COG.
     # TODO: maybe checkout as tif vs tiff should be user configurable.
     if ext is None:
-        ext = ".tif"
+        ext = ".tif.aux.xml" if filename.endswith(".aux.xml") else ".tif"
 
-    return remove_tile_extension(filename) + ext
+    return remove_tile_extension(filename, remove_pam_suffix=True) + ext
 
 
 def get_tile_path_pattern(

--- a/kart/raster/tilename_util.py
+++ b/kart/raster/tilename_util.py
@@ -10,7 +10,7 @@ def remove_tile_extension(filename, remove_pam_suffix=False):
         return (
             match.group(1)
             if remove_pam_suffix
-            else match.group(1) + (match.group(3) or "")
+            else match.group(1) + (match.group(3).lower() if match.group(3) else "")
         )
     return filename
 
@@ -50,5 +50,5 @@ def get_tile_path_pattern(
     version_pattern = (
         r"(?:\.ancestor|\.ours|\.theirs)?" if include_conflict_versions else ""
     )
-    ext_pattern = r"\.[Tt][Ii][Ff][Ff]?"
+    ext_pattern = r"(?i:\.tiff?)"
     return re.compile(parent_pattern + tile_pattern + version_pattern + ext_pattern)

--- a/kart/raster/v1.py
+++ b/kart/raster/v1.py
@@ -1,5 +1,7 @@
+import functools
+
 from kart.diff_structs import DatasetDiff, DeltaDiff, Delta, KeyValue, WORKING_COPY_EDIT
-from kart.key_filters import DatasetKeyFilter
+from kart.key_filters import DatasetKeyFilter, FeatureKeyFilter
 from kart.tile.tile_dataset import TileDataset
 from kart.raster.metadata_util import (
     extract_raster_tile_metadata,
@@ -42,6 +44,43 @@ class RasterV1(TileDataset):
             parent_path=parent_path,
             include_conflict_versions=include_conflict_versions,
         )
+
+    def diff_tile(self, other, tile_filter=FeatureKeyFilter.MATCH_ALL, reverse=False):
+        """
+        Yields tile deltas from self -> other, but only for tile that match the tile_filter.
+        If reverse is true, yields tile deltas from other -> self.
+        """
+
+        # PAM files deltas are output in the same delta as the tile they are attached to.
+        def _unify_pam_delta(key_value, pam_key_value):
+            if key_value is None or pam_key_value is None:
+                return key_value
+            return key_value.key, functools.partial(
+                _pam_delta_value_promise, key_value, pam_key_value
+            )
+
+        # Don't access lazy values until we need to, for efficient diff streaming.
+        def _pam_delta_value_promise(key_value, pam_key_value):
+            value = key_value.get_lazy_value()
+            pam_key_value = pam_key_value.get_lazy_value()
+            value["pamOid"] = pam_key_value["oid"]
+            value["pamSize"] = pam_key_value["size"]
+            return value
+
+        raw_diff = super().diff_tile(other, tile_filter=tile_filter, reverse=reverse)
+        result = DeltaDiff()
+        for key, delta in raw_diff.items():
+            if key.endswith(".aux.xml"):
+                continue
+            if f"{key}.aux.xml" in raw_diff:
+                pam_delta = raw_diff[f"{key}.aux.xml"]
+                old_half_delta = _unify_pam_delta(delta.old, pam_delta.old)
+                new_half_delta = _unify_pam_delta(delta.new, pam_delta.new)
+                result[key] = Delta(old_half_delta, new_half_delta)
+            else:
+                result[key] = delta
+
+        return result
 
     def diff_to_working_copy(
         self,

--- a/kart/raster/v1.py
+++ b/kart/raster/v1.py
@@ -46,11 +46,6 @@ class RasterV1(TileDataset):
         )
 
     def diff_tile(self, other, tile_filter=FeatureKeyFilter.MATCH_ALL, reverse=False):
-        """
-        Yields tile deltas from self -> other, but only for tile that match the tile_filter.
-        If reverse is true, yields tile deltas from other -> self.
-        """
-
         # PAM files deltas are output in the same delta as the tile they are attached to.
         def _unify_pam_delta(key_value, pam_key_value):
             if key_value is None or pam_key_value is None:

--- a/kart/tile/importer.py
+++ b/kart/tile/importer.py
@@ -28,6 +28,7 @@ from kart.key_filters import RepoKeyFilter
 from kart.lfs_util import (
     install_lfs_hooks,
     merge_dicts_to_pointer_file_bytes,
+    dict_to_pointer_file_bytes,
     copy_file_to_local_lfs_cache,
     get_hash_and_size_of_file,
 )
@@ -278,6 +279,15 @@ class TileImporter:
 
                 write_blob_to_stream(proc.stdin, blob_path, pointer_data)
 
+                for sidecar_file in self.sidecar_files(source):
+                    pointer_dict = copy_file_to_local_lfs_cache(self.repo, sidecar_file)
+                    pointer_data = dict_to_pointer_file_bytes(pointer_dict)
+                    rel_blob_path = self.DATASET_CLASS.tilename_to_blob_path(
+                        sidecar_file, relative=True
+                    )
+                    blob_path = f"{dataset_inner_path}/{rel_blob_path}"
+                    write_blob_to_stream(proc.stdin, blob_path, pointer_data)
+
             all_metadata = [existing_metadata] if include_existing_metadata else []
             all_metadata.extend(self.source_to_imported_metadata.values())
             self.actual_merged_metadata = self.get_actual_merged_metadata(all_metadata)
@@ -510,3 +520,6 @@ class TileImporter:
     def missing_parameter(self, param_name):
         """Raise a MissingParameter exception."""
         return click.MissingParameter(param=find_param(self.ctx, param_name))
+
+    def sidecar_files(self, source):
+        return []

--- a/kart/tile/importer.py
+++ b/kart/tile/importer.py
@@ -279,14 +279,10 @@ class TileImporter:
 
                 write_blob_to_stream(proc.stdin, blob_path, pointer_data)
 
-                for sidecar_file in self.sidecar_files(source):
+                for sidecar_file, suffix in self.sidecar_files(source):
                     pointer_dict = copy_file_to_local_lfs_cache(self.repo, sidecar_file)
                     pointer_data = dict_to_pointer_file_bytes(pointer_dict)
-                    rel_blob_path = self.DATASET_CLASS.tilename_to_blob_path(
-                        sidecar_file, relative=True
-                    )
-                    blob_path = f"{dataset_inner_path}/{rel_blob_path}"
-                    write_blob_to_stream(proc.stdin, blob_path, pointer_data)
+                    write_blob_to_stream(proc.stdin, blob_path + suffix, pointer_data)
 
             all_metadata = [existing_metadata] if include_existing_metadata else []
             all_metadata.extend(self.source_to_imported_metadata.values())

--- a/kart/tile/tile_dataset.py
+++ b/kart/tile/tile_dataset.py
@@ -304,8 +304,8 @@ class TileDataset(BaseDataset):
 
     def diff_tile(self, other, tile_filter=FeatureKeyFilter.MATCH_ALL, reverse=False):
         """
-        Yields tile deltas from self -> other, but only for tile that match the tile_filter.
-        If reverse is true, yields tile deltas from other -> self.
+        Returns a DeltaDiff of deltas from self -> other, but only for tiles that match the tile_filter.
+        If reverse is true, returns a DeltaDiff of deltas from other -> self.
         """
         return DeltaDiff(
             self.diff_subtree(

--- a/kart/tile/tilename_util.py
+++ b/kart/tile/tilename_util.py
@@ -28,7 +28,7 @@ def remove_any_tile_extension(filename):
 def case_insensitive(name):
     """
     Given a name eg "baz", returns a case-insensitive version that can be understood by pathlib.Path.glob
-    or the fnmatch module - eg "[Bb][Aa][Zz]"
+    - eg "[Bb][Aa][Zz]"
     """
     return re.sub(
         "[A-Za-z]", lambda m: f"[{m.group().upper()}{m.group().lower()}]", name

--- a/kart/tile/tilename_util.py
+++ b/kart/tile/tilename_util.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+import re
+
 # Allowed pattern for the the basename part of a tile's filename.
 # We don't allow tilenames to start with a "." since these are considered to be hidden -
 # and GDAL sometimes creates temporary files alongside TIF files that start with a "." and are best ignored.
@@ -20,3 +23,24 @@ def remove_any_tile_extension(filename):
         if len(filename) != orig_len:
             return filename
     return filename
+
+
+def case_insensitive(name):
+    """
+    Given a name eg "baz", returns a case-insensitive version that can be understood by pathlib.Path.glob
+    or the fnmatch module - eg "[Bb][Aa][Zz]"
+    """
+    return re.sub(
+        "[A-Za-z]", lambda m: f"[{m.group().upper()}{m.group().lower()}]", name
+    )
+
+
+def find_similar_files_case_insensitive(path):
+    """
+    Given the path to a particular file (which need not exist), finds all files in the same
+    directory which have the same name (case-insensitive) as that file.
+    Eg, given /foo/bar/baz, will find [/foo/bar/baz, /foo/bar/BAZ, /foo/bar/Baz], if those 3
+    files exist.
+    """
+    path = Path(path)
+    return list(path.parent.glob(case_insensitive(path.name)))

--- a/tests/raster/test_imports.py
+++ b/tests/raster/test_imports.py
@@ -1,3 +1,4 @@
+from kart.lfs_util import get_hash_and_size_of_file
 from kart.repo import KartRepo
 from .fixtures import requires_gdal_info  # noqa
 
@@ -132,7 +133,7 @@ def test_import_single_geotiff_with_rat(
             r = cli_runner.invoke(["import", f"{erosion}/erorisk_silcdb4.tif"])
             assert r.exit_code == 0, r.stderr
 
-            check_lfs_hashes(repo, 1)
+            check_lfs_hashes(repo, 2)
 
             r = cli_runner.invoke(["data", "ls"])
             assert r.exit_code == 0, r.stderr
@@ -246,4 +247,19 @@ def test_import_single_geotiff_with_rat(
                 "+                             nativeExtent = POLYGON((1573869.73 5155224.347,1573869.73 5143379.674,1585294.591 5143379.674,1585294.591 5155224.347,1573869.73 5155224.347))",
                 "+                                      oid = sha256:c4bbea4d7cfd54f4cdbca887a1b358a81710e820a6aed97cdf3337fd3e14f5aa",
                 "+                                     size = 604652",
+                "+                                   pamOid = sha256:d8f514e654a81bdcd7428886a15e300c56b5a5ff92898315d16757562d2968ca",
+                "+                                  pamSize = 36908",
             ]
+
+            tif = repo_path / "erorisk_silcdb4" / "erorisk_silcdb4.tif"
+            assert tif.is_file()
+            assert get_hash_and_size_of_file(tif) == (
+                "c4bbea4d7cfd54f4cdbca887a1b358a81710e820a6aed97cdf3337fd3e14f5aa",
+                604652,
+            )
+            pam = repo_path / "erorisk_silcdb4" / "erorisk_silcdb4.tif.aux.xml"
+            assert pam.is_file()
+            assert get_hash_and_size_of_file(pam) == (
+                "d8f514e654a81bdcd7428886a15e300c56b5a5ff92898315d16757562d2968ca",
+                36908,
+            )


### PR DESCRIPTION
Support for PAM (Persistent Auxiliary Metadata) files aka .tif.aux.xml files:

Changes:
- PAM files are imported
- PAM files are checked out
- PAM oid / size appears in the tile diff.
- Relevant tests pass

Not yet done (to be done in subsequent changes):
- Changes to PAM files in working copy cannot be diffed / committed.
- PAM files are not properly spatial filtered

https://github.com/koordinates/kart/issues/794

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
