### PR TITLE
Fix PDAL SSL cert handling in linux

### DIFF
--- a/kart/__init__.py
+++ b/kart/__init__.py
@@ -66,6 +66,13 @@ path_extras = [prefix]
 if not is_frozen:
     path_extras += [os.path.join(prefix, "scripts"), os.path.join(prefix, "lib")]
 
+if is_linux:
+    import certifi
+
+    os.environ["SSL_CERT_FILE"] = certifi.where()
+    # affects PDAL's libcurl, and possibly other libcurls
+    os.environ["CURL_CA_INFO"] = certifi.where()
+
 # Git
 # https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables
 os.environ["GIT_CONFIG_NOSYSTEM"] = "1"
@@ -133,10 +140,6 @@ gdal.UseExceptions()
 ogr.UseExceptions()
 osr.UseExceptions()
 
-if is_linux:
-    import certifi
-
-    os.environ["SSL_CERT_FILE"] = certifi.where()
 
 # Libgit2 options
 import pygit2


### PR DESCRIPTION
## Description

When kart runs its bundled `pdal` on linux (`/opt/kart/pdal`) it seems unable to handle S3 URLs, as it can't find the certificate bundle file.

output with `VERBOSE=1` in environment shows this:

```
* Connection #0 to host 169.254.169.254 left intact
*   Trying 3.5.166.161:443...
* Connected to {BUCKETNAME}.s3-ap-southeast-2.amazonaws.com (3.5.166.161) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
* error setting certificate file: /etc/pki/tls/certs/ca-bundle.crt
* Closing connection 0
```

`/etc/pki/tls/certs/ca-bundle.crt` doesn't exist and isn't the cert bundle that Kart ships with.

This PR sets `CURL_CA_INFO` to the correct path (`/opt/kart/certifi/cacert.pem`) and this fixes the issue with PDAL.


## Related links:

<!-- If you have links to [issues](https://github.com/koordinates/kart/issues) etc, link them here. -->

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
