### PR TITLE
Added a check for a pk in a table when using add-dataset command

### DIFF
--- a/kart/tabular/working_copy/base.py
+++ b/kart/tabular/working_copy/base.py
@@ -719,7 +719,15 @@ class TableWorkingCopy(WorkingCopyPart):
         Returns a diff containing all the features in the working copy.
         """
         assert delta_type in (Delta.insert, Delta.delete)
-        pk_field = schema.pk_columns[0].name
+
+        # TODO - support altering the user-provided table to add the PK column
+        # Check that the table has a primary key:
+        try:
+            pk_field = schema.pk_columns[0].name
+        except IndexError:
+            raise NotYetImplemented(
+                "Kart doesn't yet support committing tables with no primary key. Add a primary key column to the table and try again"
+            )
 
         feature_diff = DeltaDiff()
         with self.session() as sess:


### PR DESCRIPTION
## Description

The `add-dataset` command was breaking when a table didn't have a pk. I added a try-catch block to ensure this is handled properly.

## Related links:

[806](https://github.com/koordinates/kart/issues/806)

## Checklist:

- [X] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
