### PR TITLE
Added a test to check changes made to the table after creating it and committing it

### DIFF
--- a/kart/tabular/table_dataset.py
+++ b/kart/tabular/table_dataset.py
@@ -51,6 +51,9 @@ class TableDataset(BaseDataset, TableImportSource):
 
     @classmethod
     def new_dataset_for_writing(cls, path, schema, repo):
+        """
+        Creates a new dataset instance that can be used to write to a new dataset.
+        """
         result = cls(None, path, repo)
         result._schema = schema
         return result

--- a/kart/tabular/working_copy/base.py
+++ b/kart/tabular/working_copy/base.py
@@ -1046,7 +1046,7 @@ class TableWorkingCopy(WorkingCopyPart):
                     # Set up a sequence so that the user doesn't have to supply the next int PK.
                     self._initialise_sequence(sess, dataset)
 
-                self._create_triggers(sess, dataset)
+                self.create_triggers(sess, dataset)
                 self._update_last_write_time(sess, dataset, target_commit)
 
                 t1 = time.monotonic()

--- a/kart/tabular/working_copy/gpkg.py
+++ b/kart/tabular/working_copy/gpkg.py
@@ -508,7 +508,7 @@ class WorkingCopy_GPKG(TableWorkingCopy):
         # Newer repos that use kart branding use _kart_tracking_name.
         return f"gpkg_sno_{dataset.table_name}_{trigger_type}"
 
-    def _create_triggers(self, sess, dataset):
+    def create_triggers(self, sess, dataset):
         table_identifier = self.table_identifier(dataset)
         pk_column = self.quote(dataset.primary_key)
 
@@ -516,7 +516,7 @@ class WorkingCopy_GPKG(TableWorkingCopy):
         sess.execute(
             text_with_inlined_params(
                 f"""
-                CREATE TRIGGER {self._quoted_tracking_name('ins', dataset)}
+                CREATE TRIGGER IF NOT EXISTS {self._quoted_tracking_name('ins', dataset)}
                    AFTER INSERT ON {table_identifier}
                 BEGIN
                     INSERT OR REPLACE INTO {self.KART_TRACK} (table_name, pk)
@@ -530,7 +530,7 @@ class WorkingCopy_GPKG(TableWorkingCopy):
         sess.execute(
             text_with_inlined_params(
                 f"""
-                CREATE TRIGGER {self._quoted_tracking_name('upd', dataset)}
+                CREATE TRIGGER IF NOT EXISTS {self._quoted_tracking_name('upd', dataset)}
                    AFTER UPDATE ON {table_identifier}
                 BEGIN
                     INSERT OR REPLACE INTO {self.KART_TRACK} (table_name, pk)
@@ -544,7 +544,7 @@ class WorkingCopy_GPKG(TableWorkingCopy):
         sess.execute(
             text_with_inlined_params(
                 f"""
-                CREATE TRIGGER {self._quoted_tracking_name('del', dataset)}
+                CREATE TRIGGER IF NOT EXISTS {self._quoted_tracking_name('del', dataset)}
                    AFTER DELETE ON {table_identifier}
                 BEGIN
                     INSERT OR REPLACE INTO {self.KART_TRACK} (table_name, pk)
@@ -564,7 +564,7 @@ class WorkingCopy_GPKG(TableWorkingCopy):
     def _suspend_triggers(self, sess, dataset):
         self._drop_triggers(sess, dataset)
         yield
-        self._create_triggers(sess, dataset)
+        self.create_triggers(sess, dataset)
 
     def _is_schema_update_supported(self, schema_delta):
         if not schema_delta.old_value or not schema_delta.new_value:

--- a/kart/tabular/working_copy/mysql.py
+++ b/kart/tabular/working_copy/mysql.py
@@ -160,7 +160,7 @@ class WorkingCopy_MySql(DatabaseServer_WorkingCopy):
         """Returns the sno-branded name of the trigger reponsible for populating the sno_track table."""
         return f"_sno_track_{trigger_type}"
 
-    def _create_triggers(self, sess, dataset):
+    def create_triggers(self, sess, dataset):
         table_identifier = self.table_identifier(dataset)
         pk_column = self.quote(dataset.primary_key)
 
@@ -210,7 +210,7 @@ class WorkingCopy_MySql(DatabaseServer_WorkingCopy):
     def _suspend_triggers(self, sess, dataset):
         self._drop_triggers(sess, dataset)
         yield
-        self._create_triggers(sess, dataset)
+        self.create_triggers(sess, dataset)
 
     @classmethod
     def try_align_schema_col(cls, old_col_dict, new_col_dict):

--- a/kart/tabular/working_copy/postgis.py
+++ b/kart/tabular/working_copy/postgis.py
@@ -224,7 +224,7 @@ class WorkingCopy_Postgis(DatabaseServer_WorkingCopy):
         # are namespaced within the table they are attached to, so they don't require a db_schema.
         return trigger_type == "proc"
 
-    def _create_triggers(self, sess, dataset):
+    def create_triggers(self, sess, dataset):
         sess.execute(
             f"""
             CREATE TRIGGER {self._quoted_tracking_name("trigger")}

--- a/kart/tabular/working_copy/sqlserver.py
+++ b/kart/tabular/working_copy/sqlserver.py
@@ -203,7 +203,7 @@ class WorkingCopy_SqlServer(DatabaseServer_WorkingCopy):
         # Newer repos that use kart branding use _kart_tracking_name.
         return f"{dataset.table_name}_sno_track"
 
-    def _create_triggers(self, sess, dataset):
+    def create_triggers(self, sess, dataset):
         pk_name = dataset.primary_key
         # Placeholders not allowed in CREATE TRIGGER - have to use text_with_inlined_params.
         sess.execute(


### PR DESCRIPTION
## Description

Added triggers to add-dataset command for tracking changes

Add-dataset command lacked proper tracking triggers for tables, causing changes to be undetected.

Fixed by ensuring the _create_triggers function is called during the commit process within the same database transaction as reading the diff, preventing missed rows during commit.

## Related links:

[805](https://github.com/koordinates/kart/issues/805)

## Checklist:

- [X] Have you reviewed your own change?
- [X] Have you included test(s)?
- [X] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
