### PR TITLE
Add multi-worker support for tile import.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Improved progress reporting when importing tiles, in line with working copy checkout.
 - Added support for `--diff-format` option under `kart show` command to display different level of detail depending on the user's needs.  [#721](https://github.com/koordinates/kart/issues/721)
 - Allow for automatically resolving primary key conflicts during a merge using `kart resolve --renumber=(ours|theirs)` [#814](https://github.com/koordinates/kart/issues/814)
+- Improved tile import performance for point-cloud (and eventually raster) by making it multithreaded. [#818](https://github.com/koordinates/kart/pull/818)
 
 ## 0.12.2
 

--- a/kart/cli_util.py
+++ b/kart/cli_util.py
@@ -383,6 +383,7 @@ class JsonFromFile(StringFromFile):
         if self.schema:
             # jsonschema is quite a heavyweight import
             import jsonschema
+
             try:
                 jsonschema.validate(instance=value, schema=self.schema)
             except jsonschema.ValidationError as e:
@@ -500,7 +501,3 @@ def find_param(ctx_or_params, name):
         if param.name == name:
             return param
     raise RuntimeError(f"Couldn't find param: {name}")
-
-
-class RemovalInKart013Warning(UserWarning):
-    pass

--- a/kart/init.py
+++ b/kart/init.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import click
 
 
-from .cli_util import StringFromFile, RemovalInKart013Warning, KartCommand
+from .cli_util import StringFromFile, KartCommand
 from .completion_shared import file_path_completer
 from .core import check_git_user
 from .dataset_util import validate_dataset_paths
@@ -25,7 +25,7 @@ from .working_copy import PartType
 @click.option(
     "--import",
     "import_from",
-    help='Import a database (all tables): "FORMAT:PATH" eg. "GPKG:my.gpkg"',
+    help='Import a database (all tables): "FORMAT:PATH" eg. "GPKG:my.gpkg". Currently only tabular formats are supported.',
     shell_complete=file_path_completer,
 )
 @click.option(
@@ -74,8 +74,9 @@ from .working_copy import PartType
     help="--depth option to git-fast-import (advanced users only)",
 )
 @click.option(
+    "--num-workers",
     "--num-processes",
-    help="Deprecated (no longer used)",
+    help="How many import workers to run in parallel. This is not currently supported for tabular import, so this option is ignored.",
     default=None,
     hidden=True,
 )
@@ -95,18 +96,13 @@ def init(
     initial_branch,
     wc_location,
     max_delta_depth,
-    num_processes,
+    num_workers,
     spatial_filter_spec,
 ):
     """
     Initialise a new repository and optionally import data.
     DIRECTORY must be empty. Defaults to the current directory.
     """
-    if num_processes is not None:
-        warnings.warn(
-            "--num-processes is deprecated and will be removed in Kart 0.13.",
-            RemovalInKart013Warning,
-        )
 
     if directory is None:
         directory = os.curdir

--- a/kart/point_cloud/import_.py
+++ b/kart/point_cloud/import_.py
@@ -83,6 +83,14 @@ L = logging.getLogger(__name__)
         "such a commit. This option bypasses the safety"
     ),
 )
+@click.option(
+    "--num-workers",
+    "--num-processes",
+    type=click.INT,
+    help="How many import workers to run in parallel. Defaults to the number of available CPU cores.",
+    default=None,
+    hidden=True,
+)
 @click.option("--dataset-path", "--dataset", help="The dataset's path once imported")
 @click.argument(
     "args",
@@ -93,7 +101,6 @@ L = logging.getLogger(__name__)
 def point_cloud_import(
     ctx,
     convert_to_copc,
-    dataset_path,
     message,
     do_checkout,
     replace_existing,
@@ -101,6 +108,8 @@ def point_cloud_import(
     delete,
     amend,
     allow_empty,
+    num_workers,
+    dataset_path,
     args,
 ):
     """
@@ -127,6 +136,7 @@ def point_cloud_import(
         amend=amend,
         allow_empty=allow_empty,
         sources=sources,
+        num_workers=num_workers,
     )
 
 

--- a/kart/raster/import_.py
+++ b/kart/raster/import_.py
@@ -78,6 +78,14 @@ L = logging.getLogger(__name__)
         "such a commit. This option bypasses the safety"
     ),
 )
+@click.option(
+    "--num-workers",
+    "--num-processes",
+    type=click.INT,
+    help="How many import workers to run in parallel. Defaults to the number of available CPU cores.",
+    default=None,
+    hidden=True,
+)
 @click.option("--dataset-path", "--dataset", help="The dataset's path once imported")
 @click.argument(
     "args",
@@ -88,7 +96,6 @@ L = logging.getLogger(__name__)
 def raster_import(
     ctx,
     convert_to_cog,
-    dataset_path,
     message,
     do_checkout,
     replace_existing,
@@ -96,6 +103,8 @@ def raster_import(
     delete,
     amend,
     allow_empty,
+    num_workers,
+    dataset_path,
     args,
 ):
     """
@@ -125,6 +134,7 @@ def raster_import(
         amend=amend,
         allow_empty=allow_empty,
         sources=sources,
+        num_workers=num_workers,
     )
 
 

--- a/kart/tabular/import_.py
+++ b/kart/tabular/import_.py
@@ -1,4 +1,3 @@
-import warnings
 import click
 
 from kart import is_windows
@@ -8,7 +7,6 @@ from kart.cli_util import (
     StringFromFile,
     IdsFromFile,
     call_and_exit_flag,
-    RemovalInKart013Warning,
     KartCommand,
 )
 from kart.completion_shared import file_path_completer
@@ -157,8 +155,10 @@ def any_at_all(iterable):
     help="Whether to create a working copy once the import is finished, if no working copy exists yet.",
 )
 @click.option(
+    "--num-workers",
     "--num-processes",
-    help="Deprecated (no longer used)",
+    type=click.INT,
+    help="How many import workers to run in parallel. This is not currently supported for tabular import, so this option is ignored.",
     default=None,
     hidden=True,
 )
@@ -189,7 +189,7 @@ def table_import(
     allow_empty,
     max_delta_depth,
     do_checkout,
-    num_processes,
+    num_workers,
     ds_path,
     args,
 ):
@@ -220,12 +220,6 @@ def table_import(
 
     source = args[0]
     tables = args[1:]
-
-    if num_processes is not None:
-        warnings.warn(
-            "--num-processes is deprecated and will be removed in Kart 0.13.",
-            RemovalInKart013Warning,
-        )
 
     if output_format == "json" and not do_list:
         raise click.UsageError(

--- a/kart/tile/importer.py
+++ b/kart/tile/importer.py
@@ -1,8 +1,11 @@
+import concurrent.futures
+import functools
 import logging
+import math
 import os
-import uuid
 from pathlib import Path
 import sys
+import uuid
 
 import click
 import pygit2
@@ -39,6 +42,7 @@ from kart.tabular.version import (
     SUPPORTED_VERSIONS,
     extra_blobs_for_version,
 )
+from kart.utils import get_num_available_cores
 from kart.working_copy import PartType
 
 
@@ -67,6 +71,7 @@ class TileImporter:
         delete,
         amend,
         allow_empty,
+        num_workers,
         sources,
     ):
         """
@@ -81,10 +86,12 @@ class TileImporter:
         delete - list of existing tiles to delete, relevant when updating an existing dataset
         amend - if True, amends the previous commit rather than creating a new import commit
         allow_empty - if True, the import commit will be created even if the dataset is not changed
+        num_workers - specify the number of workers to use, or set to None to use the number of detected cores.
         sources - paths to tiles to import
         """
 
         self.sources = sources
+        self.num_workers = self.check_num_workers(num_workers)
 
         if not sources and not delete:
             # sources aren't required if you use --delete;
@@ -159,8 +166,9 @@ class TileImporter:
                 total=len(sources), unit="tile", desc="Checking tiles"
             )
             with progress as p:
-                for source in sources:
-                    tile_metadata = self.extract_tile_metadata(source)
+                for source, tile_metadata in self.extract_multiple_tiles_metadata(
+                    sources
+                ):
                     self.source_to_metadata[source] = tile_metadata
                     self.source_to_hash_and_size[source] = (
                         tile_metadata["tile"]["oid"],
@@ -331,6 +339,25 @@ class TileImporter:
         """
         return self.DATASET_CLASS.extract_tile_metadata_from_filesystem_path(tile_path)
 
+    def extract_multiple_tiles_metadata(self, sources):
+        # Single-threaded variant - uses the calling thread.
+        if self.num_workers == 1:
+            for source in sources:
+                yield source, self.extract_tile_metadata(source)
+            return
+
+        # Multi-worker variant - uses a thread-pool, calling thread just receives the results.
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=self.num_workers
+        ) as executor:
+            future_to_source = {
+                executor.submit(self.extract_tile_metadata, source): source
+                for source in sources
+            }
+            for future in concurrent.futures.as_completed(future_to_source):
+                source = future_to_source[future]
+                yield source, future.result()
+
     def check_metadata_pre_convert(self):
         """
         Use the self.source_to_metadata dict to see if any of the sources individually have properties that prevent
@@ -465,56 +492,77 @@ class TileImporter:
         return wrapped_func
 
     def import_tiles_to_stream(self, stream, sources):
+        already_imported = 0
+        copy_and_convert_tasks = {}
+
+        # First pass - check if the tile is already imported or if it needs to be converted,
+        # set up a callable function that will convert / hash / copy the tile to the right place as needed.
+        # This part is fast and runs single-threaded.
+        for source in sources:
+            source_metadata = self.source_to_metadata[source]
+            tilename = self.DATASET_CLASS.tilename_from_path(source)
+            rel_blob_path = self.DATASET_CLASS.tilename_to_blob_path(
+                tilename, relative=True
+            )
+            blob_path = f"{self.dataset_inner_path}/{rel_blob_path}"
+
+            # Check if tile has already been imported previously:
+            if self.existing_dataset is not None:
+                existing_summary = self.existing_dataset.get_tile_summary(
+                    tilename, missing_ok=True
+                )
+                if existing_summary:
+                    source_oid = self.source_to_hash_and_size[source][0]
+                    if self.existing_tile_matches_source(source_oid, existing_summary):
+                        # This tile has already been imported before. Reuse it rather than re-importing it.
+                        # Re-importing it could cause it to be re-converted, which is a waste of time,
+                        # and it may not convert the same the second time, which is then a waste of space
+                        # and shows up as a pointless diff.
+                        write_blob_to_stream(
+                            stream,
+                            blob_path,
+                            (self.existing_dataset.inner_tree / rel_blob_path).data,
+                        )
+                        self.include_existing_metadata = True
+                        already_imported += 1
+                        continue
+
+            conversion_func = self.wrap_conversion_func(
+                self.get_conversion_func(source_metadata)
+            )
+            if conversion_func is None:
+                self.source_to_imported_metadata[source] = self.source_to_metadata[
+                    source
+                ]
+                oid_and_size = self.source_to_hash_and_size[source]
+            else:
+                oid_and_size = None
+
+            copy_and_convert_tasks[source] = functools.partial(
+                copy_file_to_local_lfs_cache,
+                self.repo,
+                source,
+                conversion_func,
+                oid_and_size=oid_and_size,
+            )
+
+        # Second pass - actually convert / hash / copy the tile. This part can be multi-worker.
         progress = progress_bar(total=len(sources), unit="tile", desc="Importing tiles")
         with progress as p:
-            for source in sources:
-                source_metadata = self.source_to_metadata[source]
+            p.update(already_imported)
+
+            for source, pointer_dict in self.copy_multiple_files_to_lfs_cache(
+                copy_and_convert_tasks
+            ):
+                pointer_data = merge_dicts_to_pointer_file_bytes(
+                    self.source_to_imported_metadata[source]["tile"], pointer_dict
+                )
+
                 tilename = self.DATASET_CLASS.tilename_from_path(source)
                 rel_blob_path = self.DATASET_CLASS.tilename_to_blob_path(
                     tilename, relative=True
                 )
                 blob_path = f"{self.dataset_inner_path}/{rel_blob_path}"
-
-                # Check if tile has already been imported previously:
-                if self.existing_dataset is not None:
-                    existing_summary = self.existing_dataset.get_tile_summary(
-                        tilename, missing_ok=True
-                    )
-                    if existing_summary:
-                        source_oid = self.source_to_hash_and_size[source][0]
-                        if self.existing_tile_matches_source(
-                            source_oid, existing_summary
-                        ):
-                            # This tile has already been imported before. Reuse it rather than re-importing it.
-                            # Re-importing it could cause it to be re-converted, which is a waste of time,
-                            # and it may not convert the same the second time, which is then a waste of space
-                            # and shows up as a pointless diff.
-                            write_blob_to_stream(
-                                stream,
-                                blob_path,
-                                (self.existing_dataset.inner_tree / rel_blob_path).data,
-                            )
-                            self.include_existing_metadata = True
-                            continue
-
-                conversion_func = self.wrap_conversion_func(
-                    self.get_conversion_func(source_metadata)
-                )
-                if conversion_func is None:
-                    self.source_to_imported_metadata[source] = self.source_to_metadata[
-                        source
-                    ]
-                    oid_and_size = self.source_to_hash_and_size[source]
-                else:
-                    oid_and_size = None
-
-                pointer_dict = copy_file_to_local_lfs_cache(
-                    self.repo, source, conversion_func, oid_and_size=oid_and_size
-                )
-                pointer_data = merge_dicts_to_pointer_file_bytes(
-                    self.source_to_imported_metadata[source]["tile"], pointer_dict
-                )
-
                 write_blob_to_stream(stream, blob_path, pointer_data)
 
                 for sidecar_file, suffix in self.sidecar_files(source):
@@ -523,6 +571,25 @@ class TileImporter:
                     write_blob_to_stream(stream, blob_path + suffix, pointer_data)
 
                 p.update(1)
+
+    def copy_multiple_files_to_lfs_cache(self, copy_and_convert_tasks):
+        # Single-threaded variant - uses the calling thread.
+        if self.num_workers == 1:
+            for source, task in copy_and_convert_tasks.items():
+                yield source, task()
+            return
+
+        # Multi-worker variant - uses a thread-pool, calling thread just receives the results.
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=self.num_workers
+        ) as executor:
+            future_to_source = {
+                executor.submit(task): source
+                for source, task in copy_and_convert_tasks.items()
+            }
+            for future in concurrent.futures.as_completed(future_to_source):
+                source = future_to_source[future]
+                yield source, future.result()
 
     def write_meta_blobs_to_stream(self, stream, merged_metadata):
         """Writes the format.json, schema.json and crs.wkt meta items to the dataset."""
@@ -541,3 +608,22 @@ class TileImporter:
 
     def sidecar_files(self, source):
         return []
+
+    MAX_WORKERS = 64
+
+    def check_num_workers(self, num_workers):
+        if num_workers is None:
+            num_workers = self.get_default_num_workers()
+        if num_workers < 1:
+            num_workers = 1
+        elif num_workers > self.MAX_WORKERS:
+            raise click.UsageError(
+                f"Importing with more than {self.MAX_WORKERS} workers is not supported"
+            )
+        return num_workers
+
+    def get_default_num_workers(self):
+        num_workers = get_num_available_cores()
+        click.echo(num_workers)
+        # that's a float, but we need an int
+        return min(max(1, int(math.ceil(num_workers))), self.MAX_WORKERS)

--- a/kart/utils.py
+++ b/kart/utils.py
@@ -1,5 +1,8 @@
 import functools
 import itertools
+import os
+from pathlib import Path
+import platform
 
 
 def ungenerator(cast_function):
@@ -34,3 +37,34 @@ def chunk(iterable, size):
         if not chunk:
             return
         yield chunk
+
+
+def get_num_available_cores():
+    """
+    Returns the number of available CPU cores (best effort)
+      * uses cgroup quotas on Linux if available
+      * uses processor affinity on Windows/Linux if available
+      * otherwise, uses total number of CPU cores
+
+    The result is a float which may or may not be a round number, and may be less than 1.
+    """
+    if platform.system() == "Linux":
+        try:
+            quota = float(Path("/sys/fs/cgroup/cpu/cpu.cfs_quota_us").read_text())
+            period = float(Path("/sys/fs/cgroup/cpu/cpu.cfs_period_us").read_text())
+        except FileNotFoundError:
+            pass
+        else:
+            if quota == -1:
+                # no quota set
+                pass
+            else:
+                # note: this is a float, and may not be a round number
+                # (it's possible to allocate half-cores)
+                return quota / period
+    try:
+        return float(len(os.sched_getaffinity(0)))
+    except AttributeError:
+        # sched_getaffinity isn't available on some platforms (macOS mostly I think)
+        # Fallback to total machine CPUs
+        return float(os.cpu_count())


### PR DESCRIPTION
Affects both point cloud and raster tile import.
Doesn't affect diffing or committing..

Resurrected existing (deprecated) option --num-processes, but made it an alias for the preferred name: --num-workers.

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)? Existing tests pass
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
