### PR TITLE
Bugfix - don't require `user.name` and `user.email`...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Added support for `--diff-format` option under `kart show` command to display different level of detail depending on the user's needs.  [#721](https://github.com/koordinates/kart/issues/721)
 - Allow for automatically resolving primary key conflicts during a merge using `kart resolve --renumber=(ours|theirs)` [#814](https://github.com/koordinates/kart/issues/814)
 - Improved tile import performance for point-cloud (and eventually raster) by making it multithreaded. [#818](https://github.com/koordinates/kart/pull/818)
+- Fixed a bug where Kart would require `user.name` and `user.email` to be set, even when `GIT_AUTHOR_EMAIL` and similar variables were set in the environment. [#812](https://github.com/koordinates/kart/issues/812)
 
 ## 0.12.2
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -268,6 +268,11 @@ def test_check_user_config(git_user_config, monkeypatch, data_archive, tmp_path)
         with pytest.raises(click.ClickException) as e:
             check_git_user(repo=None)
         assert "Please tell me who you are" in str(e)
+
+        # The check should always pass if the user is setting these type of env variables:
+        monkeypatch.setenv("GIT_AUTHOR_EMAIL", "user@example.com")
+        check_git_user(repo=None)
+
     finally:
         pygit2.option(
             pygit2.GIT_OPT_SET_SEARCH_PATH, pygit2.GIT_CONFIG_LEVEL_GLOBAL, prev_home


### PR DESCRIPTION
when GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL, GIT_COMMITTER_NAME and GIT_COMMITTER_EMAIL are set in the environment.

There's some complexity here that makes it tricky to just check we have exactly what we need: Kart never actually needs to know the user name or user email. What it needs to know are the author or committer's name and email. And in practise it always does know these, since, the OS will probably be able to supply one (eg by `echo $USER`), and these defaults from the OS are picked up by the calls we use: `git var GIT_AUTHOR_IDENT` and `git var GIT_COMMITTER_IDENT`

The simplest fix that keeps the good behaviour we have - prompting new users to fill in user name and email if they haven't already - without messing things up for power users who want to set those env vars - is just to keep the check as is, but disable it if any of the env vars are set.

## Related links:

https://github.com/koordinates/kart/issues/812

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
