### PR TITLE
Add support for convert-to-cog during diff / commit

### DIFF
--- a/kart/raster/gdal_convert.py
+++ b/kart/raster/gdal_convert.py
@@ -1,5 +1,7 @@
 from osgeo import gdal
 
+from kart.raster.metadata_util import is_cog
+
 
 # Setting num-threads to two since we aim to spin up $ALL_CPUS threads and send tile-import GDAL tasks
 # to each thread - if we also configured each GDAL task to use $ALL_CPUS threads, then we would end up
@@ -10,6 +12,15 @@ gdal.SetConfigOption("GDAL_TIFF_INTERNAL_MASK", "TRUE")
 gdal.SetConfigOption("INTERLEAVE_OVERVIEW", "PIXEL")
 gdal.SetConfigOption("BIGTIFF_OVERVIEW", "IF_SAFER")
 gdal.SetConfigOption("GDAL_TIFF_OVR_BLOCKSIZE", "512")
+
+
+def convert_tile_to_format(source, dest, target_format):
+    """
+    Converts any GeoTIFF file at source to a tile of the given format at dest.
+    """
+    # convert-to-COG is the only tile conversion supported or required, so far.
+    assert is_cog(target_format)
+    return convert_tile_to_cog(source, dest)
 
 
 def convert_tile_to_cog(source, dest):

--- a/kart/raster/metadata_util.py
+++ b/kart/raster/metadata_util.py
@@ -348,6 +348,6 @@ def get_format_summary(format_info):
         format_info = format_info["format.json"]
 
     format_summary = format_info["fileType"]
-    if format_info["profile"]:
-        format_summary += f"/{format_info['profile']}"
+    if format_info.get("profile") == "cloud-optimized":
+        format_summary += "/cog"
     return format_summary


### PR DESCRIPTION
Just like point-clouds, uses --convert-to-dataset-format to decide whether to show diffs
(roughly) as they would be if the file was converted during commit to match the dataset,
and this flag is required during commit to go ahead and commit the change (otherwise,
of course, the tile doesn't match the dataset).

TODO - slightly related - make sure all the names are properly
 standardized during commit eg

foo.TIFF and foo.tif.AUX.XML should become foo.tif and foo.tif.aux.xml, this should actually rename the WC files as they are committed.

TODO - refactor some very similar raster / point-cloud code to avoid repetition.

https://github.com/koordinates/kart/issues/794

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
