### PR TITLE
vcpkg: update to include patchelf v0.18.0

### DIFF
--- a/vcpkg-vendor/vcpkg.json
+++ b/vcpkg-vendor/vcpkg.json
@@ -1,7 +1,7 @@
 {
     "name": "kart-vendor",
     "version-string": "0.1.2",
-    "builtin-baseline": "1e2a0f54808575de8ac947f2b0df2758c889fe5f",
+    "builtin-baseline": "7a3bd64ed5d4cb3d665d4b124d168286be3fd7e5",
     "dependencies": [
         {
             "name": "sqlite3",


### PR DESCRIPTION
## Description

Fixes #826, by upgrading patchelf in vcpkg to [v0.18.0](https://github.com/NixOS/patchelf/releases/tag/0.18.0). Avoids weird corruption in ELF structures as discussed in that issue.

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
