### PR TITLE
Suppress diffs caused by gdal info -stats -hist

### DIFF
--- a/kart/raster/pam_util.py
+++ b/kart/raster/pam_util.py
@@ -1,0 +1,53 @@
+import re
+
+
+def is_same_xml_ignoring_stats(lhs, rhs):
+    """
+    Returns True if two strings (left-hand-side, right-hand-side) of XML are the same,
+    or if they are the same except that gdal has inserted statistics into one of them,
+    in the form of a <Histograms> and/or <Metadata> block.
+    """
+    return (
+        lhs == rhs
+        or _lhs_is_rhs_minus_stats(lhs, rhs)
+        or _lhs_is_rhs_minus_stats(rhs, lhs)
+    )
+
+
+ANY_TAG = r"(<[^<>]+>)"
+HISTOGRAMS_PATTERN = re.compile(
+    rf"{ANY_TAG}\s*<Histograms>(.*)</Histograms>\s*{ANY_TAG}", re.DOTALL
+)
+# TODO - maybe check for non-statistics metadata.
+METADATA_PATTERN = re.compile(
+    rf"{ANY_TAG}\s*<Metadata>(.*)</Metadata>\s*{ANY_TAG}", re.DOTALL
+)
+
+
+def _lhs_is_rhs_minus_stats(lhs, rhs):
+    # Regex is sufficient for doing what we need to do here, which saves us parsing the XML.
+    for rhs_pattern in (HISTOGRAMS_PATTERN, METADATA_PATTERN):
+        rhs_match = re.search(rhs_pattern, rhs)
+        if not rhs_match:
+            continue
+        pre_tag = rhs_match.group(1)
+        post_tag = rhs_match.group(3)
+        # Look for the equivalent place in the LHS - a place preceded by pre_tag and succeeded
+        # by post_tag, but on the LHS it should be empty (contain only whitespace).
+        lhs_pattern = rf"{re.escape(pre_tag)}\s*{re.escape(post_tag)}"
+        lhs_match = re.search(lhs_pattern, lhs)
+        if not lhs_match:
+            # Can't find the equivalent place in the LHS, so, these files don't match.
+            return False
+
+        # We'll keep the tags outside this stats block intact (even though this code might work even if we didn't).
+        replace_with = f"{pre_tag}{post_tag}"
+        lhs_span = lhs_match.span()
+        lhs = f"{lhs[:lhs_span[0]]}{replace_with}{lhs[lhs_span[1]:]}"
+        rhs_span = rhs_match.span()
+        rhs = f"{rhs[:rhs_span[0]]}{replace_with}{rhs[rhs_span[1]:]}"
+
+        if lhs == rhs:
+            return True
+
+    return False

--- a/kart/raster/pam_util.py
+++ b/kart/raster/pam_util.py
@@ -1,53 +1,113 @@
-import re
+from xml.dom import minidom
+from xml.dom.minidom import Node
 
 
 def is_same_xml_ignoring_stats(lhs, rhs):
     """
-    Returns True if two strings (left-hand-side, right-hand-side) of XML are the same,
+    Returns True if two files (left-hand-side, right-hand-side) containing XML are the same,
     or if they are the same except that gdal has inserted statistics into one of them,
-    in the form of a <Histograms> and/or <Metadata> block.
+    in the form of <Histograms> and/or <Metadata> blocks.
+    Either file can be None meaning that the file does not exist.
+
+    The files, when not None, are read using minidom.parse, so can be string paths or file-like objects.
     """
-    return (
-        lhs == rhs
-        or _lhs_is_rhs_minus_stats(lhs, rhs)
-        or _lhs_is_rhs_minus_stats(rhs, lhs)
-    )
+    if lhs == rhs:
+        return True
+    elif lhs is None or rhs is None:
+        return _is_only_stats(lhs or rhs)
+    else:
+        return _is_same_xml_ignoring_stats(lhs, rhs)
 
 
-ANY_TAG = r"(<[^<>]+>)"
-HISTOGRAMS_PATTERN = re.compile(
-    rf"{ANY_TAG}\s*<Histograms>(.*)</Histograms>\s*{ANY_TAG}", re.DOTALL
-)
-# TODO - maybe check for non-statistics metadata.
-METADATA_PATTERN = re.compile(
-    rf"{ANY_TAG}\s*<Metadata>(.*)</Metadata>\s*{ANY_TAG}", re.DOTALL
-)
+STATISTICS_ELEMENTS = ["Histograms", "Metadata"]
+STATISTICS_CONTAINING_ELEMENTS = ["PAMDataset", "PAMRasterBand"]
 
 
-def _lhs_is_rhs_minus_stats(lhs, rhs):
-    # Regex is sufficient for doing what we need to do here, which saves us parsing the XML.
-    for rhs_pattern in (HISTOGRAMS_PATTERN, METADATA_PATTERN):
-        rhs_match = re.search(rhs_pattern, rhs)
-        if not rhs_match:
-            continue
-        pre_tag = rhs_match.group(1)
-        post_tag = rhs_match.group(3)
-        # Look for the equivalent place in the LHS - a place preceded by pre_tag and succeeded
-        # by post_tag, but on the LHS it should be empty (contain only whitespace).
-        lhs_pattern = rf"{re.escape(pre_tag)}\s*{re.escape(post_tag)}"
-        lhs_match = re.search(lhs_pattern, lhs)
-        if not lhs_match:
-            # Can't find the equivalent place in the LHS, so, these files don't match.
+def _is_only_stats(xml_file):
+    try:
+        with minidom.parse(xml_file) as parsed:
+            return _is_node_only_stats(parsed.firstChild)
+    except Exception:
+        # Don't suppress diffs if we weren't able to parse them.
+        return False
+
+
+def _is_node_only_stats(xml_node):
+    if xml_node.nodeType == Node.TEXT_NODE:
+        return xml_node.wholeText.isspace()
+    elif xml_node.nodeType == Node.ELEMENT_NODE:
+        if xml_node.tagName in STATISTICS_ELEMENTS:
+            return True
+        elif xml_node.tagName in STATISTICS_CONTAINING_ELEMENTS:
+            return all(_is_node_only_stats(child) for child in xml_node.childNodes)
+        else:
+            return False
+    else:
+        return False
+
+
+def _is_same_xml_ignoring_stats(lhs, rhs):
+    try:
+        with minidom.parse(lhs) as lhs_parsed, minidom.parse(rhs) as rhs_parsed:
+            return _is_same_element(
+                lhs_parsed.firstChild, rhs_parsed.firstChild, filter_out_stats=True
+            )
+    except Exception:
+        # Don't suppress diffs if we weren't able to parse them.
+        return False
+
+
+def _is_same_element(lhs_element, rhs_element, filter_out_stats=True):
+    assert lhs_element.nodeType == Node.ELEMENT_NODE
+    assert rhs_element.nodeType == Node.ELEMENT_NODE
+
+    if lhs_element.tagName != rhs_element.tagName:
+        return False
+
+    if bool(lhs_element.attributes) != bool(rhs_element.attributes):
+        return False
+
+    if bool(lhs_element.attributes):
+        if lhs_element.attributes.items() != lhs_element.attributes.items():
             return False
 
-        # We'll keep the tags outside this stats block intact (even though this code might work even if we didn't).
-        replace_with = f"{pre_tag}{post_tag}"
-        lhs_span = lhs_match.span()
-        lhs = f"{lhs[:lhs_span[0]]}{replace_with}{lhs[lhs_span[1]:]}"
-        rhs_span = rhs_match.span()
-        rhs = f"{rhs[:rhs_span[0]]}{replace_with}{rhs[rhs_span[1]:]}"
+    lhs_children = lhs_element.childNodes
+    rhs_children = rhs_element.childNodes
+    if filter_out_stats:
+        lhs_children = _filter_out_stats(lhs_children)
+        rhs_children = _filter_out_stats(rhs_children)
 
-        if lhs == rhs:
-            return True
+    for lhs_child, rhs_child in zip(lhs_children, rhs_children):
+        if lhs_child is None or rhs_child is None and lhs_child != rhs_child:
+            return False
 
-    return False
+        if lhs_child.nodeType != rhs_child.nodeType:
+            return False
+
+        if lhs_child.nodeType == Node.TEXT_NODE:
+            if lhs_child.wholeText != rhs_child.wholeText:
+                return False
+        elif lhs_child.nodeType == Node.ELEMENT_NODE:
+            if lhs_child.tagName != rhs_child.tagName:
+                return False
+            if not _is_same_element(
+                lhs_child,
+                rhs_child,
+                filter_out_stats=filter_out_stats
+                and lhs_child.tagName in STATISTICS_CONTAINING_ELEMENTS,
+            ):
+                return False
+
+    return True
+
+
+def _filter_out_stats(node_iter):
+    for node in node_iter:
+        if node.nodeType == Node.TEXT_NODE:
+            if not node.wholeText.isspace():
+                yield node
+        elif node.nodeType == Node.ELEMENT_NODE:
+            if node.tagName not in STATISTICS_ELEMENTS:
+                yield node
+        else:
+            yield node

--- a/kart/raster/v1.py
+++ b/kart/raster/v1.py
@@ -7,6 +7,7 @@ from kart.key_filters import DatasetKeyFilter, FeatureKeyFilter
 from kart.lfs_util import (
     copy_file_to_local_lfs_cache,
     dict_to_pointer_file_bytes,
+    get_local_path_from_lfs_hash,
     merge_pointer_file_dicts,
 )
 from kart.meta_items import MetaItemDefinition, MetaItemFileType
@@ -17,6 +18,7 @@ from kart.raster.metadata_util import (
     rewrite_and_merge_metadata,
     get_format_summary,
 )
+from kart.raster.pam_util import is_same_xml_ignoring_stats
 from kart.raster.tilename_util import (
     get_tile_path_pattern,
     remove_tile_extension,
@@ -175,6 +177,12 @@ class RasterV1(TileDataset):
 
             tile_delta = Delta(old_half_delta, new_half_delta)
             tile_delta.flags = WORKING_COPY_EDIT
+
+            if tile_delta.type == "update" and self._only_stats_have_changed(
+                tile_delta
+            ):
+                continue
+
             tile_diff[tilename] = tile_delta
 
         if not tile_diff:
@@ -237,10 +245,46 @@ class RasterV1(TileDataset):
                 tile_paths = find_similar_files_case_insensitive(
                     self._workdir_path(path[:-LEN_PAM_SUFFIX])
                 )
-                result.update("/".join(t.relative_to(wc_path).parts) for t in tile_paths)
+                result.update(
+                    "/".join(t.relative_to(wc_path).parts) for t in tile_paths
+                )
             else:
                 result.add(path)
         return result
+
+    def _only_stats_have_changed(self, tile_delta):
+        """
+        Given a tile delta where the new value is the current state of the WC,
+        return True if the only thing that has changed in the tile since the last commit
+        is that stats have been added or removed.
+        """
+        old_value = tile_delta.old_value
+        new_value = tile_delta.new_value
+
+        all_keys = set()
+        all_keys.update(old_value)
+        all_keys.update(new_value)
+        for key in all_keys:
+            if not key.startswith("pam") and old_value.get(key) != new_value.get(key):
+                return False
+
+        old_pam_oid = old_value.get("pamOid")
+        new_pam_oid = new_value.get("pamOid")
+        if old_pam_oid == new_pam_oid:
+            return True
+        if old_pam_oid is None or new_pam_oid is None:
+            return False
+
+        old_pam_path = get_local_path_from_lfs_hash(self.repo, old_pam_oid)
+        new_pam_name = new_value.get("pamSourceName") or new_value.get("pamName")
+        new_pam_path = self._workdir_path(f"{self.path}/{new_pam_name}")
+        if not old_pam_path.is_file() or not new_pam_path.is_file():
+            # Can't check if only stats have changed, so don't suppress the change.
+            return False
+
+        return is_same_xml_ignoring_stats(
+            old_pam_path.read_text(), new_pam_path.read_text()
+        )
 
     @property
     def tile_metadata(self):

--- a/tests/raster/test_pam_util.py
+++ b/tests/raster/test_pam_util.py
@@ -1,0 +1,174 @@
+from osgeo import gdal
+
+from kart.lfs_util import get_hash_and_size_of_file
+from kart.raster.pam_util import is_same_xml_ignoring_stats
+
+from .fixtures import requires_gdal_info  # noqa
+
+
+ORIGINAL = """
+<PAMDataset>
+  <PAMRasterBand band="1">
+    <Description>erorisk_si</Description>
+    <GDALRasterAttributeTable Row0Min="0" BinSize="1" tableType="thematic">
+      <FieldDefn index="0">
+        <Name>Histogram</Name>
+        <Type>1</Type>
+        <Usage>1</Usage>
+      </FieldDefn>
+    </GDALRasterAttributeTable>
+  </PAMRasterBand>
+</PAMDataset>
+""".lstrip()
+
+MODIFIED = """
+<PAMDataset>
+  <PAMRasterBand band="1">
+    <Description>erorisk_si</Description>
+    <GDALRasterAttributeTable Row0Min="0" BinSize="1" tableType="thematic">
+      <FieldDefn index="0">
+        <Name>Histogram</Name>
+        <Type>2</Type>
+        <Usage>2</Usage>
+      </FieldDefn>
+    </GDALRasterAttributeTable>
+  </PAMRasterBand>
+</PAMDataset>
+""".lstrip()
+
+WITH_STATS = """
+<PAMDataset>
+  <PAMRasterBand band="1">
+    <Description>erorisk_si</Description>
+    <Histograms>
+      <HistItem>
+        <HistMin>-0.5</HistMin>
+        <HistMax>255.5</HistMax>
+        <BucketCount>256</BucketCount>
+        <IncludeOutOfRange>1</IncludeOutOfRange>
+        <Approximate>0</Approximate>
+        <HistCounts>1|2|3|4|5|6|7|8|9|10</HistCounts>
+      </HistItem>
+    </Histograms>
+    <GDALRasterAttributeTable Row0Min="0" BinSize="1" tableType="thematic">
+      <FieldDefn index="0">
+        <Name>Histogram</Name>
+        <Type>1</Type>
+        <Usage>1</Usage>
+      </FieldDefn>
+    </GDALRasterAttributeTable>
+    <Metadata>
+      <MDI key="STATISTICS_MAXIMUM">9</MDI>
+      <MDI key="STATISTICS_MEAN">2.943554603143</MDI>
+      <MDI key="STATISTICS_MINIMUM">0</MDI>
+      <MDI key="STATISTICS_STDDEV">3.1322497995378</MDI>
+      <MDI key="STATISTICS_VALID_PERCENT">100</MDI>
+    </Metadata>
+  </PAMRasterBand>
+</PAMDataset>
+""".lstrip()
+
+MODIFIED_WITH_STATS = """
+<PAMDataset>
+  <PAMRasterBand band="1">
+    <Description>erorisk_si</Description>
+    <Histograms>
+      <HistItem>
+        <HistMin>-0.5</HistMin>
+        <HistMax>255.5</HistMax>
+        <BucketCount>256</BucketCount>
+        <IncludeOutOfRange>1</IncludeOutOfRange>
+        <Approximate>0</Approximate>
+        <HistCounts>1|2|3|4|5|6|7|8|9|10</HistCounts>
+      </HistItem>
+    </Histograms>
+    <GDALRasterAttributeTable Row0Min="0" BinSize="1" tableType="thematic">
+      <FieldDefn index="0">
+        <Name>Histogram</Name>
+        <Type>2</Type>
+        <Usage>2</Usage>
+      </FieldDefn>
+    </GDALRasterAttributeTable>
+    <Metadata>
+      <MDI key="STATISTICS_MAXIMUM">9</MDI>
+      <MDI key="STATISTICS_MEAN">2.943554603143</MDI>
+      <MDI key="STATISTICS_MINIMUM">0</MDI>
+      <MDI key="STATISTICS_STDDEV">3.1322497995378</MDI>
+      <MDI key="STATISTICS_VALID_PERCENT">100</MDI>
+    </Metadata>
+  </PAMRasterBand>
+</PAMDataset>
+""".lstrip()
+
+
+def test_is_same_xml_ignoring_stats():
+    assert is_same_xml_ignoring_stats(ORIGINAL, ORIGINAL)
+    assert is_same_xml_ignoring_stats(ORIGINAL, WITH_STATS)
+    assert is_same_xml_ignoring_stats(WITH_STATS, ORIGINAL)
+
+    assert not is_same_xml_ignoring_stats(ORIGINAL, MODIFIED)
+    assert not is_same_xml_ignoring_stats(MODIFIED, ORIGINAL)
+
+    assert not is_same_xml_ignoring_stats(ORIGINAL, MODIFIED_WITH_STATS)
+    assert not is_same_xml_ignoring_stats(MODIFIED_WITH_STATS, ORIGINAL)
+
+
+def test_add_stats_to_pam(
+    cli_runner,
+    data_archive,
+    requires_gdal_info,
+    requires_git_lfs,
+):
+    with data_archive("raster/erosion.tgz") as repo_path:
+        r = cli_runner.invoke(["diff", "--exit-code"])
+        assert r.exit_code == 0
+
+        tile_path = repo_path / "erorisk_si" / "erorisk_silcdb4.tif"
+        pam_path = repo_path / "erorisk_si" / "erorisk_silcdb4.tif.aux.xml"
+
+        orig_hash_and_size = (
+            "d8f514e654a81bdcd7428886a15e300c56b5a5ff92898315d16757562d2968ca",
+            36908,
+        )
+        assert get_hash_and_size_of_file(pam_path) == orig_hash_and_size
+
+        # This sort of command causes stats to be generated, but we don't want
+        # to show it as a diff to the user unless they make further changes:
+        gdal.Info(str(tile_path), options=["-stats", "-hist"])
+
+        assert get_hash_and_size_of_file(pam_path) != orig_hash_and_size
+
+        r = cli_runner.invoke(["status"])
+        assert r.exit_code == 0, r.stderr
+        assert r.stdout.splitlines() == [
+            "On branch main",
+            "",
+            "Nothing to commit, working copy clean",
+        ]
+
+        r = cli_runner.invoke(["diff", "--exit-code"])
+        assert r.exit_code == 0
+
+        # Real changes are not suppressed:
+        pam_path.write_text(
+            pam_path.read_text().replace(" risk", " opportunity"), newline="\n"
+        )
+
+        r = cli_runner.invoke(["status"])
+        assert r.exit_code == 0, r.stderr
+        assert r.stdout.splitlines() == [
+            "On branch main",
+            "",
+            "Changes in working copy:",
+            '  (use "kart commit" to commit)',
+            '  (use "kart restore" to discard changes)',
+            "",
+            "  erorisk_si:",
+            "    meta:",
+            "      1 updates",
+            "    tile:",
+            "      1 updates",
+        ]
+
+        r = cli_runner.invoke(["diff", "--exit-code"])
+        assert r.exit_code == 1

--- a/tests/raster/test_workingcopy.py
+++ b/tests/raster/test_workingcopy.py
@@ -1,5 +1,4 @@
 import shutil
-import platform
 
 import pytest
 


### PR DESCRIPTION
or similar commands / software.
QGIS and other gdal clients can create these diffs without the user really being aware of them, and we don't want to distract the user with diffs they don't care about until and unless they make further changes.

Not yet done - unsuppress these diffs with the right options.

https://github.com/koordinates/kart/issues/794

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
