### PR TITLE
Improve postgres testing environment 

### DIFF
--- a/tests/test_import_from_postgres.py
+++ b/tests/test_import_from_postgres.py
@@ -1,6 +1,3 @@
-import os
-
-
 def test_import_from_postgres_db_without_postgis_extension(
     no_postgis_db, cli_runner, tmp_path, chdir
 ):
@@ -17,7 +14,7 @@ def test_import_from_postgres_db_without_postgis_extension(
     assert r.exit_code == 0, r
     assert (repo_path / ".kart" / "HEAD").exists()
 
-    postgres_url = os.environ["KART_POSTGRES_URL"]
+    postgres_url = no_postgis_db.original_url
 
     # Import the test_table from the PostgreSQL container:
     with chdir(repo_path):


### PR DESCRIPTION
## Description

Fixing the testing environment for postgres environment variables.
Ensuring that a user can test the required tests with `KART_POSTGIS_URL`, `KART_NO_POSTGIS_URL` or `KART_POSTGRES_URL`, depending on the desired result.

## Related links:

A post-[728](https://github.com/koordinates/kart/issues/728) bug

## Checklist:

- [X] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
