### PR TITLE
Fix / improve tile spatial filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 ## 0.12.4 (UNRELEASED)
 
 - Allow kart to import non-spatial tables from PostgreSQL databases which don't have postGIS extension installed. [#728](https://github.com/koordinates/kart/issues/728)
+- Fixes a bug where the current spatial filter isn't stored in the filesystem working copy, affecting the spatial filtering of point cloud datasets. [#833](https://github.com/koordinates/kart/pull/833)
 
 ## 0.12.3
 

--- a/kart/core.py
+++ b/kart/core.py
@@ -83,6 +83,16 @@ def all_trees_with_paths_in_tree(tree, path="", ignore_hidden=True):
         yield from all_trees_with_paths_in_tree(entry, entry_path)
 
 
+def all_blobs_with_parent_in_tree(tree):
+    """Recursively yields all possible (parent, blob) tuples in the given directory tree."""
+    # For anything more complicated than this, you probably need walk_tree below.
+    for entry in tree:
+        if entry.type == pygit2.GIT_OBJ_BLOB:
+            yield tree, entry
+        elif entry.type == pygit2.GIT_OBJ_TREE:
+            yield from all_blobs_with_parent_in_tree(entry)
+
+
 def walk_tree(top, path="", topdown=True):
     """
     Corollary of os.walk() for git Tree objects:

--- a/kart/spatial_filter/__init__.py
+++ b/kart/spatial_filter/__init__.py
@@ -742,7 +742,9 @@ class OriginalSpatialFilter(SpatialFilter):
         def extract_geometry(tile):
             if getattr(tile, "type", None) == pygit2.GIT_OBJ_BLOB:
                 tile = pointer_file_bytes_to_dict(tile)
-            native_extent = tile["nativeExtent"]
+            native_extent = tile.get("nativeExtent")
+            if not native_extent:
+                return None
             if native_extent.startswith("POLYGON"):
                 return Geometry.from_wkt(native_extent)
             else:

--- a/kart/tabular/working_copy/base.py
+++ b/kart/tabular/working_copy/base.py
@@ -1,7 +1,6 @@
 import contextlib
 import functools
 import logging
-import operator
 import time
 
 import click
@@ -936,49 +935,6 @@ class TableWorkingCopy(WorkingCopyPart):
                 update_delta = delete_delta + insert_delta
                 feature_diff.add_delta(update_delta)
 
-    def update_state_table_tree(self, tree):
-        """Write the given tree to the state table."""
-        tree_id = tree.id.hex if isinstance(tree, pygit2.Tree) else tree
-        L.info(f"Tree sha: {tree_id}")
-        with self.session() as sess:
-            self._update_state_table_tree(sess, tree_id)
-
-    def _update_state_table_tree(self, sess, tree_id):
-        """
-        Write the given tree ID to the state table.
-
-        sess - sqlalchemy session.
-        tree_id - str, the hex SHA of the tree at HEAD.
-        """
-        r = sess.execute(
-            upsert(self.kart_tables.kart_state),
-            {"table_name": "*", "key": "tree", "value": tree_id or ""},
-        )
-        return r.rowcount
-
-    def _update_state_table_spatial_filter_hash(self, sess, spatial_filter_hash):
-        """
-        Write the given spatial filter hash to the state table.
-
-        sess - sqlalchemy session.
-        spatial_filter_hash - str, a hash of the spatial filter.
-        """
-        kart_state = self.kart_tables.kart_state
-        if spatial_filter_hash:
-            r = sess.execute(
-                upsert(kart_state),
-                {
-                    "table_name": "*",
-                    "key": "spatial-filter-hash",
-                    "value": spatial_filter_hash,
-                },
-            )
-        else:
-            r = sess.execute(
-                sa.delete(kart_state).where(kart_state.c.key == "spatial-filter-hash")
-            )
-        return r.rowcount
-
     @contextlib.contextmanager
     def _suspend_triggers(self, sess, dataset):
         """Context manager that temporarily disables the triggers that track dirty rows for the given dataset."""
@@ -1568,6 +1524,11 @@ class TableWorkingCopy(WorkingCopyPart):
             self.delete_features(
                 sess, now_outside_spatial_filter, track_changes_as_dirty=False
             )
+
+
+# Alias state_session to session:
+# a session the working-copy in general is also a good session for reading/writing the state table.
+TableWorkingCopy.state_session = TableWorkingCopy.session
 
 
 @contextlib.contextmanager

--- a/kart/tabular/working_copy/table_defs.py
+++ b/kart/tabular/working_copy/table_defs.py
@@ -263,5 +263,5 @@ class GpkgTables(TableSet):
         )
 
 
-# Makes GPKG table definitions are also accessible at the GpkgTables class itself:
+# Makes it so GPKG table definitions are also accessible at the GpkgTables class itself:
 GpkgTables.copy_tables_to_class()

--- a/tests/point_cloud/test_spatial_filters.py
+++ b/tests/point_cloud/test_spatial_filters.py
@@ -53,6 +53,8 @@ SOUTH_WEST_TILES = {
     "auckland_3_0.copc.laz",
 }
 
+ALL_AUCKLAND_TILES = {f"auckland_{x}_{y}.copc.laz" for x in range(4) for y in range(4)}
+
 
 def _tile_filenames_in_workdir(repo, ds_path):
     return set(f.name for f in (repo.workdir_path / ds_path).iterdir())
@@ -148,6 +150,11 @@ def test_reclone_pc_with_larger_spatial_filter(
         assert _count_files_in_lfs_cache(repo2) == len(
             SOUTH_EAST_TILES | SOUTH_WEST_TILES
         )
+
+        r = cli_runner.invoke(["-C", repo2_path, "checkout", "--spatial-filter=none"])
+        assert r.exit_code == 0, r.stderr
+        assert _tile_filenames_in_workdir(repo2, "auckland") == ALL_AUCKLAND_TILES
+        assert _count_files_in_lfs_cache(repo2) == len(ALL_AUCKLAND_TILES)
 
 
 def test_spatial_filtered_diff(data_archive, cli_runner, tmp_path, requires_pdal):


### PR DESCRIPTION
- Make tile spatial filtering work for PAM files, which should be spatial filtered based on the extent stored in the tile pointer file, not in the PAM pointer file.
- Fixes a bug: the hash of the current spatial filter should be stored in the "workdir-state.db" sqlite DB, since it's more likely to reflect the true state of the workdir than the git config which is easy for the user to tamper with. Since this step was missing previously, spatial filtering worked poorly for tile-based datasets - Kart would forget it had already applied a spatial filter and would reapply it, and would fail to unapply a spatial filter in response to `kart checkout --spatial-filter=none`

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
