### PR TITLE
No postgis 729

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 ## 0.12.4 (UNRELEASED)
 
 - Allow kart to import non-spatial tables from PostgreSQL databases which don't have postGIS extension installed. [#728](https://github.com/koordinates/kart/issues/728)
+- PostgreSQL working copy no longer requires PostGIS for aspatial datasets. [#729] (https://github.com/koordinates/kart/issues/729)
 
 ## 0.12.3
 

--- a/kart/tabular/v3.py
+++ b/kart/tabular/v3.py
@@ -450,3 +450,8 @@ class TableV3(RichTableDataset):
             existing_tree,
             resolve_missing_values_from_tree=resolve_missing_values_from_tree,
         )
+
+    @property
+    def is_spatial(self):
+        """Returns True if the dataset is spatial."""
+        return len(self.crs_definitions()) > 0

--- a/kart/tabular/working_copy/base.py
+++ b/kart/tabular/working_copy/base.py
@@ -1338,6 +1338,9 @@ class TableWorkingCopy(WorkingCopyPart):
         )
 
         with self.session() as sess:
+            # Check if the dataset is spatial, and if so, if the WC has any necessary spatial extension installed.
+            self._check_for_unsupported_ds_types(sess, target_datasets)
+
             # Delete old tables
             if ds_deletes:
                 self.drop_tables(
@@ -1568,6 +1571,9 @@ class TableWorkingCopy(WorkingCopyPart):
             self.delete_features(
                 sess, now_outside_spatial_filter, track_changes_as_dirty=False
             )
+
+    def _check_for_unsupported_ds_types(self, sess, target_datasets, schema="public"):
+        pass
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
## Description

Making kart allow the user to checkout a non-spatial working copy into a non-postgis database.
If there are spatial datasets in the repo, then the checkout should error out, with a message suggesting you install postGIS in your database.

## Related links:

[729](https://github.com/koordinates/kart/issues/729)

## Checklist:

- [X] Have you reviewed your own change?
- [X] Have you included test(s)?
- [X] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
