### PR TITLE
Flip --convert-to-cog flag: default is --preserve-format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Fixes a bug where the current spatial filter isn't stored in the filesystem working copy, affecting the spatial filtering of point cloud datasets. [#833](https://github.com/koordinates/kart/pull/833)
 - Fixes pthread_key leaks in a long running Kart process due to repeated loading and unloading of mod_spatialite. [#838](https://github.com/koordinates/kart/pull/838)
 - Fixes a bug where features are written to the working copy without their CRS identifier during `kart resolve`. [#840](https://github.com/koordinates/kart/issues/840)
+- Drop CI testing of amazonlinux:2, replace with amazonlinux:2023. [#838](https://github.com/koordinates/kart/pull/838)
+- Point clouds (or rasters): During import, switched the default behavior from "convert to cloud optimized" to "preserve format". [#839](https://github.com/koordinates/kart/pull/839)
 
 ## 0.12.3
 

--- a/kart/point_cloud/import_.py
+++ b/kart/point_cloud/import_.py
@@ -25,7 +25,7 @@ L = logging.getLogger(__name__)
     "--convert-to-copc/--no-convert-to-copc",
     " /--preserve-format",
     is_flag=True,
-    default=True,
+    default=False,
     help="Whether to convert all non-COPC LAS or LAZ files to COPC LAZ files, or to import all files in their native format.",
 )
 @click.option(

--- a/kart/raster/import_.py
+++ b/kart/raster/import_.py
@@ -24,7 +24,7 @@ L = logging.getLogger(__name__)
     "--convert-to-cog/--no-convert-to-cog",
     " /--preserve-format",
     is_flag=True,
-    default=True,
+    default=False,
     help="Whether to convert all GeoTIFFs to COGs (Cloud Optimized GeoTIFFs), or to import all files in their native format.",
 )
 @click.pass_context

--- a/tests/point_cloud/test_imports.py
+++ b/tests/point_cloud/test_imports.py
@@ -28,7 +28,7 @@ def count_head_tile_changes(cli_runner, dataset_path):
     return inserts, updates, deletes
 
 
-def test_import_single_las(
+def test_import_single_las__convert(
     tmp_path,
     chdir,
     cli_runner,
@@ -45,7 +45,12 @@ def test_import_single_las(
         repo = KartRepo(repo_path)
         with chdir(repo_path):
             r = cli_runner.invoke(
-                ["point-cloud-import", f"{autzen}/autzen.las", "--dataset-path=autzen"]
+                [
+                    "point-cloud-import",
+                    f"{autzen}/autzen.las",
+                    "--dataset-path=autzen",
+                    "--convert-to-copc",
+                ]
             )
             assert r.exit_code == 0, r.stderr
 
@@ -131,7 +136,7 @@ def test_import_single_las(
 
 @pytest.mark.slow
 @pytest.mark.parametrize("command", ["point-cloud-import", "import"])
-def test_import_several_laz(
+def test_import_several_laz__convert(
     command,
     tmp_path,
     chdir,
@@ -154,6 +159,7 @@ def test_import_several_laz(
                     command,
                     *glob(f"{auckland}/auckland_*.laz"),
                     "--dataset-path=auckland",
+                    "--convert-to-copc",
                 ]
             )
             assert r.exit_code == 0, r.stderr
@@ -214,7 +220,7 @@ def test_import_several_laz(
 
 
 @pytest.mark.parametrize("command", ["point-cloud-import", "import"])
-def test_import_single_laz_no_convert(
+def test_import_single_laz__no_convert(
     command,
     tmp_path,
     chdir,
@@ -386,6 +392,7 @@ def test_import_update_existing_non_homogenous(
                     "point-cloud-import",
                     "--dataset-path=auckland",
                     "--update-existing",
+                    "--convert-to-copc",
                     f"{src}/autzen.laz",
                 ]
             )
@@ -497,7 +504,7 @@ def test_import_empty_commit_error(cli_runner, data_archive, requires_pdal):
             assert "No changes to commit" in r.stderr
 
 
-def test_import_single_las_no_convert(
+def test_import_single_las__no_convert(
     tmp_path, chdir, cli_runner, data_archive_readonly, requires_pdal, requires_git_lfs
 ):
     with data_archive_readonly("point-cloud/las-autzen.tgz") as autzen:
@@ -533,6 +540,7 @@ def test_import_convert_to_copc_mismatched_CRS(
                         *glob(f"{auckland}/auckland_*.laz"),
                         f"{autzen}/autzen.las",
                         "--dataset-path=mixed",
+                        "--convert-to-copc",
                     ]
                 )
                 assert r.exit_code == WORKING_COPY_OR_IMPORT_CONFLICT
@@ -573,6 +581,7 @@ def test_import_convert_to_copc_mismatched_schema(
                     f"{autzen}/autzen.las",
                     f"{tmp_path}/converted.laz",
                     "--dataset-path=mixed",
+                    "--convert-to-copc",
                 ]
             )
             assert r.exit_code == WORKING_COPY_OR_IMPORT_CONFLICT

--- a/tests/raster/test_imports.py
+++ b/tests/raster/test_imports.py
@@ -180,7 +180,9 @@ def test_import_single_cogtiff(
 
         repo = KartRepo(repo_path)
         with chdir(repo_path):
-            r = cli_runner.invoke(["import", f"{aerial}/aerial.tif"])
+            r = cli_runner.invoke(
+                ["import", f"{aerial}/aerial.tif", "--convert-to-cog"]
+            )
             assert r.exit_code == 0, r.stderr
 
             check_lfs_hashes(repo, 1)
@@ -192,7 +194,6 @@ def test_import_single_cogtiff(
             r = cli_runner.invoke(["show"])
             assert r.exit_code == 0, r.stderr
 
-            # NOTE: this particular format is still subject to change.
             assert r.stdout.splitlines()[6:] == AERIAL_CRS_DIFF + [
                 "+++ aerial:meta:format.json",
                 "+ {",
@@ -240,7 +241,9 @@ def test_import_single_geotiff_with_rat(
 
         repo = KartRepo(repo_path)
         with chdir(repo_path):
-            r = cli_runner.invoke(["import", f"{erosion}/erorisk_silcdb4.tif"])
+            r = cli_runner.invoke(
+                ["import", f"{erosion}/erorisk_silcdb4.tif", "--convert-to-cog"]
+            )
             assert r.exit_code == 0, r.stderr
 
             check_lfs_hashes(repo, 2)
@@ -252,7 +255,6 @@ def test_import_single_geotiff_with_rat(
             r = cli_runner.invoke(["show"])
             assert r.exit_code == 0, r.stderr
 
-            # NOTE: this particular format is still subject to change.
             assert r.stdout.splitlines()[6:] == [
                 "+++ erorisk_silcdb4:meta:band/band-1-categories.json",
                 "+ {",


### PR DESCRIPTION
TODO (in further PRs) - add confirmation prompts / inform the user about this option during imports.

--convert-to-dataset-format may also need changing, internal discussion is ongoing.

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
