### PR TITLE
Fix for https://github.com/koordinates/kart-qgis-plugin/issues/100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - PostgreSQL working copy no longer requires PostGIS for aspatial datasets. [#729] (https://github.com/koordinates/kart/issues/729)
 - Fixes a bug where the current spatial filter isn't stored in the filesystem working copy, affecting the spatial filtering of point cloud datasets. [#833](https://github.com/koordinates/kart/pull/833)
 - Fixes pthread_key leaks in a long running Kart process due to repeated loading and unloading of mod_spatialite. [#838](https://github.com/koordinates/kart/pull/838)
+- Fixes a bug where features are written to the working copy without their SRID during `kart resolve`. [#840](https://github.com/koordinates/kart/issues/840)
 
 ## 0.12.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - PostgreSQL working copy no longer requires PostGIS for aspatial datasets. [#729] (https://github.com/koordinates/kart/issues/729)
 - Fixes a bug where the current spatial filter isn't stored in the filesystem working copy, affecting the spatial filtering of point cloud datasets. [#833](https://github.com/koordinates/kart/pull/833)
 - Fixes pthread_key leaks in a long running Kart process due to repeated loading and unloading of mod_spatialite. [#838](https://github.com/koordinates/kart/pull/838)
-- Fixes a bug where features are written to the working copy without their SRID during `kart resolve`. [#840](https://github.com/koordinates/kart/issues/840)
+- Fixes a bug where features are written to the working copy without their CRS identifier during `kart resolve`. [#840](https://github.com/koordinates/kart/issues/840)
 
 ## 0.12.3
 

--- a/kart/resolve.py
+++ b/kart/resolve.py
@@ -277,7 +277,9 @@ def update_workingcopy_with_resolve(
         if wc is None:
             return
         dataset = load_dataset(rich_conflict)
-        features = [dataset.get_feature(path=r.path, data=repo[r.id]) for r in res]
+        features = [
+            dataset.get_feature_with_crs_id(path=r.path, data=repo[r.id]) for r in res
+        ]
         with wc.session() as sess:
             wc.delete_features(sess, rich_conflict.as_key_filter())
             if features:

--- a/kart/tabular/rich_table_dataset.py
+++ b/kart/tabular/rich_table_dataset.py
@@ -57,6 +57,17 @@ class RichTableDataset(TableDataset):
             )
         )
 
+    def get_feature_with_crs_id(self, pk_values=None, *, path=None, data=None):
+        """
+        Same as table_dataset.get_feature(...), but includes the CRS ID from the schema in every Geometry object.
+        By contrast, the returned Geometry from table_dataset.get_feature() will contain a CRS ID of zero,
+        so the schema must be consulted separately to learn about CRS IDs.
+        """
+        return self._add_crs_ids_to_feature(
+            self.get_feature(pk_values=pk_values, path=path, data=data),
+            self._cols_to_crs_ids(),
+        )
+
     def _add_crs_ids_to_features(self, features):
         cols_to_crs_ids = self._cols_to_crs_ids()
 

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -77,7 +77,8 @@ def test_resolve_with_version(data_working_copy, cli_runner):
             if resolution in ("ancestor", "delete"):
                 with repo.working_copy.tabular.session() as sess:
                     count = sess.scalar(
-                        f"""SELECT COUNT(*) FROM nz_waca_adjustments WHERE id = {pk};"""
+                        f"""SELECT COUNT(*) FROM nz_waca_adjustments WHERE id = :id;""",
+                        {"id": pk},
                     )
                     assert count == 0
                 continue
@@ -85,7 +86,8 @@ def test_resolve_with_version(data_working_copy, cli_runner):
             # Make sure the resolution was written to the working copy during kart resolve:
             with repo.working_copy.tabular.session() as sess:
                 survey_reference = sess.scalar(
-                    f"""SELECT survey_reference FROM nz_waca_adjustments WHERE id = {pk};"""
+                    f"""SELECT survey_reference FROM nz_waca_adjustments WHERE id = :id;""",
+                    {"id": pk},
                 )
                 assert survey_reference == f"{resolution}_version"
 


### PR DESCRIPTION
Missing the piece of code that adds SRIDs to features while writing them to the working copy, specifically during kart resolve.

The Kart model doesn't store SRIDs per-row, so normal checkout operations add them in (at least for those working copies that do store them per row).

https://github.com/koordinates/kart/issues/840

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
