### PR TITLE
Harden vcvarsall.bat

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -989,6 +989,17 @@ jobs:
       - name: "msvc setup"
         uses: ilammy/msvc-dev-cmd@v1
 
+      - name: "Harden vcvarsall.bat"
+        shell: pwsh
+        run: |
+          cd 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build'
+          mv vcvarsall.bat orig_vcvarsall.bat
+          echo @'
+          @if not "%VSCMD_DEBUG%" GEQ "3" echo off
+          FOR /F "tokens=*" %%g IN ('powershell -Command "($Env:PATH.split(';') | Select -Unique) -Join ';'"') do (SET PATH=%%g)
+          '@ > vcvarsall.bat
+          type orig_vcvarsall.bat >> vcvarsall.bat
+
       - name: "setup: cmake"
         uses: lukka/get-cmake@latest
         with:


### PR DESCRIPTION
<img src="https://media4.giphy.com/media/ny3TbC9poLEEAiJj19/giphy.gif"/>

vcvarsall.bat is a batch file to set up the environment ready for building using MSVC++ - it sets ENV variables related to the host architecture, target architecture, MSVC version, the PATH to various tools, depending on the arguments it is called with.

vcvarsall.bat fails if the PATH is too long.
It tends to cause an error message like:
"Microsoft Visual C++ 14.0 or greater is required" This is because the wheel-building python module on windows tries to run vcvarsall.bat, and if it fails, it guesses that the problem is that you don't have the right MSVC version installed.

By the time we try to build the wheels, in the CMake buils step, our PATH is at least 7600 chars long, which is long enough to crash vcvarsall.bat

Happily we can fix the PATH without any adverse effects simply by removing duplicate entries, which brings it down to 5400 chars long, and so vcvarsall.bat starts working.

Finding the right place to fix the PATH has been a challenge - various tools including vcvarsall.bat itself prepend things to the PATH while they work. Trying to fix the PATH immediately before kicking off the CMake build didn't fix this issue, it just changed where it occurred. In the end, fixing the PATH in vcvarsall.bat itself in a safe way (only useless duplicate entires are removed) seemed to be the most robust option / the only one I that I could get to work.

Fixes https://github.com/koordinates/kart/issues/847
