### PR TITLE
Maintain a VRT file for each raster dataset in the workdir

### DIFF
--- a/kart/point_cloud/v1.py
+++ b/kart/point_cloud/v1.py
@@ -61,6 +61,11 @@ class PointCloudV1(TileDataset):
             include_conflict_versions=include_conflict_versions,
         )
 
+    @classmethod
+    def write_mosaic_for_directory(cls, directory_path):
+        # TODO: Not yet implemented
+        pass
+
     def get_dirty_dataset_paths(self, workdir_diff_cache):
         # TODO - improve finding and handling of non-standard tile filenames.
         return workdir_diff_cache.dirty_paths_for_dataset(self)

--- a/kart/raster/mosaic_util.py
+++ b/kart/raster/mosaic_util.py
@@ -1,0 +1,35 @@
+from osgeo import gdal
+
+import os
+
+
+KART_VRT_HEADING = os.linesep.join(
+    [
+        "<!-- Kart maintains this VRT file as a mosaic of every tile in this dataset. -->",
+        "<!-- Any changes made to this file will be overwritten by Kart each time the dataset changes. -->",
+        "<!-- To maintain your own VRT files in this folder, choose a different name. -->",
+        "",
+    ]
+)
+
+
+def write_vrt_for_directory(directory_path):
+    """
+    Given a folder containing some GeoTIFFs, write a mosaic file that combines them all into a single VRT.
+    The VRT will contain references to the tiles, rather than replicating their contents.
+    """
+    tiles = [str(p) for p in directory_path.glob("*.tif")]
+    if not tiles:
+        return
+
+    vrt_path = directory_path / f"{directory_path.name}.vrt"
+
+    # We write the VRT file in-place ... then we re-write so we can prepend the KART_VRT_HEADING.
+    # Trying to write it somewhere else is likely to mess up relative paths.
+
+    vrt = gdal.BuildVRT(str(vrt_path), tiles)
+    vrt.FlushCache()
+    del vrt
+
+    vrt_text = vrt_path.read_text()
+    vrt_path.write_text(KART_VRT_HEADING + vrt_text)

--- a/kart/raster/v1.py
+++ b/kart/raster/v1.py
@@ -70,12 +70,18 @@ class RasterV1(TileDataset):
         return extract_raster_tile_metadata(path)
 
     @classmethod
-    def get_format_summary(self, format_json):
+    def get_format_summary(cls, format_json):
         return get_format_summary(format_json)
 
     @classmethod
-    def convert_tile_to_format(self, source_path, dest_path, target_format):
+    def convert_tile_to_format(cls, source_path, dest_path, target_format):
         convert_tile_to_format(source_path, dest_path, target_format)
+
+    @classmethod
+    def write_mosaic_for_directory(cls, directory_path):
+        from kart.raster.mosaic_util import write_vrt_for_directory
+
+        write_vrt_for_directory(directory_path)
 
     @classmethod
     def get_tile_path_pattern(

--- a/kart/tile/tile_dataset.py
+++ b/kart/tile/tile_dataset.py
@@ -237,13 +237,21 @@ class TileDataset(BaseDataset):
         raise NotImplementedError()
 
     @classmethod
-    def get_format_summary(self, format_json):
+    def get_format_summary(cls, format_json):
         """Given a format.json meta-item, returns a string that summarizes the most important aspects of the format."""
         raise NotImplementedError()
 
     @classmethod
-    def convert_tile_to_format(self, source_path, dest_path, target_format):
+    def convert_tile_to_format(cls, source_path, dest_path, target_format):
         """Given a tile at source_path, writes the equivalent tile at dest_path in the target format."""
+        raise NotImplementedError()
+
+    @classmethod
+    def write_mosaic_for_directory(cls, directory_path):
+        """
+        Given a folder containing some point-cloud / raster tiles, write a mosaic file that combines them all into a single
+        "virtual" tile. The mosaic file will contain references to the tiles, rather than replicating their contents.
+        """
         raise NotImplementedError()
 
     @classmethod


### PR DESCRIPTION
Basic implementation: each time a raster dataset is updated by Kart, rewrites the VRT file to reference every tif file currently in the dataset, using gdal.BuildVRT.