### PR TITLE
Fix tab-completion to work with helper mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Point clouds (or rasters): during import, require the user to choose if they want to make a "cloud-optimized" dataset or a "preserve-format" dataset. [#842](https://github.com/koordinates/kart/issues/842)
 - Point clouds (or rasters): require `--no-convert-to-dataset-format` to add new tiles to a dataset that can be committed as-is but only if the dataset's format is changed. Note `--convert-to-dataset-format` works as before. [#842](https://github.com/koordinates/kart/issues/842)
 - Allow kart to check out attached files into the file-based working copy.
+- Fixes a bug where tab-completion wasn't working with helper mode, affects macOS and Linux. [#851](https://github.com/koordinates/kart/pull/851)
 
 ## 0.12.3
 

--- a/kart/cli.py
+++ b/kart/cli.py
@@ -403,7 +403,9 @@ def load_commands_from_args(args, skip_first_arg=True):
 def entrypoint():
     freeze_support()
     load_commands_from_args(sys.argv)
-    cli()
+    # Don't let helper mode mess up the usage-text, or the shell complete environment variables.
+    prog_name = "kart" if os.path.basename(sys.argv[0]) == "kart_cli" else None
+    cli(prog_name=prog_name, complete_var="_KART_COMPLETE")
 
 
 if __name__ == "__main__":

--- a/kart/completion.py
+++ b/kart/completion.py
@@ -15,12 +15,14 @@ try:
 except ImportError:
     shellingham = None
 
+
 def provide_default_shell():
-    if os.name == 'posix':
-        return os.environ.get('SHELL', '')
-    elif os.name == 'nt':
-        return os.environ.get('COMSPEC', '')
-    raise NotImplementedError(f'OS {os.name!r} support not available')
+    if os.name == "posix":
+        return os.environ.get("SHELL", "")
+    elif os.name == "nt":
+        return os.environ.get("COMSPEC", "")
+    raise NotImplementedError(f"OS {os.name!r} support not available")
+
 
 class Shells(str, Enum):
     bash = "bash"
@@ -185,37 +187,28 @@ def install_powershell(*, prog_name: str, complete_var: str, shell: str) -> Path
 
 def install_tab_completion(
     shell: Optional[str] = None,
-    prog_name: Optional[str] = None,
-    complete_var: Optional[str] = None,
 ) -> Tuple[str, Path]:
-    prog_name = prog_name or click.get_current_context().find_root().info_name
-    assert prog_name
-    if complete_var is None:
-        complete_var = "_{}_COMPLETE".format(prog_name.replace("-", "_").upper())
     if shell is None and shellingham is not None:
         try:
             shell, _ = shellingham.detect_shell()
         except shellingham.ShellDetectionFailure:
             shell = os.path.basename(provide_default_shell())
+
+    # Hardcode these variables - kart helper means that click can get mixed up between KART and KART_CLI,
+    # but this means we always use KART in practise.
+    kwargs = {"prog_name": "kart", "complete_var": "_KART_COMPLETE", "shell": shell}
+
     if shell == "bash":
-        installed_path = install_bash(
-            prog_name=prog_name, complete_var=complete_var, shell=shell
-        )
+        installed_path = install_bash(**kwargs)
         return shell, installed_path
     elif shell == "zsh":
-        installed_path = install_zsh(
-            prog_name=prog_name, complete_var=complete_var, shell=shell
-        )
+        installed_path = install_zsh(**kwargs)
         return shell, installed_path
     elif shell == "fish":
-        installed_path = install_fish(
-            prog_name=prog_name, complete_var=complete_var, shell=shell
-        )
+        installed_path = install_fish(**kwargs)
         return shell, installed_path
     elif shell in {"powershell", "pwsh"}:
-        installed_path = install_powershell(
-            prog_name=prog_name, complete_var=complete_var, shell=shell
-        )
+        installed_path = install_powershell(**kwargs)
         return shell, installed_path
     else:
         click.echo(f"Shell {shell} is not supported.")

--- a/kart/helper.py
+++ b/kart/helper.py
@@ -233,7 +233,13 @@ def helper(ctx, socket_filename, timeout, args):
                     _helper_log(f"semid={semid}")
                     try:
                         _helper_log("invoking cli()...")
-                        cli()
+                        # Don't let helper mode mess up the usage-text, or the shell complete environment variables.
+                        prog_name = (
+                            "kart"
+                            if os.path.basename(sys.argv[0]) == "kart_cli"
+                            else None
+                        )
+                        cli(prog_name=prog_name, complete_var="_KART_COMPLETE")
                     except SystemExit as system_exit:
                         """exit is called in the commands but we ignore as we need to clean up the caller"""
                         # TODO - do we ever see negative exit codes from cli (git etc)?

--- a/tests/scripts/e2e-1.sh
+++ b/tests/scripts/e2e-1.sh
@@ -45,6 +45,8 @@ set -x
 echo "Using helper mode: ${KART_USE_HELPER:-?}"
 
 kart -vvvv install tab-completion --shell auto
+# This checks our tab-completion works with _KART_COMPLETE (and not _KART_CLI_COMPLETE)
+COMP_WORDS="kart sta" COMP_CWORD=1 _KART_COMPLETE=bash_complete kart sta
 
 kart init --initial-branch=main .
 kart config user.name "Kart E2E Test 1"

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -27,7 +27,7 @@ def test_completion_install_bash(cli_runner):
     r = cli_runner.invoke(["install", "tab-completion", "--shell", "bash"])
     new_text = bash_completion_path.read_text()
     bash_completion_path.write_text(text)
-    install_source = os.path.join(".bash_completions", "cli.sh")
+    install_source = os.path.join(".bash_completions", "kart.sh")
     assert install_source not in text
     assert install_source in new_text
     assert "completion installed in" in r.stdout
@@ -36,7 +36,7 @@ def test_completion_install_bash(cli_runner):
     assert install_source_path.is_file()
     install_content = install_source_path.read_text()
     install_source_path.unlink()
-    assert "complete -o nosort -F _cli_completion cli" in install_content
+    assert "complete -o nosort -F _kart_completion kart" in install_content
 
 
 def test_completion_install_zsh(cli_runner):
@@ -53,21 +53,21 @@ def test_completion_install_zsh(cli_runner):
     assert zfunc_fragment in new_text
     assert "completion installed in" in r.stdout
     assert "Completion will take effect once you restart the terminal" in r.stdout
-    install_source_path = Path.home() / os.path.join(".zfunc", "_cli")
+    install_source_path = Path.home() / os.path.join(".zfunc", "_kart")
     assert install_source_path.is_file()
     install_content = install_source_path.read_text()
     install_source_path.unlink()
-    assert "compdef _cli_completion cli" in install_content
+    assert "compdef _kart_completion kart" in install_content
 
 
 def test_completion_install_fish(cli_runner):
     completion_path: Path = Path.home() / os.path.join(
-        ".config", "fish", "completions", "cli.fish"
+        ".config", "fish", "completions", "kart.fish"
     )
     r = cli_runner.invoke(["install", "tab-completion", "--shell", "fish"])
     new_text = completion_path.read_text()
     completion_path.unlink()
-    assert "complete --no-files --command cli" in new_text
+    assert "complete --no-files --command kart" in new_text
     assert "completion installed in" in r.stdout
     assert "Completion will take effect once you restart the terminal" in r.stdout
 


### PR DESCRIPTION
Click tab completion uses the name of the program for various environment variables eg _KART_COMPLETE.
Our program name varies depending on how the program is run kart vs kart_cli depending on helper mode etc.
Since we can't be sure if the way kart is currently being run is the same as it was run when tab-completion was installed, its safest to stick to one "canoncial" program name for tab-completion at all times. Click lets us do this. The chosen name is "kart" and therefore the variable is _KART_COMPLETE.

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
