### PR TITLE
Explicitly connect stdin, stdout, stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Point clouds (or rasters): require `--no-convert-to-dataset-format` to add new tiles to a dataset that can be committed as-is but only if the dataset's format is changed. Note `--convert-to-dataset-format` works as before. [#842](https://github.com/koordinates/kart/issues/842)
 - Allow kart to check out attached files into the file-based working copy.
 - Fixes a bug where tab-completion wasn't working with helper mode, affects macOS and Linux. [#851](https://github.com/koordinates/kart/pull/851)
+- Fixes a bug where git-lfs (and potentially other subprocesses) wasn't working reliably with helper mode, affects macOS and Linux. [#853](https://github.com/koordinates/kart/issues/853)
 
 ## 0.12.3
 

--- a/cli_helper/kart.c
+++ b/cli_helper/kart.c
@@ -192,30 +192,6 @@ int is_helper_enabled()
 }
 
 /**
- * @brief Check whether using the helper is allowed for this kart command.
- * the helper is disallowed for certain commands since they need to be able to launch an editor.
- * Launching an editor from the helper doesn't work since it's not properly attached to the terminal.
- * @return 0 no, 1 yes
- */
-int is_helper_allowed(char **argv) {
-    char **arg_ptr;
-    for (arg_ptr = argv; *arg_ptr != NULL; arg_ptr++) {
-        if (strncmp(*arg_ptr, "-", 1) == 0 || strcmp(*arg_ptr, "kart") == 0) {
-            // Skip options.
-            continue;
-        }
-        // kart commit, kart merge, and kart pull can all spawn an editor for the commit message.
-        if (strcmp(*arg_ptr, "commit") == 0 ||
-            strcmp(*arg_ptr, "merge") == 0 ||
-            strcmp(*arg_ptr, "pull") == 0) {
-            return 0;
-        }
-        return 1;
-    }
-    return 1;
-}
-
-/**
  * @brief Exit signal handler for SIGALRM
  */
 void exit_on_alarm(int sig)
@@ -241,7 +217,7 @@ int main(int argc, char **argv, char **environ)
         exit(1);
     }
 
-    if (is_helper_enabled() && is_helper_allowed(argv))
+    if (is_helper_enabled())
     {
         debug("enabled %s, pid=%d\n", cmd_path, getpid());
 

--- a/kart/branch.py
+++ b/kart/branch.py
@@ -3,9 +3,9 @@ import sys
 import click
 import pygit2
 
-from .exceptions import InvalidOperation
-from .subprocess_util import run_then_exit
-from .output_util import dump_json_output
+from kart.exceptions import InvalidOperation
+from kart import subprocess_util as subprocess
+from kart.output_util import dump_json_output
 from kart.cli_util import KartCommand
 
 
@@ -42,7 +42,7 @@ def branch(ctx, output_format, args):
                 f"Cannot delete the branch '{branch}' which you are currently on."
             )
 
-    run_then_exit(["git", "-C", repo.path, "branch"] + list(args))
+    subprocess.run_then_exit(["git", "-C", repo.path, "branch"] + list(args))
 
 
 def list_branches_json(repo):

--- a/kart/checkout.py
+++ b/kart/checkout.py
@@ -1,22 +1,22 @@
 import functools
-import subprocess
 
 import click
 import pygit2
-from .completion_shared import ref_completer
 
-from .cli_util import tool_environment
-from .exceptions import (
+from kart.cli_util import KartCommand
+from kart.completion_shared import ref_completer
+from kart.exceptions import (
     NO_BRANCH,
     NO_COMMIT,
     InvalidOperation,
     NotFound,
 )
-from .key_filters import RepoKeyFilter
-from .promisor_utils import get_partial_clone_envelope
-from .spatial_filter import SpatialFilterString, spatial_filter_help_text
-from .structs import CommitWithReference
-from kart.cli_util import KartCommand
+from kart.key_filters import RepoKeyFilter
+from kart.promisor_utils import get_partial_clone_envelope
+from kart.spatial_filter import SpatialFilterString, spatial_filter_help_text
+from kart.structs import CommitWithReference
+from kart import subprocess_util as subprocess
+
 
 _DISCARD_CHANGES_HELP_MESSAGE = (
     "Commit these changes first (`kart commit`) or"
@@ -193,7 +193,6 @@ def checkout(
 def _git_fetch_supports_flag(repo, flag):
     r = subprocess.run(
         ["git", "fetch", "?", f"--{flag}"],
-        env=tool_environment(),
         cwd=repo.workdir_path,
         capture_output=True,
         text=True,

--- a/kart/cli.py
+++ b/kart/cli.py
@@ -7,7 +7,6 @@ import os
 from multiprocessing import freeze_support
 import pathlib
 import re
-import subprocess
 import sys
 import traceback
 from pathlib import Path
@@ -16,15 +15,14 @@ import click
 import pygit2
 
 from . import core, is_darwin, is_linux, is_windows  # noqa
-from .cli_util import (
+from kart.cli_util import (
     add_help_subcommand,
     call_and_exit_flag,
-    tool_environment,
     KartGroup,
 )
-from .context import Context
+from kart.context import Context
 from kart.parse_args import PreserveDoubleDash
-from kart.subprocess_util import run_then_exit
+from kart import subprocess_util as subprocess
 
 MODULE_COMMANDS = {
     "annotations.cli": {"build-annotations"},
@@ -99,7 +97,7 @@ def print_version(ctx):
     click.echo(f"Kart v{get_version()}, Copyright (c) Kart Contributors")
 
     git_version = (
-        subprocess.check_output(["git", "--version"], env=tool_environment())
+        subprocess.check_output(["git", "--version"])
         .decode("ascii")
         .strip()
         .split()[-1]
@@ -107,13 +105,11 @@ def print_version(ctx):
 
     gitlfs_version = re.match(
         r"git-lfs/([^ ]+) \(",
-        subprocess.check_output(
-            ["git-lfs", "version"], env=tool_environment(), text=True
-        ),
+        subprocess.check_output(["git-lfs", "version"], text=True),
     ).group(1)
 
     pdal_version = (
-        subprocess.check_output(["pdal", "--version"], env=tool_environment())
+        subprocess.check_output(["pdal", "--version"])
         .decode("ascii")
         .strip()
         .split()[2]
@@ -302,7 +298,7 @@ def git(ctx, args):
     repo_params = []
     if ctx.obj.user_repo_path:
         repo_params = ["-C", ctx.obj.user_repo_path]
-    run_then_exit(["git", *repo_params, *args])
+    subprocess.run_then_exit(["git", *repo_params, *args])
 
 
 @cli.command(context_settings=dict(ignore_unknown_options=True), hidden=True)
@@ -315,7 +311,7 @@ def lfs(ctx, args):
     repo_params = []
     if ctx.obj.user_repo_path:
         repo_params = ["-C", ctx.obj.user_repo_path]
-    run_then_exit(["git", *repo_params, "lfs", *args])
+    subprocess.run_then_exit(["git", *repo_params, "lfs", *args])
 
 
 @cli.command(

--- a/kart/commit.py
+++ b/kart/commit.py
@@ -2,34 +2,33 @@ import os
 import re
 import shlex
 import shutil
-import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 
 import click
 
+from kart import is_windows
+from kart.base_diff_writer import BaseDiffWriter
+from kart.cli_util import StringFromFile, KartCommand
+from kart.core import check_git_user
 from kart.diff_format import DiffFormat
-
-from . import is_windows
-from .base_diff_writer import BaseDiffWriter
-from .cli_util import StringFromFile, tool_environment, KartCommand
-from .core import check_git_user
-from .exceptions import (
+from kart.exceptions import (
     NO_CHANGES,
     SPATIAL_FILTER_CONFLICT,
     InvalidOperation,
     NotFound,
     SubprocessError,
 )
-from .key_filters import RepoKeyFilter
-from .output_util import dump_json_output
-from .repo import KartRepoFiles
-from .status import (
+from kart.key_filters import RepoKeyFilter
+from kart.output_util import dump_json_output
+from kart.repo import KartRepoFiles
+from kart.status import (
     diff_status_to_text,
     get_branch_status_message,
     get_diff_status_message,
 )
-from .timestamps import (
+from kart import subprocess_util as subprocess
+from kart.timestamps import (
     commit_time_to_text,
     datetime_to_iso8601_utc,
     timedelta_to_iso8601_tz,
@@ -269,7 +268,7 @@ def user_edit_file(path):
 
 
 def run_editor_cmd(editor_cmd):
-    subprocess.check_call(editor_cmd, shell=True, env=tool_environment())
+    subprocess.check_call(editor_cmd, shell=True)
 
 
 def commit_obj_to_json(commit, repo, wc_diff):

--- a/kart/completion.py
+++ b/kart/completion.py
@@ -2,13 +2,15 @@ import os
 import re
 import sys
 import platform
-import subprocess
 from enum import Enum
 from pathlib import Path
 from typing import Optional, Tuple, Optional, Any, Dict, List
 
 import click
 from click.shell_completion import _SOURCE_BASH, _SOURCE_ZSH, _SOURCE_FISH
+
+from kart import subprocess_util as subprocess
+
 
 try:
     import shellingham

--- a/kart/diff_estimation.py
+++ b/kart/diff_estimation.py
@@ -1,10 +1,10 @@
-import subprocess
 import threading
 
 import pygit2
 
 from kart.diff_util import get_dataset_diff
 from kart.exceptions import SubprocessError
+from kart import subprocess_util as subprocess
 
 ACCURACY_SUBTREE_SAMPLES = {
     "veryfast": 2,

--- a/kart/diff_util.py
+++ b/kart/diff_util.py
@@ -1,13 +1,12 @@
 import logging
 import re
-import subprocess
 
-from kart.cli_util import tool_environment
 from kart.diff_format import DiffFormat
 from kart.diff_structs import FILES_KEY, Delta, DeltaDiff, DatasetDiff, RepoDiff
 from kart.exceptions import SubprocessError
 from kart.key_filters import DatasetKeyFilter, RepoKeyFilter
 from kart.structure import RepoStructure
+from kart import subprocess_util as subprocess
 
 L = logging.getLogger("kart.diff_util")
 
@@ -202,15 +201,7 @@ def get_file_diff(
         ":^**/.*dataset*/**",  # Data inside datasets
     ]
     try:
-        lines = (
-            subprocess.check_output(
-                cmd,
-                encoding="utf8",
-                env=tool_environment(),
-            )
-            .strip()
-            .splitlines()
-        )
+        lines = subprocess.check_output(cmd, encoding="utf8").strip().splitlines()
     except subprocess.CalledProcessError as e:
         raise SubprocessError(
             f"There was a problem with git diff: {e}", called_process_error=e

--- a/kart/fast_import.py
+++ b/kart/fast_import.py
@@ -1,5 +1,4 @@
 import logging
-import subprocess
 import time
 import uuid
 from contextlib import contextmanager
@@ -8,16 +7,16 @@ from enum import Enum, auto
 import click
 import pygit2
 
-from .cli_util import tool_environment
-from .exceptions import NO_CHANGES, InvalidOperation, NotFound, SubprocessError
+from kart.exceptions import NO_CHANGES, InvalidOperation, NotFound, SubprocessError
+from kart import subprocess_util as subprocess
 from kart.tabular.version import (
     SUPPORTED_VERSIONS,
     dataset_class_for_version,
     extra_blobs_for_version,
 )
-from .tabular.import_source import TableImportSource
-from .tabular.pk_generation import PkGeneratingTableImportSource
-from .timestamps import minutes_to_tz_offset
+from kart.tabular.import_source import TableImportSource
+from kart.tabular.pk_generation import PkGeneratingTableImportSource
+from kart.timestamps import minutes_to_tz_offset
 
 L = logging.getLogger("kart.fast_import")
 
@@ -143,7 +142,6 @@ def git_fast_import(repo, *args):
         ["git", "fast-import", "--done", *args],
         cwd=repo.path,
         stdin=subprocess.PIPE,
-        env=tool_environment(),
         bufsize=128 * 1024,
         stderr=subprocess.DEVNULL,
     )

--- a/kart/fsck.py
+++ b/kart/fsck.py
@@ -1,12 +1,12 @@
 import os
-import subprocess
 
 import click
 
-from .cli_util import tool_environment, KartCommand
-from .exceptions import NO_WORKING_COPY, NotFound
-from .geometry import normalise_gpkg_geom
-from .sqlalchemy.gpkg import Db_GPKG
+from kart.cli_util import KartCommand
+from kart.exceptions import NO_WORKING_COPY, NotFound
+from kart.geometry import normalise_gpkg_geom
+from kart import subprocess_util as subprocess
+from kart.sqlalchemy.gpkg import Db_GPKG
 
 
 def _fsck_reset(repo, working_copy, dataset_paths):
@@ -32,7 +32,7 @@ def fsck(ctx, reset_datasets, fsck_args):
 
     click.echo("Checking repository integrity...")
     r = subprocess.call(
-        ["git", "-C", repo.path, "fsck"] + list(fsck_args), env=tool_environment()
+        ["git", "-C", repo.path, "fsck"] + list(fsck_args),
     )
     if r:
         click.Abort()

--- a/kart/log.py
+++ b/kart/log.py
@@ -1,4 +1,3 @@
-import subprocess
 import sys
 import logging
 from datetime import datetime, timedelta, timezone
@@ -6,10 +5,10 @@ from datetime import datetime, timedelta, timezone
 import click
 
 from kart import diff_estimation
-from kart.cli_util import OutputFormatType, tool_environment
+from kart.cli_util import OutputFormatType
 from kart.completion_shared import ref_or_repo_path_completer
 from kart.exceptions import NotYetImplemented, SubprocessError
-from kart.subprocess_util import run_then_exit
+from kart import subprocess_util as subprocess
 from kart.key_filters import RepoKeyFilter
 from kart.output_util import dump_json_output
 from kart.parse_args import PreserveDoubleDash, parse_revisions_and_filters
@@ -40,7 +39,6 @@ def find_dataset(ds_path, repo, commits):
             encoding="utf8",
             check=True,
             capture_output=True,
-            env=tool_environment(),
         )
     except subprocess.CalledProcessError as e:
         raise SubprocessError(
@@ -267,7 +265,7 @@ def log(
         if fmt:
             options.append(f"--format={fmt}")
         cmd = ["git", "-C", repo.path, "log", *options, *commits, "--", *paths]
-        run_then_exit(cmd)
+        subprocess.run_then_exit(cmd)
 
     elif output_type in ("json", "json-lines"):
         if kwargs.get("graph"):
@@ -290,7 +288,6 @@ def log(
                 encoding="utf8",
                 check=True,
                 capture_output=True,
-                env=tool_environment(),
             )
         except subprocess.CalledProcessError as e:
             raise SubprocessError(

--- a/kart/point_cloud/__init__.py
+++ b/kart/point_cloud/__init__.py
@@ -1,10 +1,9 @@
 import json
 from pathlib import Path
-import subprocess
 import tempfile
 
 from kart import is_windows
-from kart.cli_util import tool_environment
+from kart import subprocess_util as subprocess
 
 
 def pdal_execute_pipeline(pipeline, *, env_overrides=None):
@@ -13,7 +12,7 @@ def pdal_execute_pipeline(pipeline, *, env_overrides=None):
     Returns a list of metadata output from each stage.
     """
 
-    env = tool_environment()
+    env = subprocess.tool_environment()
     # NOTE: Kart itself doesn't currently use env_overrides, but don't remove it.
     # PDAL uses environment variables for various purposes, and this is helpful for `kart ext-run` scripts.
     env.update(env_overrides or {})

--- a/kart/point_cloud/pdal_convert.py
+++ b/kart/point_cloud/pdal_convert.py
@@ -1,8 +1,7 @@
-import subprocess
-
 from kart.exceptions import InvalidOperation, INVALID_FILE_FORMAT
 from kart.point_cloud.metadata_util import is_copc, get_las_version
 from kart.point_cloud import pdal_execute_pipeline
+from kart import subprocess_util as subprocess
 
 
 def convert_tile_to_format(source, dest, target_format):

--- a/kart/promisor_utils.py
+++ b/kart/promisor_utils.py
@@ -1,9 +1,8 @@
-import subprocess
 from contextlib import contextmanager
 from enum import IntEnum
 
-from .cli_util import tool_environment
-from .exceptions import NotFound, SubprocessError
+from kart.exceptions import NotFound, SubprocessError
+from kart import subprocess_util as subprocess
 
 
 class LibgitSubcode(IntEnum):
@@ -113,7 +112,6 @@ class FetchPromisedBlobsProcess:
             self.cmd,
             cwd=self.repo.path,
             stdin=subprocess.PIPE,
-            env=tool_environment(),
             bufsize=41,  # Works as line buffering
         )
 

--- a/kart/pull.py
+++ b/kart/pull.py
@@ -1,14 +1,12 @@
 import logging
-import os
-import subprocess
 
 import click
 
+from kart.cli_util import KartCommand
 from kart.completion_shared import ref_completer
-
-from . import merge
-from .cli_util import tool_environment, KartCommand
-from .exceptions import NO_BRANCH, NotFound
+from kart.exceptions import NO_BRANCH, NotFound
+from kart import merge
+from kart import subprocess_util as subprocess
 
 L = logging.getLogger("kart.pull")
 
@@ -96,7 +94,6 @@ def pull(ctx, ff, ff_only, launch_editor, do_progress, repository, refspecs):
             repository,
             *refspecs,
         ],
-        env=tool_environment(),
     )
 
     # now merge with FETCH_HEAD

--- a/kart/rev_list_objects.py
+++ b/kart/rev_list_objects.py
@@ -2,13 +2,12 @@
 # For example, reachable from commits A, B, C, but not from D, E, F (which have already been taken care of).
 
 import re
-import subprocess
 
 import pygit2
 
 from kart.core import all_trees_with_paths_in_tree
-from kart.cli_util import tool_environment
 from kart.exceptions import SubprocessError
+from kart import subprocess_util as subprocess
 
 
 def _rev_list_commits_command(repo):
@@ -51,11 +50,7 @@ def rev_list_object_oids(repo, start_commits, stop_commits, pathspecs):
     ]
     try:
         with subprocess.Popen(
-            cmd,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            encoding="utf8",
-            env=tool_environment(),
+            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, encoding="utf8"
         ) as p:
             p.stdin.write("\n".join(["--", *pathspecs]))
             p.stdin.close()
@@ -83,12 +78,7 @@ def get_dataset_pathspecs(repo, start_commits, stop_commits, dirname_filter):
     ]
     result = set()
     try:
-        with subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            encoding="utf8",
-            env=tool_environment(),
-        ) as p:
+        with subprocess.Popen(cmd, stdout=subprocess.PIPE, encoding="utf8") as p:
             for line in p.stdout:
                 commit = repo[line.strip()]
                 for tree_path, tree in all_trees_with_paths_in_tree(commit.tree):

--- a/kart/subprocess_util.py
+++ b/kart/subprocess_util.py
@@ -1,12 +1,93 @@
 import asyncio
+import functools
 import os
+from pathlib import Path
+import platform
 import subprocess
 import sys
 from asyncio import IncompleteReadError, LimitOverrunError
-from asyncio.subprocess import PIPE
 from functools import partial
 
-from .cli_util import tool_environment
+# Package kart.subprocess_util is a drop-in replacement for subprocess which handles some things
+# that kart will generally want to do when calling a subprocess, as well as having some extra
+# functionality that the subprocess module does not. Here are the things it can do:
+
+# 1. tool_environment() - this makes sure that when we call git, git-lfs, pdal etc, we have the right
+# environment including the right PATH that includes the kart bin/ directory.
+
+# Every method here - run, call, check_call, check_output, run_and_tee_output, run_then_exit -
+# sets the environment to be the tool_environment() if no other environment is supplied.
+
+# 2. sys.stdin, sys.stdout, sys.stderr: When Kart is run in helper mode, these variables are updated
+# each time a new kart process connects to the helper daemon to be the same as the file-descriptors
+# from the calling process. However, the default stdin,stderr,stdout parameters of subprocess.call
+# are not updated accordingly - that means, when running in helper mode, these parameters need to
+# be set explicitly every time a subprocess is called.
+
+# Every method here - run, call, check_call, check_output, run_and_tee_output, run_then_exit -
+# makes sure to set these parameters explicitly when run in helper mode.
+
+# 3. Capturing output during testing: similar to #2, the click test harness updates sys.stdout
+# and sys.stderr to special values that capture the output so that it can be checked in asserts.
+# Theoretically, the code from #2 would handle this perfectly too, except that unfortunately
+# these special values of sys.stdin and sys.stderr don't have file-descriptors attached and
+# so can't be used in calls to subprocess.run. Since this is only an issue during testing, we
+# instead just set the stdout and stderr to PIPE, capture the subprocess output, and then write
+# it to the special values of sys.stdout and sys.stderr. This breaks real-time progress output
+# for the subprocess but this is not important during testing.
+
+# This fix is only applied to run_and_tee_output and run_then_exit. For correctness, it should be
+# applied to other subprocess calls, but in practice, all of our tests that make asserts about
+# subprocess output rely only on run_then_exit - in the other cases, the test will be unaware
+# of the output from the subprocess, but we don't make any asserts based on it.
+# We could if needed apply this fix to the other methods (with a little more complexity - other
+# methods might have set the stdout / stderr parameters already).
+
+# 4. Two extra functions: run_and_tee_output, run_and_then_exit.
+
+
+CalledProcessError = subprocess.CalledProcessError
+DEVNULL = subprocess.DEVNULL
+PIPE = subprocess.PIPE
+
+
+def run(cmd, **kwargs):
+    return subprocess.run(cmd, **add_default_kwargs(kwargs))
+
+
+def call(cmd, **kwargs):
+    return subprocess.call(cmd, **add_default_kwargs(kwargs))
+
+
+def check_call(cmd, **kwargs):
+    return subprocess.check_call(cmd, **add_default_kwargs(kwargs))
+
+
+def check_output(cmd, **kwargs):
+    return subprocess.check_output(cmd, **add_default_kwargs(kwargs, check_output=True))
+
+
+def Popen(cmd, **kwargs):
+    return subprocess.Popen(cmd, **add_default_kwargs(kwargs))
+
+
+def add_default_kwargs(kwargs_dict, check_output=False):
+    # Set up the environment if not supplied by the caller.
+    if "env" not in kwargs_dict:
+        kwargs_dict.setdefault("env", tool_environment())
+
+    # Specifically set sys.stdin, sys.stderr, sys.stdout if this is running via helper mode.
+    if os.environ.get("KART_HELPER_PID"):
+        if "input" not in kwargs_dict:
+            kwargs_dict.setdefault("stdin", sys.stdin)
+
+        capture_output = kwargs_dict.get("capture_output", False)
+        if not check_output and not capture_output:
+            kwargs_dict.setdefault("stdout", sys.stdout)
+        if not capture_output:
+            kwargs_dict.setdefault("stderr", sys.stderr)
+
+    return kwargs_dict
 
 
 async def read_stream_and_display(stream, display):
@@ -124,36 +205,16 @@ async def read_until_any_of(stream, separators=b"\n"):
     return bytes(chunk)
 
 
-def subprocess_tee(cmd, **kwargs):
+def run_and_tee_output(cmd, **kwargs):
     """
     Run a subprocess and *don't* capture its output - let stdout and stderr display as per usual -
     - but also *do* capture its output so that we can inspect it.
     Returns a tuple of (exit-code, stdout output string, stderr output string).
     """
+    if "env" not in kwargs:
+        kwargs.setdefault("env", tool_environment())
     return_code, stdout, stderr = asyncio.run(read_and_display(cmd, **kwargs))
     return return_code, stdout, stderr
-
-
-def run_with_capture_then_exit(cmd):
-    # In testing, .run must be set to capture_output and so use PIPEs to communicate
-    # with the process to run whereas in normal operation the standard streams of
-    # this process are passed into subprocess.run.
-    # Capturing the output in a PIPE and then writing to sys.stdout is compatible
-    # with click.testing which sets sys.stdout and sys.stderr to a custom
-    # io wrapper.
-    # This io wrapper is not compatible with the stdin= kwarg to .run - in that case
-    # it gets treated as a file like object and fails.
-    p = subprocess.run(
-        cmd,
-        capture_output=True,
-        encoding="utf-8",
-        env=tool_environment(os.environ),
-    )
-    sys.stdout.write(p.stdout)
-    sys.stdout.flush()
-    sys.stderr.write(p.stderr)
-    sys.stderr.flush()
-    sys.exit(p.returncode)
 
 
 def run_then_exit(cmd):
@@ -168,14 +229,137 @@ def run_then_exit(cmd):
        it buffers all the output until the process has finished, so the user wouldn't see progress.
     """
     if "_KART_RUN_WITH_CAPTURE" in os.environ:
-        run_with_capture_then_exit(cmd)
+        _run_with_capture_then_exit(cmd)
     else:
         p = subprocess.run(
             cmd,
             encoding="utf-8",
-            env=tool_environment(os.environ),
+            env=tool_environment(),
             stdin=sys.stdin,
             stdout=sys.stdout,
             stderr=sys.stderr,
         )
         sys.exit(p.returncode)
+
+
+def _run_with_capture_then_exit(cmd):
+    # In testing, .run must be set to capture_output and so use PIPEs to communicate
+    # with the process to run whereas in normal operation the standard streams of
+    # this process are passed into subprocess.run.
+    # Capturing the output in a PIPE and then writing to sys.stdout is compatible
+    # with click.testing which sets sys.stdout and sys.stderr to a custom
+    # io wrapper.
+    # This io wrapper is not compatible with the stdin= kwarg to .run - in that case
+    # it gets treated as a file like object and fails.
+    p = subprocess.run(
+        cmd,
+        capture_output=True,
+        encoding="utf-8",
+        env=tool_environment(),
+    )
+    sys.stdout.write(p.stdout)
+    sys.stdout.flush()
+    sys.stderr.write(p.stderr)
+    sys.stderr.flush()
+    sys.exit(p.returncode)
+
+
+def tool_environment(env=None):
+    """Returns a dict of environment for launching an external process."""
+    init_git_config()
+    env = (env or os.environ).copy()
+
+    # Add kart bin directory to the start of the path:
+    kart_bin_path = str(Path(sys.executable).parents[0])
+    if "PATH" in env:
+        env["PATH"] = kart_bin_path + os.pathsep + env["PATH"]
+    else:
+        env["PATH"] = kart_bin_path
+
+    if platform.system() == "Linux":
+        # https://pyinstaller.readthedocs.io/en/stable/runtime-information.html#ld-library-path-libpath-considerations
+        if "LD_LIBRARY_PATH_ORIG" in env:
+            env["LD_LIBRARY_PATH"] = env["LD_LIBRARY_PATH_ORIG"]
+        else:
+            env.pop("LD_LIBRARY_PATH", None)
+    return env
+
+
+_ORIG_GIT_CONFIG_PARAMETERS = os.environ.get("GIT_CONFIG_PARAMETERS")
+
+
+# These are all the Kart defaults that differ from git's defaults.
+# (all of these can still be overridden by setting them in a git config file.)
+GIT_CONFIG_DEFAULT_OVERRIDES = {
+    # git will change to this branch sooner or later, but hasn't yet.
+    "init.defaultBranch": "main",
+    # Deltified objects seem to affect clone and diff performance really badly
+    # for Kart repos. So we disable them by default.
+    "pack.depth": 0,
+    "pack.window": 0,
+}
+if platform.system() == "Linux":
+    import certifi
+
+    GIT_CONFIG_DEFAULT_OVERRIDES["http.sslCAInfo"] = certifi.where()
+
+# These are the settings that Kart always *overrides* in git config.
+# i.e. regardless of your local git settings, kart will use these settings instead.
+GIT_CONFIG_FORCE_OVERRIDES = {
+    # We use base64 for feature paths.
+    # "kcya" and "kcyA" are *not* the same feature; that way lies data loss
+    "core.ignoreCase": "false",
+}
+
+
+# from https://github.com/git/git/blob/ebf3c04b262aa27fbb97f8a0156c2347fecafafb/quote.c#L12-L44
+def _git_sq_quote_buf(src):
+    dst = src.replace("'", r"'\''").replace("!", r"'\!'")
+    return f"'{dst}'"
+
+
+@functools.lru_cache()
+def init_git_config():
+    """
+    Initialises default config values that differ from git's defaults.
+    """
+    configs = list(_pygit2_configs())
+    new_config_params = []
+    for k, v in GIT_CONFIG_DEFAULT_OVERRIDES.items():
+        for config in configs:
+            if k in config:
+                break
+        else:
+            new_config_params.append(_git_sq_quote_buf(f"{k}={v}"))
+    for k, v in GIT_CONFIG_FORCE_OVERRIDES.items():
+        new_config_params.append(_git_sq_quote_buf(f"{k}={v}"))
+
+    if new_config_params:
+        os.environ["GIT_CONFIG_PARAMETERS"] = " ".join(
+            filter(None, [*new_config_params, _ORIG_GIT_CONFIG_PARAMETERS])
+        )
+
+
+def _pygit2_configs():
+    """
+    Yields pygit2.Config objects in order of decreasing specificity.
+    """
+    import pygit2
+
+    try:
+        # ~/.gitconfig
+        yield pygit2.Config.get_global_config()
+    except OSError:
+        pass
+    try:
+        # ~/.config/git/config
+        yield pygit2.Config.get_xdg_config()
+    except OSError:
+        pass
+
+    if "GIT_CONFIG_NOSYSTEM" not in os.environ:
+        # /etc/gitconfig
+        try:
+            yield pygit2.Config.get_system_config()
+        except OSError:
+            pass

--- a/kart/workdir.py
+++ b/kart/workdir.py
@@ -6,7 +6,6 @@ from enum import Enum, auto
 import functools
 from pathlib import Path
 import shutil
-import subprocess
 import sys
 from kart.structure import RepoStructure
 
@@ -16,8 +15,8 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.schema import CreateTable
 
 
-from kart.cli_util import tool_environment
 from kart import diff_util
+from kart.diff_util import get_file_diff
 from kart.diff_structs import Delta, DatasetDiff
 from kart.exceptions import (
     NotFound,
@@ -32,13 +31,11 @@ from kart.output_util import InputMode, get_input_mode
 from kart.reflink_util import try_reflink
 from kart.sqlalchemy import TableSet
 from kart.sqlalchemy.sqlite import sqlite_engine
+from kart import subprocess_util as subprocess
 from kart.tile import ALL_TILE_DATASET_TYPES
 from kart.tile.tile_dataset import TileDataset
 from kart.tile.tilename_util import remove_any_tile_extension, PAM_SUFFIX
 from kart.working_copy import WorkingCopyPart
-from kart.diff_structs import FILES_KEY, BINARY_FILE, DatasetDiff, RepoDiff
-from kart.diff_util import get_file_diff, get_repo_diff
-from .base_diff_writer import BaseDiffWriter
 
 L = logging.getLogger("kart.workdir")
 
@@ -671,7 +668,7 @@ class FileSystemWorkingCopy(WorkingCopyPart):
 
         paths = [path(d) for d in datasets]
 
-        env = tool_environment()
+        env = subprocess.tool_environment()
         env["GIT_INDEX_FILE"] = str(self.index_path)
 
         try:
@@ -730,7 +727,7 @@ class FileSystemWorkingCopy(WorkingCopyPart):
         # the file's `stat` information - this allows for an optimisation where diffs can be generated
         # without hashing the working copy files. pygit2.Index doesn't give easy access to this info.
 
-        env = tool_environment()
+        env = subprocess.tool_environment()
         env["GIT_INDEX_FILE"] = str(self.index_path)
 
         try:
@@ -855,7 +852,7 @@ class FileSystemWorkingCopy(WorkingCopyPart):
         dataset.write_mosaic_for_directory((self.path / dataset.path).resolve())
 
     def dirty_paths(self):
-        env = tool_environment()
+        env = subprocess.tool_environment()
         env["GIT_INDEX_FILE"] = str(self.index_path)
 
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ import os
 import random
 import re
 import shutil
-import subprocess
 import tarfile
 import time
 import uuid
@@ -34,6 +33,7 @@ from kart.repo import KartRepo  # noqa: E402
 from kart.sqlalchemy.postgis import Db_Postgis  # noqa: E402
 from kart.sqlalchemy.sqlserver import Db_SqlServer  # noqa: E402
 from kart.sqlalchemy.mysql import Db_MySql  # noqa: E402
+from kart import subprocess_util as subprocess
 
 
 pytest_plugins = ["helpers_namespace"]
@@ -421,7 +421,7 @@ class KartCliRunner(CliRunner):
 
     def invoke(self, args=None, **kwargs):
         from kart.cli import load_commands_from_args, cli
-        from kart.cli_util import init_git_config
+        from kart.subprocess_util import init_git_config
 
         init_git_config.cache_clear()
 
@@ -1199,10 +1199,8 @@ def dodgy_restore(cli_runner):
 
 @pytest.fixture(scope="session")
 def requires_git_lfs():
-    from kart.cli_util import tool_environment
-
     try:
-        r = subprocess.run(["git", "lfs", "--version"], env=tool_environment())
+        r = subprocess.run(["git", "lfs", "--version"])
         has_git_lfs = r.returncode == 0
     except OSError:
         has_git_lfs = False

--- a/tests/point_cloud/fixtures.py
+++ b/tests/point_cloud/fixtures.py
@@ -1,6 +1,6 @@
-import subprocess
-from kart.cli_util import tool_environment
 import pytest
+
+from kart import subprocess_util as subprocess
 
 
 # using a fixture instead of a skipif decorator means we get one aggregated skip
@@ -8,7 +8,7 @@ import pytest
 @pytest.fixture(scope="session")
 def requires_pdal():
     try:
-        r = subprocess.run(["pdal", "--version"], env=tool_environment())
+        r = subprocess.run(["pdal", "--version"])
         has_pdal = r.returncode == 0
     except OSError:
         has_pdal = False

--- a/tests/point_cloud/test_workingcopy.py
+++ b/tests/point_cloud/test_workingcopy.py
@@ -1,19 +1,18 @@
 import re
 import shutil
-import subprocess
 
 import pygit2
 import pytest
 
-from kart.cli_util import tool_environment
 from kart.exceptions import (
     WORKING_COPY_OR_IMPORT_CONFLICT,
     NO_CHANGES,
     INVALID_OPERATION,
 )
 from kart.lfs_util import get_hash_and_size_of_file
-from kart.repo import KartRepo
 from kart.point_cloud.metadata_util import extract_pc_tile_metadata
+from kart.repo import KartRepo
+from kart import subprocess_util as subprocess
 from .fixtures import requires_pdal  # noqa
 
 
@@ -980,7 +979,7 @@ def test_working_copy_mtime_updated(cli_runner, data_archive, requires_pdal):
         assert r.stdout.splitlines()[-1] == "Nothing to commit, working copy clean"
 
         repo = KartRepo(repo_path)
-        env = tool_environment()
+        env = subprocess.tool_environment()
         env["GIT_INDEX_FILE"] = str(repo.working_copy.workdir.index_path)
 
         def get_touched_files():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,6 @@ import pygit2
 import pytest
 
 from kart import cli
-from kart.cli_util import tool_environment
 
 
 H = pytest.helpers.helpers()
@@ -78,30 +77,6 @@ def test_config(empty_gitconfig, cli_runner):
     r = cli_runner.invoke(["config", "init.defaultBranch"])
     assert r.exit_code == 0, r.stderr
     assert r.stdout == "main\n"
-
-
-def test_cli_tool_environment():
-    env_exec = tool_environment()
-    assert len(env_exec)
-    assert env_exec is not os.environ
-    assert sys.executable.startswith(env_exec["PATH"].split(os.pathsep)[0])
-
-    if platform.system() == "Linux":
-        env_in = {"LD_LIBRARY_PATH": "bob", "LD_LIBRARY_PATH_ORIG": "alex", "my": "me"}
-        env_exec = tool_environment(env_in)
-        assert env_exec is not env_in
-        assert env_exec["LD_LIBRARY_PATH"] == "alex"
-        assert env_exec["my"] == "me"
-
-        env_in = {"LD_LIBRARY_PATH": "bob", "my": "me"}
-        env_exec = tool_environment(env_in)
-        assert "LD_LIBRARY_PATH" not in env_exec
-    else:
-        env_in = {"my": "me"}
-        env_exec = tool_environment(env_in)
-        assert env_exec is not env_in
-        env_exec.pop("PATH", None)
-        assert env_exec == env_in
 
 
 def test_ext_run(tmp_path, cli_runner, sys_path_reset):

--- a/tests/test_spatial_filter.py
+++ b/tests/test_spatial_filter.py
@@ -1,11 +1,9 @@
 import json
 import os
-import subprocess
 import tempfile
 
 import pytest
 
-from kart.cli_util import tool_environment
 from kart.exceptions import (
     INVALID_ARGUMENT,
     NO_SPATIAL_FILTER,
@@ -15,6 +13,7 @@ from kart.exceptions import (
 from kart.geometry import ring_as_wkt, bbox_as_wkt_polygon
 from kart.promisor_utils import FetchPromisedBlobsProcess, LibgitSubcode
 from kart.repo import KartRepo
+from kart import subprocess_util as subprocess
 
 H = pytest.helpers.helpers()
 
@@ -25,13 +24,11 @@ def git_supports_filter_extensions():
     with tempfile.TemporaryDirectory() as td:
         subprocess.run(
             ["git", "-C", td, "init", "--quiet", "."],
-            env=tool_environment(),
             check=True,
         )
 
         p = subprocess.run(
             ["git", "-C", td, "rev-list", "--filter=extension:z", "--objects"],
-            env=tool_environment(),
             stderr=subprocess.PIPE,
             text=True,
         )
@@ -69,7 +66,6 @@ def git_supports_spatial_filter(git_supports_filter_extensions):
     with tempfile.TemporaryDirectory() as td:
         subprocess.run(
             ["git", "-C", td, "init", "--quiet", "."],
-            env=tool_environment(),
             check=True,
         )
 
@@ -82,7 +78,6 @@ def git_supports_spatial_filter(git_supports_filter_extensions):
                 "--max-count=1",
                 "--filter=extension:spatial=1,2,3,4",
             ],
-            env=tool_environment(),
             stderr=subprocess.PIPE,
             text=True,
         )

--- a/tests/test_subprocess_util.py
+++ b/tests/test_subprocess_util.py
@@ -1,0 +1,29 @@
+import os
+import platform
+import sys
+
+from kart import subprocess_util
+
+
+def test_subprocess_tool_environment():
+    env_exec = subprocess_util.tool_environment()
+    assert len(env_exec)
+    assert env_exec is not os.environ
+    assert sys.executable.startswith(env_exec["PATH"].split(os.pathsep)[0])
+
+    if platform.system() == "Linux":
+        env_in = {"LD_LIBRARY_PATH": "bob", "LD_LIBRARY_PATH_ORIG": "alex", "my": "me"}
+        env_exec = subprocess_util.tool_environment(env_in)
+        assert env_exec is not env_in
+        assert env_exec["LD_LIBRARY_PATH"] == "alex"
+        assert env_exec["my"] == "me"
+
+        env_in = {"LD_LIBRARY_PATH": "bob", "my": "me"}
+        env_exec = subprocess_util.tool_environment(env_in)
+        assert "LD_LIBRARY_PATH" not in env_exec
+    else:
+        env_in = {"my": "me"}
+        env_exec = subprocess_util.tool_environment(env_in)
+        assert env_exec is not env_in
+        env_exec.pop("PATH", None)
+        assert env_exec == env_in


### PR DESCRIPTION
## Description

Read this before you review - start the review at subprocess_util and kart.c

The point of this change is to explicitly set stdin, stdout, and stderr whenever the Kart helper daemon launches a subprocess - for reasons documented in subprocess_util. This fixes the helper-mode weirdness I've been seeing.

Fixes https://github.com/koordinates/kart/issues/853
Fixes https://github.com/koordinates/kart/issues/854

I ensure the fix is applied everywhere by making sure the fix is applied whenever `subprocess_util` module is used, then make sure I use `subprocess_util` module everywhere instead of subprocess directly.

While I'm about it: remembering to set env to tool_environment is better handled by subprocess_util too, instead of relying on the caller to remember to set it.
Also - logically, tool_environment should be part of subprocess_util and not cli_util, since it's only used when we are starting a subprocess. So, I moved that too.

Also added some more documentation to subprocess_util explaining all it can do. This file is the file that needs reviewing.
In addition to this, kart.c has changed - it no longer disables the helper for certain commands, since these commands now work with the kart helper.

All other changes to all other files are pretty mechanical and don't really need to be reviewed one-by-one:
- don't import subprocess, import subprocess_util as subprocess
- don't generally need to import tool_environment - this gets applied automatically anyway
- renamed subprocess_tee -> run_and_tee_output, run -> run_then_exit
- some import tidy-ups (alphabeticized etc)

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
