### PR TITLE
Refactor: simplify env-overrides for subprocess calls

### DIFF
--- a/kart/point_cloud/__init__.py
+++ b/kart/point_cloud/__init__.py
@@ -12,10 +12,8 @@ def pdal_execute_pipeline(pipeline, *, env_overrides=None):
     Returns a list of metadata output from each stage.
     """
 
-    env = subprocess.tool_environment()
     # NOTE: Kart itself doesn't currently use env_overrides, but don't remove it.
     # PDAL uses environment variables for various purposes, and this is helpful for `kart ext-run` scripts.
-    env.update(env_overrides or {})
 
     if is_windows:
         # On windows we can't keep the metadata file open while pdal writes to it:
@@ -28,7 +26,7 @@ def pdal_execute_pipeline(pipeline, *, env_overrides=None):
             input=json.dumps(pipeline),
             encoding="utf-8",
             capture_output=True,
-            env=env,
+            env_overrides=env_overrides,
         )
 
         with metadata_path.open(encoding="utf-8") as f:
@@ -46,7 +44,7 @@ def pdal_execute_pipeline(pipeline, *, env_overrides=None):
                 input=json.dumps(pipeline),
                 encoding="utf-8",
                 capture_output=True,
-                env=env,
+                env_overrides=env_overrides,
             )
             f_metadata.seek(0)
             metadata = json.load(f_metadata)

--- a/kart/repo.py
+++ b/kart/repo.py
@@ -737,21 +737,21 @@ class KartRepo(pygit2.Repository):
         # 'git var' lets us use the environment variables to
         # control the user info, e.g. GIT_AUTHOR_DATE.
         # libgit2/pygit2 doesn't handle those env vars at all :(
-        env = os.environ.copy()
+        env_overrides = {}
 
         name = overrides.pop("name", None)
         if name is not None:
-            env[f"GIT_{person_type}_NAME"] = name
+            env_overrides[f"GIT_{person_type}_NAME"] = name
 
         email = overrides.pop("email", None)
         if email is not None:
-            env[f"GIT_{person_type}_EMAIL"] = email
+            env_overrides[f"GIT_{person_type}_EMAIL"] = email
 
         output = subprocess.check_output(
             ["git", "var", f"GIT_{person_type}_IDENT"],
             cwd=self.path,
             encoding="utf8",
-            env=subprocess.tool_environment(env),
+            env_overrides=env_overrides,
         )
         m = self._GIT_VAR_OUTPUT_RE.match(output)
         kwargs = m.groupdict()

--- a/tests/point_cloud/test_workingcopy.py
+++ b/tests/point_cloud/test_workingcopy.py
@@ -979,8 +979,7 @@ def test_working_copy_mtime_updated(cli_runner, data_archive, requires_pdal):
         assert r.stdout.splitlines()[-1] == "Nothing to commit, working copy clean"
 
         repo = KartRepo(repo_path)
-        env = subprocess.tool_environment()
-        env["GIT_INDEX_FILE"] = str(repo.working_copy.workdir.index_path)
+        env_overrides = {"GIT_INDEX_FILE": str(repo.working_copy.workdir.index_path)}
 
         def get_touched_files():
             # git diff-files never compares OIDs - it just lists files which appear
@@ -988,7 +987,10 @@ def test_working_copy_mtime_updated(cli_runner, data_archive, requires_pdal):
             cmd = ["git", "diff-files"]
             return (
                 subprocess.check_output(
-                    cmd, env=env, encoding="utf-8", cwd=repo.workdir_path
+                    cmd,
+                    env_overrides=env_overrides,
+                    encoding="utf-8",
+                    cwd=repo.workdir_path,
                 )
                 .strip()
                 .splitlines()

--- a/tests/test_subprocess_util.py
+++ b/tests/test_subprocess_util.py
@@ -12,18 +12,22 @@ def test_subprocess_tool_environment():
     assert sys.executable.startswith(env_exec["PATH"].split(os.pathsep)[0])
 
     if platform.system() == "Linux":
-        env_in = {"LD_LIBRARY_PATH": "bob", "LD_LIBRARY_PATH_ORIG": "alex", "my": "me"}
-        env_exec = subprocess_util.tool_environment(env_in)
-        assert env_exec is not env_in
+        base_env = {
+            "LD_LIBRARY_PATH": "bob",
+            "LD_LIBRARY_PATH_ORIG": "alex",
+            "my": "me",
+        }
+        env_exec = subprocess_util.tool_environment(base_env=base_env)
+        assert env_exec is not base_env
         assert env_exec["LD_LIBRARY_PATH"] == "alex"
         assert env_exec["my"] == "me"
 
-        env_in = {"LD_LIBRARY_PATH": "bob", "my": "me"}
-        env_exec = subprocess_util.tool_environment(env_in)
+        base_env = {"LD_LIBRARY_PATH": "bob", "my": "me"}
+        env_exec = subprocess_util.tool_environment(base_env=base_env)
         assert "LD_LIBRARY_PATH" not in env_exec
     else:
-        env_in = {"my": "me"}
-        env_exec = subprocess_util.tool_environment(env_in)
-        assert env_exec is not env_in
+        base_env = {"my": "me"}
+        env_exec = subprocess_util.tool_environment(base_env=base_env)
+        assert env_exec is not base_env
         env_exec.pop("PATH", None)
-        assert env_exec == env_in
+        assert env_exec == base_env


### PR DESCRIPTION
so that callers don't have to manually copy the env and then add their own overrides to it, before calling tool_environment.

One of the changes requested in #856 
