### PR TITLE
Don't modify os.environ when calling subprocesses...

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -421,9 +421,6 @@ class KartCliRunner(CliRunner):
 
     def invoke(self, args=None, **kwargs):
         from kart.cli import load_commands_from_args, cli
-        from kart.subprocess_util import init_git_config
-
-        init_git_config.cache_clear()
 
         if args:
             # force everything to strings (eg. PathLike objects, numbers)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,9 @@
 import contextlib
 import json
-import os
-import platform
 import re
 import sys
 from pathlib import Path
 
-import pygit2
 import pytest
 
 from kart import cli
@@ -39,20 +36,6 @@ def test_help_page_render(cli_runner, command):
 
 
 @pytest.fixture
-def empty_gitconfig(monkeypatch, tmpdir):
-    old = os.environ["HOME"]
-    (tmpdir / ".gitconfig").write_text("", encoding="utf8")
-    monkeypatch.setenv("HOME", str(tmpdir))
-    pygit2.option(
-        pygit2.GIT_OPT_SET_SEARCH_PATH, pygit2.GIT_CONFIG_LEVEL_GLOBAL, str(tmpdir)
-    )
-    yield
-    pygit2.option(
-        pygit2.GIT_OPT_SET_SEARCH_PATH, pygit2.GIT_CONFIG_LEVEL_GLOBAL, str(old)
-    )
-
-
-@pytest.fixture
 def sys_path_reset(monkeypatch):
     """A context manager to save & reset after code that changes sys.path"""
 
@@ -63,20 +46,6 @@ def sys_path_reset(monkeypatch):
             yield
 
     return _sys_path_reset
-
-
-def test_config(empty_gitconfig, cli_runner):
-    # don't load the ~/.gitconfig file from conftest.py
-    # (because it sets init.defaultBranch and we're trying to test what
-    # happens without that set)
-    # note: merely changing os.environ['HOME'] doesn't help here;
-    # once libgit has seen one HOME it never notices if we change it.
-
-    # The default init.defaultBranch in git is still 'master' as of 2.30.0
-    # but we override it to 'main'. Let's check that works properly
-    r = cli_runner.invoke(["config", "init.defaultBranch"])
-    assert r.exit_code == 0, r.stderr
-    assert r.stdout == "main\n"
 
 
 def test_ext_run(tmp_path, cli_runner, sys_path_reset):

--- a/tests/test_subprocess_util.py
+++ b/tests/test_subprocess_util.py
@@ -1,6 +1,9 @@
 import os
 import platform
+import pytest
 import sys
+
+import pygit2
 
 from kart import subprocess_util
 
@@ -30,4 +33,35 @@ def test_subprocess_tool_environment():
         env_exec = subprocess_util.tool_environment(base_env=base_env)
         assert env_exec is not base_env
         env_exec.pop("PATH", None)
+        env_exec.pop("GIT_CONFIG_PARAMETERS", None)
         assert env_exec == base_env
+
+
+@pytest.fixture
+def empty_gitconfig(monkeypatch, tmpdir):
+    old = os.environ["HOME"]
+    (tmpdir / ".gitconfig").write_text("", encoding="utf8")
+    monkeypatch.setenv("HOME", str(tmpdir))
+    pygit2.option(
+        pygit2.GIT_OPT_SET_SEARCH_PATH, pygit2.GIT_CONFIG_LEVEL_GLOBAL, str(tmpdir)
+    )
+    subprocess_util.get_tool_environment_overrides.cache_clear()
+    yield
+    subprocess_util.get_tool_environment_overrides.cache_clear()
+    pygit2.option(
+        pygit2.GIT_OPT_SET_SEARCH_PATH, pygit2.GIT_CONFIG_LEVEL_GLOBAL, str(old)
+    )
+
+
+def test_git_config(empty_gitconfig, cli_runner):
+    # don't load the ~/.gitconfig file from conftest.py
+    # (because it sets init.defaultBranch and we're trying to test what
+    # happens without that set)
+    # note: merely changing os.environ['HOME'] doesn't help here;
+    # once libgit has seen one HOME it never notices if we change it.
+
+    # The default init.defaultBranch in git is still 'master' as of 2.30.0
+    # but we override it to 'main'. Let's check that works properly
+    r = cli_runner.invoke(["config", "init.defaultBranch"])
+    assert r.exit_code == 0, r.stderr
+    assert r.stdout == "main\n"


### PR DESCRIPTION
for simplicity and consistency. Just create a tool environment.

One of the improvements suggested in #856