### PR TITLE
Disable VRTs, unless specifically flagged on

### DIFF
--- a/docs/pages/raster_datasets.rst
+++ b/docs/pages/raster_datasets.rst
@@ -55,3 +55,7 @@ For instance, every tile in a dataset must have the same CRS. If newly added til
 Git LFS
 ~~~~~~~
 For technical reasons, raster tiles are stored within the repository using `Git LFS <git_lfs_>`_, instead of the more fundamental backend store which is the "Git Object Database". For more details, see the section on :doc:`Git LFS </pages/git_lfs>`.
+
+VRT files
+~~~~~~~~~
+Setting an environment variable ``KART_RASTER_VRTS=1`` when creating the Kart working copy or checking out a commit will cause Kart to create a `VRT <vrt_>`_ (Virtual Raster) file for each raster dataset. This single file comprises a mosaic of all the tiles in the working copy that belong to that dataset, so that if you load this file in your tile-editing software, you have effectively loaded the entire dataset. The individual tiles are referenced by the VRT, rather than the data from each tile being duplicated in the VRT. Creation of VRTs is still experimental but should become the default in a future version of Kart.

--- a/kart/raster/v1.py
+++ b/kart/raster/v1.py
@@ -1,4 +1,5 @@
 import functools
+import os
 import re
 
 from kart.core import all_blobs_in_tree
@@ -81,7 +82,8 @@ class RasterV1(TileDataset):
     def write_mosaic_for_directory(cls, directory_path):
         from kart.raster.mosaic_util import write_vrt_for_directory
 
-        write_vrt_for_directory(directory_path)
+        if os.environ.get("KART_RASTER_VRTS"):
+            write_vrt_for_directory(directory_path)
 
     @classmethod
     def get_tile_path_pattern(

--- a/tests/raster/test_workingcopy.py
+++ b/tests/raster/test_workingcopy.py
@@ -732,7 +732,9 @@ def test_working_copy_conflicting_extension(cli_runner, data_archive):
         assert "More than one tile found in working copy with the same name" in r.stderr
 
 
-def test_working_copy_vrt(cli_runner, data_archive):
+def test_working_copy_vrt(cli_runner, data_archive, monkeypatch):
+    monkeypatch.setenv("KART_RASTER_VRTS", "1")
+
     with data_archive("raster/elevation.tgz") as repo_path:
         vrt_path = repo_path / "elevation" / "elevation.vrt"
 
@@ -755,6 +757,20 @@ def test_working_copy_vrt(cli_runner, data_archive):
         assert "Kart maintains this VRT file" in vrt_text
         assert '<SourceFilename relativeToVRT="1">EL.tif</SourceFilename>' in vrt_text
         assert '<SourceFilename relativeToVRT="1">EK.tif</SourceFilename>' in vrt_text
+
+
+def test_working_copy_vrt_disabled(cli_runner, data_archive, monkeypatch):
+    with data_archive("raster/elevation.tgz") as repo_path:
+
+        shutil.rmtree(repo_path / "elevation")
+
+        r = cli_runner.invoke(
+            ["create-workingcopy", "--delete-existing", "--discard-changes"]
+        )
+        assert r.exit_code == 0, r.stderr
+
+        vrt_path = repo_path / "elevation" / "elevation.vrt"
+        assert not vrt_path.is_file()
 
 
 @pytest.mark.skipif(is_windows, reason="copy-on-write not supported on windows")


### PR DESCRIPTION
Also add some documentation.

Nobody's yet spent enough time to be sure whether VRT creation is generally fast and reliable, or, not.
