### PR TITLE
Don't pipe stderr on windows - fixes #852

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please note that compatibility for 0.x releases (software or repositories) isn't
 
 _When adding new entries to the changelog, please include issue/PR numbers wherever possible._
 
+## 0.14.1 (UNRELEASED)
+
+- Fixes a bug where Git subprocesses (such as git clone) don't prompt the user for credentials or to resolve SSH issues on Windows. [#852](https://github.com/koordinates/kart/issues/852)
+
 ## 0.14.0
 
 ### Major changes

--- a/kart/repo.py
+++ b/kart/repo.py
@@ -371,10 +371,12 @@ class KartRepo(pygit2.Repository):
 
     @classmethod
     def _create_with_git_command(cls, cmd, gitdir_path, temp_workdir_path=None):
-        returncode, stdout, stderr = subprocess.run_and_tee_output(cmd)
-        if returncode != 0:
+        proc = subprocess.run_and_tee_output(cmd, tee_stderr=not is_windows)
+        if proc.returncode != 0:
             raise SubprocessError(
-                f"Error calling {cmd[0]} {cmd[1]}", exit_code=returncode, stderr=stderr
+                f"Error calling {cmd[0]} {cmd[1]}",
+                exit_code=proc.returncode,
+                stderr=b"" if is_windows else proc.stderr,
             )
 
         result = KartRepo(gitdir_path, validate=False)


### PR DESCRIPTION
## Description

Fixes https://github.com/koordinates/kart/issues/852 by no longer pushing git's stderr stream into a pipe - which git detects and then won't prompt the user.

Contains a more in-depth change that I made while still experimenting - the ability to choose which of the streams are piped (that is, tee'd to both kart and to their regular output stream). This makes the utility more generally useful - although we don't really need it, but I do use it to easily turn on or off the piping of stderr.

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
