### PR TITLE
html template option for diff command

### DIFF
--- a/kart/base_diff_writer.py
+++ b/kart/base_diff_writer.py
@@ -82,6 +82,8 @@ class BaseDiffWriter:
         target_crs=None,
         # used by json-lines diffs only
         diff_estimate_accuracy=None,
+        # used by html diff only
+        html_template=None
     ):
         self.repo = repo
         self.commit_spec = commit_spec
@@ -93,6 +95,7 @@ class BaseDiffWriter:
 
         self.user_key_filters = user_key_filters
         self.repo_key_filter = RepoKeyFilter.build_from_user_patterns(user_key_filters)
+        self.html_template = html_template
 
         self.spatial_filter = repo.spatial_filter
 

--- a/kart/diff.py
+++ b/kart/diff.py
@@ -129,6 +129,12 @@ def feature_count_diff(
     is_flag=True,
     help="Show changes to file contents (instead of just showing the object IDs of changed files)",
 )
+@click.option(
+    "--html-template",
+    default=None,
+    help="Provide a user defined/specific html template for diff representation",
+    type=click.Path(exists=True),
+)
 @click.argument(
     "args",
     metavar="[REVISIONS] [--] [FILTERS]",
@@ -147,6 +153,7 @@ def diff(
     add_feature_count_estimate,
     convert_to_dataset_format,
     diff_files,
+    html_template,
     args,
 ):
     """
@@ -205,6 +212,7 @@ def diff(
         json_style=fmt,
         target_crs=crs,
         diff_estimate_accuracy=add_feature_count_estimate,
+        html_template=html_template,
     )
     diff_writer.convert_to_dataset_format(convert_to_dataset_format)
     diff_writer.full_file_diffs(diff_files)

--- a/kart/html_diff_writer.py
+++ b/kart/html_diff_writer.py
@@ -1,6 +1,7 @@
 import json
 import string
 import sys
+import os
 import webbrowser
 from pathlib import Path
 
@@ -28,11 +29,12 @@ class HtmlDiffWriter(BaseDiffWriter):
         return output_path or repo.workdir_path / "DIFF.html"
 
     def write_diff(self, diff_format=DiffFormat.FULL):
+        template_path = self.html_template or (Path(kart.package_data_path) / "diff-view.html")
+        if not os.path.exists(template_path):
+            raise click.UsageError("Html template not found")
         if diff_format != DiffFormat.FULL:
             raise click.UsageError("Html format only supports full diffs")
-        with open(
-            Path(kart.package_data_path) / "diff-view.html", "r", encoding="utf8"
-        ) as ft:
+        with open(template_path, "r", encoding="utf8") as ft:
             template = string.Template(ft.read())
 
         repo_diff = self.get_repo_diff(diff_format=diff_format)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -2,6 +2,7 @@ import functools
 import json
 import re
 import time
+from pathlib import Path
 
 import html5lib
 import pytest
@@ -2096,3 +2097,15 @@ def test_attached_files_patch(data_archive, cli_runner):
                 "+": 'text:<gmd:MD_Metadata xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml" xmlns:gts="http://www.isotc211.org/2005/gts" xmlns:topo="http://www.linz.govt.nz/schemas/topo/data-dictionary" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.isotc211.org/2005/gmd">'
             },
         }
+
+def test_load_user_provided_html_template(data_archive, cli_runner):
+    with data_archive("points") as repo_path:
+        r = cli_runner.invoke(
+            [
+                "diff",
+                f"--output-format=html",
+                f"--html-template=" + str(Path(__file__).absolute().parent.parent / "kart" / "diff-view.html"),
+                "HEAD^...",
+            ]
+        )
+        assert r.exit_code == 0, r.stderr


### PR DESCRIPTION
## Description

The PR introduces a new parameter `--html-template` for diff command that allows to provide a custom html template for html rendering of diffs. The custom template must contains a `<script id="kart-data">const DATA=${geojson_data};</script>  where geojson diffs are delivered for javascript handling. 

## Related links:

The default template that can be used as reference is the following: https://github.com/koordinates/kart/blob/master/kart/diff-view.html

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
