### PR TITLE
Protect against XSS in diff-view by using application/json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 ## 0.14.1 (UNRELEASED)
 
 - Fixes a bug where Git subprocesses (such as git clone) don't prompt the user for credentials or to resolve SSH issues on Windows. [#852](https://github.com/koordinates/kart/issues/852)
+- Better protection against XSS in the HTML diff viewer. [#884](https://github.com/koordinates/kart/pull/884)
 
 ## 0.14.0
 

--- a/kart/diff-view.html
+++ b/kart/diff-view.html
@@ -103,8 +103,9 @@
             top: 2px;
         }
     </style>
-    <script id="kart-data">const DATA=${geojson_data};</script>
+    <script id="kart-data" type="application/json">${geojson_data}</script>
     <script type="module">
+        const DATA = JSON.parse(document.getElementById('kart-data').textContent);
         const GEOM = '⭔'
 
         function buildMap() {

--- a/kart/html_diff_writer.py
+++ b/kart/html_diff_writer.py
@@ -57,22 +57,27 @@ class HtmlDiffWriter(BaseDiffWriter):
         }
 
         fo = resolve_output_path(self.output_path)
-        fo.write(
-            template.substitute(
-                {
-                    "title": html.escape(title),
-                    "geojson_data": json.dumps(
-                        all_datasets_geojson, cls=ExtendedJsonEncoder
-                    ),
-                }
-            )
-        )
+        fo.write(self.substitute_into_template(template, title, all_datasets_geojson))
 
         if fo != sys.stdout:
             fo.close()
             webbrowser.open_new(f"file://{self.output_path.resolve()}")
 
         self.write_warnings_footer()
+
+    @classmethod
+    def substitute_into_template(cls, template, title, all_datasets_geojson):
+        return template.substitute(
+            {
+                "title": html.escape(title),
+                "geojson_data": json.dumps(
+                    all_datasets_geojson, cls=ExtendedJsonEncoder
+                )
+                .replace("/", r"\x2f")
+                .replace("<", r"\x3c")
+                .replace(">", r"\x3e"),
+            }
+        )
 
 
 HtmlDiffWriter.filtered_dataset_deltas_as_geojson = (

--- a/kart/html_diff_writer.py
+++ b/kart/html_diff_writer.py
@@ -1,3 +1,4 @@
+import html
 import json
 import string
 import sys
@@ -59,7 +60,7 @@ class HtmlDiffWriter(BaseDiffWriter):
         fo.write(
             template.substitute(
                 {
-                    "title": title,
+                    "title": html.escape(title),
                     "geojson_data": json.dumps(
                         all_datasets_geojson, cls=ExtendedJsonEncoder
                     ),

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -8,10 +8,8 @@ import html5lib
 import pytest
 
 import kart
-from kart.base_diff_writer import BaseDiffWriter
 from kart.diff_format import DiffFormat
 from kart.diff_structs import Delta, DeltaDiff
-from kart.diff_util import get_file_diff
 from kart.json_diff_writers import JsonLinesDiffWriter
 from kart.geometry import hex_wkb_to_ogr
 from kart.repo import KartRepo
@@ -30,10 +28,10 @@ def _check_html_output(s):
     document = parser.parse(s)
     # find the <script> element containing data
     el = document.find("./head/script[@id='kart-data']")
-    # find the JSON
-    m = re.match(r"\s*const DATA=(.*);\s*$", el.text, flags=re.DOTALL)
+    # Make sure we're parsing it as JSON.
+    assert el.attrib == {"id": "kart-data", "type": "application/json"}
     # validate it
-    return json.loads(m.group(1))
+    return json.loads(el.text)
 
 
 @pytest.mark.parametrize("output_format", DIFF_OUTPUT_FORMATS)


### PR DESCRIPTION
## Description

As discussed in https://github.com/koordinates/kart/pull/883
No extra tests yet, this is all the time I was willing to spend on it for right now.

Not clear if tests would be super valuable - we could test the following:
- does html.escape escape the characters that it says it escapes
- does json.dumps create valid json (ie, can we load it using json.loads)
but honestly it seems like these would be pretty well tested already

We can't really test the following:
- is html.escape guaranteed XSS safe for whatever browser the user has
- is json.dumps guaranteed XSS safe for whatever browser the user has (ie, it won't get tripped up by `{"xss": "</script><script>alert(1)</script>"}` or some nonsense)
- does the user's browser respect <script type="application/json"> and not allow XSS inside it? (my one does so that's good)

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
