### PR TITLE
Use Index.add_entry_with_custom_stat...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 - Fixes a bug where Git subprocesses (such as git clone) don't prompt the user for credentials or to resolve SSH issues on Windows. [#852](https://github.com/koordinates/kart/issues/852)
 - Better protection against XSS in the HTML diff viewer. [#884](https://github.com/koordinates/kart/pull/884)
+- Speed-up: greatly reduces the time taken to update the index file after checking out LFS tiles to the working copy. [#880](https://github.com/koordinates/kart/pull/880)
 
 ## 0.14.0
 

--- a/kart/lfs_util.py
+++ b/kart/lfs_util.py
@@ -1,6 +1,5 @@
 import base64
 import hashlib
-import json
 import logging
 from pathlib import Path
 import re

--- a/vcpkg-vendor/CMakeLists.txt
+++ b/vcpkg-vendor/CMakeLists.txt
@@ -261,7 +261,7 @@ set(PYGIT2_WHEEL_VER 1.12.1)
 ExternalProject_Add(
   pygit2
   GIT_REPOSITORY https://github.com/koordinates/pygit2.git
-  GIT_TAG kart-pygit-v1.12.1
+  GIT_TAG kart-v0.14.1
   GIT_SHALLOW ON
   BUILD_IN_SOURCE ON
   DEPENDS wheelBuildEnv unofficial::git2::libgit2package

--- a/vcpkg-vendor/vcpkg-overlay-ports/libgit2/portfile.cmake
+++ b/vcpkg-vendor/vcpkg-overlay-ports/libgit2/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO koordinates/libgit2
-    REF kart-libgit-v1.6.4
-    SHA512 0de7c2e0efe04d94f8116133bd167f641c51499c94e9b5a601309ab8045b276832347b7cdc75152b4f5c110c0c0c29224134e5aff32267d7a78595b4d2b5dd90
+    REF kart-v0.14.1
+    SHA512 ef2a5a1238909a3a7f78bd71b98f72a60bd69c6c3fc7707ba785d88e4910f37eef98664774cb99fe440bf384463469458c45caa6ee3dac7bbafe5f3a73cbb08b
     HEAD_REF kx-latest
     PATCHES
         fix-configcmake.patch


### PR DESCRIPTION
to greatly increase efficiency during LFS working copy checkout.
Without this change, the step of building the index during
the working copy checkout will take a long time as it hashes
all the LFS tiles that have been checked out.

## Related links:

https://github.com/koordinates/kart/issues/880

## Checklist:

- [x] Have you reviewed your own change?
- [x] Existing tests pass
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
