### PR TITLE
Fix for global-mapper incompatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Speed-up: greatly reduces the time taken to update the index file after checking out LFS tiles to the working copy. [#880](https://github.com/koordinates/kart/pull/880)
 - Adds `--with-dataset-types` option to `kart data ls` command (and deprecates `kart data version`). [#892](https://github.com/koordinates/kart/issues/892)
 - Use `journal_mode = WAL` in annotations.db sqlite database. [#898](https://github.com/koordinates/kart/pull/898)
+- Slightly modifies the GPKG working copy format to avoid an incompatiblity with [Global Mapper](https://www.bluemarblegeo.com/global-mapper/). [#899](https://github.com/koordinates/kart/issues/899)
 
 ## 0.14.0
 

--- a/kart/tabular/working_copy/gpkg.py
+++ b/kart/tabular/working_copy/gpkg.py
@@ -533,8 +533,8 @@ class WorkingCopy_GPKG(TableWorkingCopy):
                 CREATE TRIGGER IF NOT EXISTS {self._quoted_tracking_name('upd', dataset)}
                    AFTER UPDATE ON {table_identifier}
                 BEGIN
-                    INSERT OR REPLACE INTO {self.KART_TRACK} (table_name, pk)
-                    VALUES (:table_name1, NEW.{pk_column}), (:table_name2, OLD.{pk_column});
+                    INSERT OR REPLACE INTO {self.KART_TRACK} (table_name, pk) VALUES (:table_name1, NEW.{pk_column});
+                    INSERT OR REPLACE INTO {self.KART_TRACK} (table_name, pk) VALUES (:table_name2, OLD.{pk_column});
                 END;
                 """,
                 {"table_name1": dataset.table_name, "table_name2": dataset.table_name},


### PR DESCRIPTION
## Description

Global Mapper doesn't understand certain forms of sqlite triggers.
Happily, there are some equivalent forms we can use without any real issue.

## Related links:

https://github.com/koordinates/kart/issues/899

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
