### PR TITLE
Add GPKG application ID to GPKG working copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please note that compatibility for 0.x releases (software or repositories) isn't
 
 _When adding new entries to the changelog, please include issue/PR numbers wherever possible._
 
+## 0.14.2 (UNRELEASED)
+
+- Fixes a bug where the GPKG application ID is not being written in GPKG working copies - other software reading the GPKG may be confused by this. [#902](https://github.com/koordinates/kart/issues/902)
+
 ## 0.14.1
 
 - Fixes a bug where Git subprocesses (such as git clone) don't prompt the user for credentials or to resolve SSH issues on Windows. [#852](https://github.com/koordinates/kart/issues/852)

--- a/kart/tabular/working_copy/gpkg.py
+++ b/kart/tabular/working_copy/gpkg.py
@@ -191,6 +191,8 @@ class WorkingCopy_GPKG(TableWorkingCopy):
 
     def create_and_initialise(self):
         with self.session() as sess:
+            sess.execute("PRAGMA application_id = 0x47504B47")  # "GPKG"
+            sess.execute("PRAGMA user_version = 10300")  # GPKG 1.3
             # Create standard GPKG tables:
             GpkgTables.create_all(sess)
             GpkgTables.init_table_contents(sess)

--- a/tests/test_working_copy_gpkg.py
+++ b/tests/test_working_copy_gpkg.py
@@ -1240,3 +1240,21 @@ def test_global_mapper_compatibility(data_working_copy):
             # But it does not understand this SQL snippet: VALUES (...), (...)
             # Make sure that doesn't occur in our GPKG working copy.
             assert all(not re.search(r"VALUES\s*\([^();]*\)\s*,", s) for s in schemas)
+
+
+def test_gpkg_application_id(data_working_copy):
+    # See https://github.com/koordinates/kart/issues/902
+
+    try:
+        subprocess.check_output(["ogrinfo", "--version"])
+    except FileNotFoundError:
+        raise pytest.skip("This test only runs if ogrinfo is installed")
+
+    with data_working_copy("points") as (repo_path, wc_path):
+        r = subprocess.run(
+            ["ogrinfo", "-ro", "-so", "-al", wc_path],
+            encoding="utf8",
+            capture_output=True,
+        )
+        # No warnings shown:
+        assert r.stderr == ""

--- a/vcpkg-vendor/CMakeLists.txt
+++ b/vcpkg-vendor/CMakeLists.txt
@@ -584,10 +584,14 @@ endif()
 set(LIB_DIR "lib/")
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   set(EXE_DIR scripts)
-  set(LIB_SEARCH_DIR "${CURRENT_PACKAGES_DIR}/bin")
-else()
+  set(LIB_SEARCH_DIRS --search-path "${CURRENT_PACKAGES_DIR}/bin")
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set(EXE_DIR bin)
-  set(LIB_SEARCH_DIR "${CURRENT_PACKAGES_DIR}/lib")
+  set(LIB_SEARCH_DIRS --search-path "${CURRENT_PACKAGES_DIR}/lib" --search-path
+                      /usr/local/opt/libtool/lib/)
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  set(EXE_DIR bin)
+  set(LIB_SEARCH_DIRS --search-path "${CURRENT_PACKAGES_DIR}/lib")
 endif()
 
 #
@@ -653,7 +657,7 @@ add_custom_command(
     ${CMAKE_COMMAND} -E env CMAKE_COMMAND=${CMAKE_COMMAND} --modify
     PATH=path_list_prepend:${TOOLS_PATH} -- ${wheelBuildEnv_PYTHON}
     "${CMAKE_CURRENT_SOURCE_DIR}/fix_vendor_libs.py" $<IF:$<BOOL:$ENV{VERBOSE}>,-v2,-v0> .
-    ${VENDOR_ARCHIVE} -s "${LIB_SEARCH_DIR}"
+    ${VENDOR_ARCHIVE} ${LIB_SEARCH_DIRS}
   VERBATIM
   COMMENT "Vendor dependency archive assembly")
 


### PR DESCRIPTION
Fixes https://github.com/koordinates/kart/issues/902

GPKG working copies written by kart currently are missing the GPKG application ID, which means they are not spec conformant.
Not yet aware of any clients that are affected by this, but we should conform to spec. Now we do:

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
