### PR TITLE
Fix CURL_CA_INFO incorrect when using kart helper

### DIFF
--- a/kart/__init__.py
+++ b/kart/__init__.py
@@ -17,6 +17,28 @@ import sys
 
 L = logging.getLogger("kart.__init__")
 
+# These env vars are retained in the helper process, rather than being clobbered
+# by the environment of the Kart client process.
+# This allows the helper to do initial setup (mostly below, in this file)
+# without it being later undone by the client process.
+HELPER_PRESERVE_ENV_VARS = (
+    "CURL_CA_INFO",
+    "GDAL_DATA",
+    "GIT_CONFIG_NOSYSTEM",
+    "GIT_EXEC_PATH",
+    "GIT_INDEX_FILE",
+    "GIT_TEMPLATE_DIR",
+    "KART_HELPER_LOG",
+    "LD_LIBRARY_PATH_ORIG",
+    "LD_LIBRARY_PATH",
+    "OGR_SQLITE_PRAGMA",
+    "PATH",
+    "PROJ_LIB",
+    "PROJ_NETWORK",
+    "SSL_CERT_FILE",
+    "XDG_CONFIG_HOME",
+)
+
 try:
     import _kart_env
 

--- a/kart/helper.py
+++ b/kart/helper.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import click
 
+from . import HELPER_PRESERVE_ENV_VARS
 from .socket_utils import recv_json_and_fds
 from .cli import load_commands_from_args, cli, is_windows, is_darwin, is_linux
 
@@ -70,29 +71,7 @@ def helper(ctx, socket_filename, timeout, args):
     # TODO - this should be checked to ensure it is all that is needed
     #  is there anything beyond these which is needed, eg. PWD, USER, etc.
     required_environment = {
-        k: v
-        for k, v in os.environ.items()
-        if k
-        in [
-            "CURL_CA_INFO",
-            "GDAL_DATA",
-            "GIT_CONFIG_NOSYSTEM",
-            "GIT_EXEC_PATH",
-            "GIT_EXEC_PATH",
-            "GIT_INDEX_FILE",
-            "GIT_INDEX_FILE",
-            "GIT_TEMPLATE_DIR",
-            "GIT_TEMPLATE_DIR",
-            "KART_HELPER_LOG",
-            "LD_LIBRARY_PATH_ORIG",
-            "LD_LIBRARY_PATH",
-            "OGR_SQLITE_PRAGMA",
-            "PATH",
-            "PROJ_LIB",
-            "PROJ_NETWORK",
-            "SSL_CERT_FILE",
-            "XDG_CONFIG_HOME",
-        ]
+        k: v for k, v in os.environ.items() if k in HELPER_PRESERVE_ENV_VARS
     }
 
     sock = socket.socket(family=socket.AF_UNIX)

--- a/kart/helper.py
+++ b/kart/helper.py
@@ -74,23 +74,24 @@ def helper(ctx, socket_filename, timeout, args):
         for k, v in os.environ.items()
         if k
         in [
-            "PATH",
-            "LD_LIBRARY_PATH",
-            "LD_LIBRARY_PATH_ORIG",
+            "CURL_CA_INFO",
+            "GDAL_DATA",
             "GIT_CONFIG_NOSYSTEM",
             "GIT_EXEC_PATH",
-            "GIT_TEMPLATE_DIR",
+            "GIT_EXEC_PATH",
             "GIT_INDEX_FILE",
-            "GDAL_DATA",
+            "GIT_INDEX_FILE",
+            "GIT_TEMPLATE_DIR",
+            "GIT_TEMPLATE_DIR",
+            "KART_HELPER_LOG",
+            "LD_LIBRARY_PATH_ORIG",
+            "LD_LIBRARY_PATH",
+            "OGR_SQLITE_PRAGMA",
+            "PATH",
             "PROJ_LIB",
             "PROJ_NETWORK",
-            "OGR_SQLITE_PRAGMA",
-            "XDG_CONFIG_HOME",
-            "GIT_EXEC_PATH",
-            "GIT_TEMPLATE_DIR",
-            "GIT_INDEX_FILE",
             "SSL_CERT_FILE",
-            "KART_HELPER_LOG",
+            "XDG_CONFIG_HOME",
         ]
     }
 


### PR DESCRIPTION
## Description

Kart sets `CURL_CA_INFO` at startup in `__init__.py` and this also happens in helper mode.

Unfortunately, in helper mode the environment is overwritten with the environment of the calling process, and `CURL_CA_INFO` disappears.

Then if the helper invokes PDAL or any other subprocess it doesn't get that variable.

This fix adds `CURL_CA_INFO` to the whitelist of env vars to preserve in the helper rather than override from the calling process.

## Related links:

<!-- If you have links to [issues](https://github.com/koordinates/kart/issues) etc, link them here. -->

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
