### PR TITLE
Store S3 region along with S3 URL

### DIFF
--- a/kart/byod/point_cloud_import.py
+++ b/kart/byod/point_cloud_import.py
@@ -6,7 +6,7 @@ from kart.byod.importer import ByodTileImporter
 from kart.cli_util import StringFromFile, MutexOption, KartCommand
 from kart.point_cloud.import_ import PointCloudImporter
 from kart.point_cloud.metadata_util import extract_pc_tile_metadata
-from kart.s3_util import get_hash_and_size_of_s3_object, fetch_from_s3
+from kart.s3_util import get_hash_and_size_of_s3_object, fetch_from_s3, get_region_name
 
 
 L = logging.getLogger(__name__)
@@ -128,5 +128,6 @@ class ByodPointCloudImporter(ByodTileImporter, PointCloudImporter):
         )
         tmp_downloaded_tile.unlink()
         # TODO - format still not definite, we might not put the whole URL in here.
+        result["tile"]["region"] = get_region_name()
         result["tile"]["url"] = tile_location
         return result

--- a/kart/byod/raster_import.py
+++ b/kart/byod/raster_import.py
@@ -6,7 +6,7 @@ from kart.byod.importer import ByodTileImporter
 from kart.cli_util import StringFromFile, MutexOption, KartCommand
 from kart.raster.import_ import RasterImporter
 from kart.raster.metadata_util import extract_raster_tile_metadata
-from kart.s3_util import get_hash_and_size_of_s3_object, fetch_from_s3
+from kart.s3_util import get_hash_and_size_of_s3_object, get_region_name
 
 
 L = logging.getLogger(__name__)
@@ -123,5 +123,6 @@ class ByodRasterImporter(ByodTileImporter, RasterImporter):
         oid_and_size = get_hash_and_size_of_s3_object(tile_location)
         result = extract_raster_tile_metadata(tile_location, oid_and_size=oid_and_size)
         # TODO - format still not definite, we might not put the whole URL in here.
+        result["tile"]["region"] = get_region_name()
         result["tile"]["url"] = tile_location
         return result

--- a/kart/s3_util.py
+++ b/kart/s3_util.py
@@ -35,6 +35,11 @@ def get_s3_resource():
     return resource
 
 
+@functools.lru_cache(maxsize=1)
+def get_region_name():
+    return get_s3_client().meta.config.region_name
+
+
 @functools.lru_cache()
 def get_bucket(name):
     return get_s3_resource().Bucket(name)

--- a/tests/byod/test_imports.py
+++ b/tests/byod/test_imports.py
@@ -52,6 +52,7 @@ def test_byod_point_cloud_import(
             {"name": "Blue", "dataType": "integer", "size": 16},
         ]
 
+        tile_region = auckland["tile"][0]["+"]["region"]
         tile_0_url = os.path.join(
             s3_test_data_point_cloud.split("*")[0], "auckland_0_0.laz"
         )
@@ -62,6 +63,7 @@ def test_byod_point_cloud_import(
             "format": "laz-1.2",
             "nativeExtent": "1754987.85,1755987.77,5920219.76,5921219.64,-1.66,99.83",
             "pointCount": 4231,
+            "region": tile_region,
             "url": tile_0_url,
             "oid": "sha256:6b980ce4d7f4978afd3b01e39670e2071a792fba441aca45be69be81cb48b08c",
             "size": 51489,
@@ -114,6 +116,7 @@ def test_byod_raster_import(
             "5": "Gully risk",
         }
 
+        tile_region = erorisk_si["tile"][0]["+"]["region"]
         tile_url = os.path.join(
             s3_test_data_raster.split("*")[0], "erorisk_silcdb4.tif"
         )
@@ -124,6 +127,7 @@ def test_byod_raster_import(
             "dimensions": "762x790",
             "format": "geotiff/cog",
             "nativeExtent": "POLYGON((1573869.73 5155224.347,1573869.73 5143379.674,1585294.591 5143379.674,1585294.591 5155224.347,1573869.73 5155224.347))",
+            "region": tile_region,
             "url": tile_url,
             "oid": "sha256:c4bbea4d7cfd54f4cdbca887a1b358a81710e820a6aed97cdf3337fd3e14f5aa",
             "size": 604652,


### PR DESCRIPTION
<img src="https://media2.giphy.com/media/zDxDq6KN3CwGzAzpT6/giphy-downsized-medium.gif"/>

## Description

Allows for a dataset to contain tiles from more than one S3 region.
Might not be very common to have multi-S3-region datasets but conceptually, the region is just an extra part of the URL - other non-S3 schemes (such as https / azure / whatever) don't have regions, so the closer we keep the region to the rest of the URL, the more consistent things will be across the bourd.

## Related links:

https://github.com/koordinates/kart/issues/905

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
