### PR TITLE
Add citation information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please note that compatibility for 0.x releases (software or repositories) isn't
 
 _When adding new entries to the changelog, please include issue/PR numbers wherever possible._
 
+## 0.14.3 (UNRELEASED)
+
+- Adds information on referencing and citing Kart to `CITATION`. [#914](https://github.com/koordinates/kart/pull/914)
+
 ## 0.14.2
 
 - Fixes a bug where the GPKG application ID is not being written in GPKG working copies - other software reading the GPKG may be confused by this. [#902](https://github.com/koordinates/kart/issues/902)

--- a/CITATION
+++ b/CITATION
@@ -1,0 +1,13 @@
+To cite Kart in publications use:
+
+  Kart contributors (2023). Kart geospatial data version-control software.
+  URL https://kartproject.org
+
+A BibTeX entry for LaTeX users is
+
+  @Manual{,
+    title = {{Kart} geospatial data version-control software},
+    author = {{Kart contributors}},
+    year = {2023},
+    url = {https://kartproject.org},
+  }


### PR DESCRIPTION
## Description

Add a note on how we want Kart to be cited.

[Zenodo archiving has been configured for Kart on Github](https://docs.github.com/en/repositories/archiving-a-github-repository/referencing-and-citing-content). It doesn't go back in time though, so once we do our next release we can update this with a DOI ala [GDAL's](https://github.com/OSGeo/gdal/blob/master/CITATION).

## Related links:

https://github.com/koordinates/kart/discussions/913

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
