### PR TITLE
Improved configuration / resource reuse for S3

### DIFF
--- a/kart/byod/point_cloud_import.py
+++ b/kart/byod/point_cloud_import.py
@@ -6,7 +6,7 @@ from kart.byod.importer import ByodTileImporter
 from kart.cli_util import StringFromFile, MutexOption, KartCommand
 from kart.point_cloud.import_ import PointCloudImporter
 from kart.point_cloud.metadata_util import extract_pc_tile_metadata
-from kart.s3_util import get_hash_and_size_of_s3_object, fetch_from_s3, get_region_name
+from kart.s3_util import get_hash_and_size_of_s3_object, fetch_from_s3
 
 
 L = logging.getLogger(__name__)
@@ -130,6 +130,5 @@ class ByodPointCloudImporter(ByodTileImporter, PointCloudImporter):
         )
         tmp_downloaded_tile.unlink()
         # TODO - format still not definite, we might not put the whole URL in here.
-        result["tile"]["region"] = get_region_name()
         result["tile"]["url"] = tile_location
         return result

--- a/kart/byod/raster_import.py
+++ b/kart/byod/raster_import.py
@@ -6,7 +6,7 @@ from kart.byod.importer import ByodTileImporter
 from kart.cli_util import StringFromFile, MutexOption, KartCommand
 from kart.raster.import_ import RasterImporter
 from kart.raster.metadata_util import extract_raster_tile_metadata
-from kart.s3_util import get_hash_and_size_of_s3_object, get_region_name
+from kart.s3_util import get_hash_and_size_of_s3_object, fetch_from_s3
 
 
 L = logging.getLogger(__name__)
@@ -125,6 +125,5 @@ class ByodRasterImporter(ByodTileImporter, RasterImporter):
         oid_and_size = get_hash_and_size_of_s3_object(tile_location)
         result = extract_raster_tile_metadata(tile_location, oid_and_size=oid_and_size)
         # TODO - format still not definite, we might not put the whole URL in here.
-        result["tile"]["region"] = get_region_name()
         result["tile"]["url"] = tile_location
         return result

--- a/kart/s3_util.py
+++ b/kart/s3_util.py
@@ -4,7 +4,7 @@ import functools
 import os
 from pathlib import Path
 import tempfile
-from threading import currentThread
+from threading import current_thread
 from urllib.parse import urlparse
 
 import boto3
@@ -14,19 +14,13 @@ from kart.exceptions import NotFound, NO_IMPORT_SOURCE, NO_CHECKSUM
 
 # Utility functions for dealing with S3 - not yet launched.
 
-# Lots of functions in this file look like this:
-# >> @functools.lru_cache()
-# >> def _get_some_thread_unsafe_s3_resource(region, thread_hash):
-# This is a simple way of effectively getting a thread-local cache, ie,
-# - we want to get a resource that is configured how we currently need it (has the correct default region)
-# - we don't want a resource that is also being used by another thread
-# - aside from these two constraints, we can reuse the resources, hence the lru_cache.
-
 L = logging.getLogger("kart.s3_util")
 
 
 @functools.lru_cache()
 def get_region(bucket):
+    """Returns the name of the S3 region that a particular bucket is in."""
+
     # The region -> bucket cache is not thread-local, since the region a bucket is in doesn't depend
     # on which thread we are currently using.
     if not bucket:
@@ -42,45 +36,75 @@ def get_region(bucket):
         return None
 
 
-def get_s3_session(*, region=None, bucket=None):
-    return _get_s3_session(region or get_region(bucket), hash(currentThread()))
+def threadlocal_lru_cache(*decorator_args, **decorator_kwargs):
+    """
+    Decorator that works just like functools.lru_cache, but stores the hash of the calling thread
+    as part of the cache-key, so that each thread effectively gets a (albeit smaller) separate cache.
+
+    Used heavily here since boto3 sessions and resources are not guaranteed thread-safe.
+    """
+
+    def _threadlocal_lru_cache(user_func):
+        @functools.lru_cache(*decorator_args, **decorator_kwargs)
+        def caching_func(*args, thread_hash=None, **kwargs):
+            return user_func(*args, **kwargs)
+
+        @functools.wraps(user_func)
+        def wrapping_func(*args, **kwargs):
+            return caching_func(*args, thread_hash=hash(current_thread()), **kwargs)
+
+        return wrapping_func
+
+    return _threadlocal_lru_cache
 
 
-@functools.lru_cache()
-def _get_s3_session(region, thread_hash):
+def add_bucket_kwarg():
+    """
+    Decorator that adds a `bucket=None` kwarg to a function definition that already
+    has a `region` kwarg. If the region kwarg is not set and the bucket is set,
+    then the wrapped function will have its region kwarg set to the region of the bucket
+    using get_region(bucket).
+
+    This decorator goes *before* threadlocal_lru_cache since the aim is to have one client
+    per region per thread - there is no need to have one decorator per bucket.
+    """
+
+    def _add_bucket_kwarg(user_func):
+        @functools.wraps(user_func)
+        def wrapping_func(*args, region=None, bucket=None, **kwargs):
+            return user_func(*args, region=region or get_region(bucket), **kwargs)
+
+        return wrapping_func
+
+    return _add_bucket_kwarg
+
+
+@add_bucket_kwarg()
+@threadlocal_lru_cache()
+def get_s3_session(*, region=None):
     return boto3.session.Session(region_name=region)
 
 
-def get_s3_client(*, region=None, bucket=None):
-    return _get_s3_client(region or get_region(bucket), hash(currentThread()))
-
-
-@functools.lru_cache()
-def _get_s3_client(region, thread_hash):
-    client = _get_s3_session(region, thread_hash).client("s3")
+@add_bucket_kwarg()
+@threadlocal_lru_cache()
+def get_s3_client(*, region=None):
+    client = get_s3_session(region=region).client("s3")
     if "AWS_NO_SIGN_REQUEST" in os.environ:
         client._request_signer.sign = lambda *args, **kwargs: None
     return client
 
 
+@add_bucket_kwarg()
+@threadlocal_lru_cache()
 def get_s3_resource(*, region=None, bucket=None):
-    return _get_s3_resource(region or get_region(bucket), hash(currentThread()))
-
-
-@functools.lru_cache()
-def _get_s3_resource(region, thread_hash):
-    resource = _get_s3_session(region, thread_hash).resource("s3")
+    resource = get_s3_session(region=region).resource("s3")
     if "AWS_NO_SIGN_REQUEST" in os.environ:
         resource.meta.client._request_signer.sign = lambda *args, **kwargs: None
     return resource
 
 
+@threadlocal_lru_cache()
 def get_s3_bucket(bucket):
-    return _get_s3_bucket(bucket, hash(currentThread()))
-
-
-@functools.lru_cache()
-def _get_s3_bucket(bucket, thread_hash):
     return get_s3_resource(bucket=bucket).Bucket(bucket)
 
 

--- a/kart/s3_util.py
+++ b/kart/s3_util.py
@@ -35,11 +35,6 @@ def get_s3_resource():
     return resource
 
 
-@functools.lru_cache(maxsize=1)
-def get_region_name():
-    return get_s3_client().meta.config.region_name
-
-
 @functools.lru_cache()
 def get_bucket(name):
     return get_s3_resource().Bucket(name)

--- a/kart/s3_util.py
+++ b/kart/s3_util.py
@@ -1,8 +1,10 @@
 from base64 import standard_b64decode
+import logging
 import functools
 import os
 from pathlib import Path
 import tempfile
+from threading import currentThread
 from urllib.parse import urlparse
 
 import boto3
@@ -12,32 +14,82 @@ from kart.exceptions import NotFound, NO_IMPORT_SOURCE, NO_CHECKSUM
 
 # Utility functions for dealing with S3 - not yet launched.
 
+# Lots of functions in this file look like this:
+# >> @functools.lru_cache()
+# >> def _get_some_thread_unsafe_s3_resource(region, thread_hash):
+# This is a simple way of effectively getting a thread-local cache, ie,
+# - we want to get a resource that is configured how we currently need it (has the correct default region)
+# - we don't want a resource that is also being used by another thread
+# - aside from these two constraints, we can reuse the resources, hence the lru_cache.
 
-@functools.lru_cache(maxsize=1)
-def get_s3_config():
-    # TODO - add an option --s3-region to commands where it would be useful.
-    return None
+L = logging.getLogger("kart.s3_util")
 
 
-@functools.lru_cache(maxsize=1)
-def get_s3_client():
-    client = boto3.client("s3", config=get_s3_config())
+@functools.lru_cache()
+def get_region(bucket):
+    # The region -> bucket cache is not thread-local, since the region a bucket is in doesn't depend
+    # on which thread we are currently using.
+    if not bucket:
+        return None
+    try:
+        response = get_s3_client().head_bucket(Bucket=bucket)
+        return response["ResponseMetadata"]["HTTPHeaders"]["x-amz-bucket-region"]
+    except Exception as e:
+        L.warning("Couldn't find S3 region for bucket %s: %s", bucket, e)
+        # We don't necessarily need to know which region a bucket is in -
+        # - we try to configure S3 clients to default to connecting to the right region, for efficiency
+        # - but even if this doesn't work, the overall operation might still work. We'll keep going.
+        return None
+
+
+def get_s3_session(*, region=None, bucket=None):
+    return _get_s3_session(region or get_region(bucket), hash(currentThread()))
+
+
+@functools.lru_cache()
+def _get_s3_session(region, thread_hash):
+    return boto3.session.Session(region_name=region)
+
+
+def get_s3_client(*, region=None, bucket=None):
+    return _get_s3_client(region or get_region(bucket), hash(currentThread()))
+
+
+@functools.lru_cache()
+def _get_s3_client(region, thread_hash):
+    client = _get_s3_session(region, thread_hash).client("s3")
     if "AWS_NO_SIGN_REQUEST" in os.environ:
         client._request_signer.sign = lambda *args, **kwargs: None
     return client
 
 
-@functools.lru_cache(maxsize=1)
-def get_s3_resource():
-    resource = boto3.resource("s3", config=get_s3_config())
+def get_s3_resource(*, region=None, bucket=None):
+    return _get_s3_resource(region or get_region(bucket), hash(currentThread()))
+
+
+@functools.lru_cache()
+def _get_s3_resource(region, thread_hash):
+    resource = _get_s3_session(region, thread_hash).resource("s3")
     if "AWS_NO_SIGN_REQUEST" in os.environ:
         resource.meta.client._request_signer.sign = lambda *args, **kwargs: None
     return resource
 
 
+def get_s3_bucket(bucket):
+    return _get_s3_bucket(bucket, hash(currentThread()))
+
+
 @functools.lru_cache()
-def get_bucket(name):
-    return get_s3_resource().Bucket(name)
+def _get_s3_bucket(bucket, thread_hash):
+    return get_s3_resource(bucket=bucket).Bucket(bucket)
+
+
+def parse_s3_url(s3_url):
+    parsed = urlparse(s3_url)
+    assert parsed.scheme == "s3"
+    bucket = parsed.netloc
+    key = parsed.path.lstrip("/")
+    return bucket, key
 
 
 def fetch_from_s3(s3_url, output_path=None):
@@ -46,14 +98,13 @@ def fetch_from_s3(s3_url, output_path=None):
     If output-path is not set, creates a temporary file using tempfile.mkstemp()
     """
     # TODO: handle failure.
-    parsed = urlparse(s3_url)
-    bucket = get_bucket(parsed.netloc)
+    bucket, key = parse_s3_url(s3_url)
     if output_path is None:
-        fd, path = tempfile.mkstemp()
+        fd, output_path = tempfile.mkstemp()
         # If we keep it open, boto3 won't be able to write to it (on Windows):
         os.close(fd)
-        output_path = Path(path)
-    bucket.download_file(parsed.path.lstrip("/"), str(output_path.resolve()))
+    output_path = Path(output_path).resolve()
+    get_s3_bucket(bucket).download_file(key, str(output_path))
     return output_path
 
 
@@ -67,8 +118,15 @@ def expand_s3_glob(source_spec):
     if "*" not in source_spec:
         return [source_spec]
 
-    parsed = urlparse(source_spec)
-    prefix, suffix = parsed.path.split("*", maxsplit=1)
+    bucket, key = parse_s3_url(source_spec)
+    if "*" in bucket:
+        raise click.UsageError(
+            "Wildcard '*' should only be in key part of s3 URL, not in bucket"
+        )
+    if "*" not in key:
+        return [source_spec]
+
+    prefix, suffix = key.split("*", maxsplit=1)
     if "*" in suffix:
         raise click.UsageError(
             f"Two wildcards '*' found in {source_spec} - only one wildcard is supported"
@@ -76,8 +134,7 @@ def expand_s3_glob(source_spec):
     prefix = prefix.lstrip("/")
     prefix_len = len(prefix)
 
-    bucket = get_bucket(parsed.netloc)
-    matches = bucket.objects.filter(Prefix=prefix)
+    matches = get_s3_bucket(bucket).objects.filter(Prefix=prefix)
     result = []
     for match in matches:
         assert match.key.startswith(prefix)
@@ -94,10 +151,8 @@ def expand_s3_glob(source_spec):
 
 def get_hash_and_size_of_s3_object(s3_url):
     """Returns the (SHA256-hash-in-Base64, filesize) of an S3 object."""
-    parsed = urlparse(s3_url)
-    bucket = parsed.netloc
-    key = parsed.path.lstrip("/")
-    response = get_s3_client().head_object(
+    bucket, key = parse_s3_url(s3_url)
+    response = get_s3_client(bucket=bucket).head_object(
         Bucket=bucket, Key=key, ChecksumMode="ENABLED"
     )
     # TODO: fall back to other ways of learning the checksum.

--- a/tests/byod/test_imports.py
+++ b/tests/byod/test_imports.py
@@ -52,7 +52,6 @@ def test_byod_point_cloud_import(
             {"name": "Blue", "dataType": "integer", "size": 16},
         ]
 
-        tile_region = auckland["tile"][0]["+"]["region"]
         tile_0_url = os.path.join(
             s3_test_data_point_cloud.split("*")[0], "auckland_0_0.laz"
         )
@@ -63,7 +62,6 @@ def test_byod_point_cloud_import(
             "format": "laz-1.2",
             "nativeExtent": "1754987.85,1755987.77,5920219.76,5921219.64,-1.66,99.83",
             "pointCount": 4231,
-            "region": tile_region,
             "url": tile_0_url,
             "oid": "sha256:6b980ce4d7f4978afd3b01e39670e2071a792fba441aca45be69be81cb48b08c",
             "size": 51489,
@@ -116,7 +114,6 @@ def test_byod_raster_import(
             "5": "Gully risk",
         }
 
-        tile_region = erorisk_si["tile"][0]["+"]["region"]
         tile_url = os.path.join(
             s3_test_data_raster.split("*")[0], "erorisk_silcdb4.tif"
         )
@@ -127,7 +124,6 @@ def test_byod_raster_import(
             "dimensions": "762x790",
             "format": "geotiff/cog",
             "nativeExtent": "POLYGON((1573869.73 5155224.347,1573869.73 5143379.674,1585294.591 5143379.674,1585294.591 5155224.347,1573869.73 5155224.347))",
-            "region": tile_region,
             "url": tile_url,
             "oid": "sha256:c4bbea4d7cfd54f4cdbca887a1b358a81710e820a6aed97cdf3337fd3e14f5aa",
             "size": 604652,


### PR DESCRIPTION
Don't store S3 regions - we don't need them, and they could (occasionally) change over time,
if somebody carefully deletes and recreates a bucket. And, it's extra junk to store.

Learn the region that buckets are in, where possible.
Configure S3 the client to default to the region that the resource is in,
to save it potentially finding the region itself on a per-request basis.
Dont' reuse clients across multiple regions (for the config reason).
Don't reuse clients across multiple threads (S3 resources and sessions are not guaranteed to be thread safe).
Do reuse clients / resources / buckets otherwise - these will be cached until the command exits.

This is the also the groundwork for fetching tiles during WC checkout,
which will probably need to happen on multiple threads.

## Related links:

https://github.com/koordinates/kart/issues/905

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)? (Existing tests pass.)
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
