### PR TITLE
Change the logic for detecting table-dataset V1 repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 ## 0.14.3 (UNRELEASED)
 
 - Adds information on referencing and citing Kart to `CITATION`. [#914](https://github.com/koordinates/kart/pull/914)
+- Fixes a bug where Kart would misidentify a non-Kart repo as a Kart V1 repo in some circumstances. [#918](https://github.com/koordinates/kart/issues/918)
 
 ## 0.14.2
 

--- a/kart/subprocess_util.py
+++ b/kart/subprocess_util.py
@@ -332,6 +332,10 @@ def tool_environment(*, base_env=None, env_overrides=None):
 
     if env_overrides:
         env.update(env_overrides)
+        # Handle {key: None} to unset env variables:
+        for key, value in env_overrides.items():
+            if value is None:
+                env.pop(key)
     return env
 
 

--- a/kart/subprocess_util.py
+++ b/kart/subprocess_util.py
@@ -335,7 +335,7 @@ def tool_environment(*, base_env=None, env_overrides=None):
         # Handle {key: None} to unset env variables:
         for key, value in env_overrides.items():
             if value is None:
-                env.pop(key)
+                env.pop(key, None)
     return env
 
 

--- a/kart/tabular/version.py
+++ b/kart/tabular/version.py
@@ -2,7 +2,12 @@ import itertools
 import json
 
 from kart.core import walk_tree
-from kart.exceptions import UNSUPPORTED_VERSION, InvalidOperation
+from kart.exceptions import (
+    UNSUPPORTED_VERSION,
+    NO_REPOSITORY,
+    InvalidOperation,
+    NotFound,
+)
 
 # Kart repos have a repo-wide marker - either in the .kart/config file or in a blob in the ODB -
 # that stores which version all of the table-datasets are, if they are V2 or V3.
@@ -132,5 +137,9 @@ def _distinguish_v0_v1(tree):
             return 0
         elif dir_name == ".sno-table":
             return 1
-    # Maybe this isn't even a Kart repo?
-    return 1
+    # No evidence that this is a Kart repo, but, it's possible if you mess with Kart repo internals that you could
+    # get here by corrupting your HEAD commit - so the message provide a tiny bit of context to help diagnose:
+    raise NotFound(
+        "Current directory is not a Kart repository (no Kart datasets found at HEAD commit)",
+        exit_code=NO_REPOSITORY,
+    )


### PR DESCRIPTION
If a repo has a .kart folder but no kart.repostructure.version marker, and no datasets, it is incorerectly identified as a V1 repo.

## Related links:

https://github.com/koordinates/kart/issues/918

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
