### PR TITLE
Fetch tiles from S3, not just from the remote

### DIFF
--- a/kart/byod/importer.py
+++ b/kart/byod/importer.py
@@ -77,7 +77,11 @@ class ByodTileImporter:
                 write_blob_to_stream(stream, blob_path, pointer_data)
                 if "pamOid" in tile_info:
                     pam_data = dict_to_pointer_file_bytes(
-                        {"oid": tile_info["pamOid"], "size": tile_info["pamSize"]}
+                        {
+                            "url": tile_info["pamUrl"],
+                            "oid": tile_info["pamOid"],
+                            "size": tile_info["pamSize"],
+                        }
                     )
                     write_blob_to_stream(stream, blob_path + PAM_SUFFIX, pam_data)
                 p.update(1)

--- a/kart/byod/point_cloud_import.py
+++ b/kart/byod/point_cloud_import.py
@@ -129,6 +129,5 @@ class ByodPointCloudImporter(ByodTileImporter, PointCloudImporter):
             tmp_downloaded_tile, oid_and_size=oid_and_size
         )
         tmp_downloaded_tile.unlink()
-        # TODO - format still not definite, we might not put the whole URL in here.
         result["tile"]["url"] = tile_location
         return result

--- a/kart/byod/raster_import.py
+++ b/kart/byod/raster_import.py
@@ -123,7 +123,4 @@ def byod_raster_import(
 class ByodRasterImporter(ByodTileImporter, RasterImporter):
     def extract_tile_metadata(self, tile_location):
         oid_and_size = get_hash_and_size_of_s3_object(tile_location)
-        result = extract_raster_tile_metadata(tile_location, oid_and_size=oid_and_size)
-        # TODO - format still not definite, we might not put the whole URL in here.
-        result["tile"]["url"] = tile_location
-        return result
+        return extract_raster_tile_metadata(tile_location, oid_and_size=oid_and_size)

--- a/kart/lfs_commands/__init__.py
+++ b/kart/lfs_commands/__init__.py
@@ -366,13 +366,14 @@ def _do_fetch_from_urls(repo, urls_and_lfs_oids, quiet=False):
             f"Invalid URL - only S3 URLs are currently supported for BYOD repos: {non_s3_url}"
         )
 
-    urls_and_paths = [
-        (url, get_local_path_from_lfs_hash(repo, lfs_oid))
+    urls_and_paths_and_oids = [
+        (url, get_local_path_from_lfs_hash(repo, lfs_oid), lfs_oid)
         for (url, lfs_oid) in urls_and_lfs_oids
     ]
-    for url, path in urls_and_paths:
-        path.parent.mkdir(parents=True, exist_ok=True)
-    fetch_multiple_from_s3(urls_and_paths, quiet=quiet)
+    path_parents = {path.parent for url, path, lfs_oid in urls_and_paths_and_oids}
+    for path_parent in path_parents:
+        path_parent.mkdir(parents=True, exist_ok=True)
+    fetch_multiple_from_s3(urls_and_paths_and_oids, quiet=quiet)
 
 
 def _do_fetch_from_remote(repo, pointer_file_and_lfs_oids, remote_name, quiet=False):

--- a/kart/lfs_util.py
+++ b/kart/lfs_util.py
@@ -118,6 +118,7 @@ _TRANSIENT_KEYS = (
     # make sure we don't serialize them in the tile pointer file using the "pam" prefix.
     "pamName",
     "pamSourceName",
+    "pamUrl",
     "pamOid",
     "pamSize",
 )

--- a/kart/point_cloud/metadata_util.py
+++ b/kart/point_cloud/metadata_util.py
@@ -197,9 +197,11 @@ def extract_pc_tile_metadata(pc_tile_path, oid_and_size=None):
     else:
         oid, size = get_hash_and_size_of_file(pc_tile_path)
 
+    name = Path(pc_tile_path).name
+    url = str(pc_tile_path) if str(pc_tile_path).startswith("s3://") else None
     # Keep tile info keys in alphabetical order, except oid and size should be last.
     tile_info = {
-        "name": Path(pc_tile_path).name,
+        "name": name,
         # Reprojection seems to work best if we give it only the horizontal CRS here:
         "crs84Extent": _calc_crs84_extent(
             native_extent, horizontal_crs or compound_crs
@@ -207,9 +209,12 @@ def extract_pc_tile_metadata(pc_tile_path, oid_and_size=None):
         "format": get_format_summary(format_json),
         "nativeExtent": _format_list_as_str(native_extent),
         "pointCount": info["count"],
+        "url": url,
         "oid": f"sha256:{oid}",
         "size": size,
     }
+    if not url:
+        tile_info.pop("url", None)
 
     result = {
         "format.json": format_json,

--- a/kart/point_cloud/metadata_util.py
+++ b/kart/point_cloud/metadata_util.py
@@ -159,11 +159,16 @@ def extract_pc_tile_metadata(pc_tile_path, oid_and_size=None):
     same dataset to be homogenous enough that the meta items format.json, schema.json and crs.wkt
     describe *all* of the tiles in that dataset. The "tile" field is where we keep all information
     that can be different for every tile in the dataset, which is why it must be stored in pointer files.
+
+    pc_tile_path - a pathlib.Path or a string containing the path to a file or an S3 url.
+    oid_and_size - a tuple (sha256_oid, filesize) if already known, to avoid repeated work.
     """
+    pc_tile_path = str(pc_tile_path)
+
     pipeline = [
         {
             "type": "readers.las",
-            "filename": str(pc_tile_path),
+            "filename": pc_tile_path,
             "count": 0,  # Don't read any individual points.
         },
         {"type": "filters.info"},
@@ -198,7 +203,7 @@ def extract_pc_tile_metadata(pc_tile_path, oid_and_size=None):
         oid, size = get_hash_and_size_of_file(pc_tile_path)
 
     name = Path(pc_tile_path).name
-    url = str(pc_tile_path) if str(pc_tile_path).startswith("s3://") else None
+    url = pc_tile_path if pc_tile_path.startswith("s3://") else None
     # Keep tile info keys in alphabetical order, except oid and size should be last.
     tile_info = {
         "name": name,

--- a/kart/raster/metadata_util.py
+++ b/kart/raster/metadata_util.py
@@ -131,16 +131,21 @@ def extract_raster_tile_metadata(raster_tile_path, oid_and_size=None):
     same dataset to be homogenous enough that the meta items format.json, schema.json and crs.wkt
     describe *all* of the tiles in that dataset. The "tile" field is where we keep all information
     that can be different for every tile in the dataset, which is why it must be stored in pointer files.
+
+    pc_tile_path - a pathlib.Path or a string containing the path to a file or an S3 url.
+    oid_and_size - a tuple (sha256_oid, filesize) if already known, to avoid repeated work.
     """
     from osgeo import gdal
 
-    gdal_path_str = str(raster_tile_path)
-    if gdal_path_str.startswith("s3://"):
-        gdal_path_str = gdal_path_str.replace("s3://", "/vsis3/")
-    metadata = gdal.Info(gdal_path_str, options=["-json", "-norat", "-noct"])
+    raster_tile_path = str(raster_tile_path)
 
-    full_check = not gdal_path_str.startswith("/vsi")
-    warnings, errors, details = validate_cogtiff(gdal_path_str, full_check=full_check)
+    gdal_path_spec = raster_tile_path
+    if gdal_path_spec.startswith("s3://"):
+        gdal_path_spec = gdal_path_spec.replace("s3://", "/vsis3/")
+    metadata = gdal.Info(gdal_path_spec, options=["-json", "-norat", "-noct"])
+
+    full_check = not gdal_path_spec.startswith("/vsi")
+    warnings, errors, details = validate_cogtiff(gdal_path_spec, full_check=full_check)
     is_cog = not errors
 
     format_json = {
@@ -160,7 +165,7 @@ def extract_raster_tile_metadata(raster_tile_path, oid_and_size=None):
         oid, size = get_hash_and_size_of_file(raster_tile_path)
 
     name = Path(raster_tile_path).name
-    url = str(raster_tile_path) if str(raster_tile_path).startswith("s3://") else None
+    url = raster_tile_path if raster_tile_path.startswith("s3://") else None
     # Keep tile info keys in alphabetical order, except oid and size should be last.
     tile_info = {
         "name": name,
@@ -240,11 +245,12 @@ def gdalinfo_band_to_kart_columnschema(gdalinfo_band):
 
 
 def _find_and_add_pam_info(raster_tile_path, raster_tile_metadata):
+    raster_tile_path = str(raster_tile_path)
     tile_info = raster_tile_metadata["tile"]
 
-    if str(raster_tile_path).startswith("s3://"):
+    if raster_tile_path.startswith("s3://"):
         try:
-            pam_url = str(raster_tile_path) + PAM_SUFFIX
+            pam_url = raster_tile_path + PAM_SUFFIX
             pam_path = fetch_from_s3(pam_url)
             raster_tile_metadata.update(extract_aux_xml_metadata(pam_path))
             pam_oid, pam_size = get_hash_and_size_of_file(pam_path)

--- a/kart/s3_util.py
+++ b/kart/s3_util.py
@@ -173,7 +173,7 @@ def fetch_multiple_from_s3(s3_urls_and_paths, quiet=False):
     ) as executor:
         futures = [executor.submit(fetch_from_s3, *args) for args in s3_urls_and_paths]
         for future in concurrent.futures.as_completed(futures):
-            assert future.result() is not None
+            future.result()  # Raises any exception that occurred in the worker thread.
             p.update(1)
 
 

--- a/kart/s3_util.py
+++ b/kart/s3_util.py
@@ -1,4 +1,5 @@
 from base64 import standard_b64decode
+import concurrent.futures
 import logging
 import functools
 import os
@@ -11,6 +12,8 @@ import boto3
 import click
 
 from kart.exceptions import NotFound, NO_IMPORT_SOURCE, NO_CHECKSUM
+from kart.lfs_util import get_hash_and_size_of_file
+from kart.progress_util import progress_bar
 
 # Utility functions for dealing with S3 - not yet launched.
 
@@ -116,10 +119,12 @@ def parse_s3_url(s3_url):
     return bucket, key
 
 
-def fetch_from_s3(s3_url, output_path=None):
+def fetch_from_s3(s3_url, output_path=None, sha256_hash=None):
     """
     Downloads the object at s3_url to output_path.
     If output-path is not set, creates a temporary file using tempfile.mkstemp()
+    If sha_256 hash is set, verifies that the downloaded file has the expected hash -
+        if it does not, deletes the downloaded file and raises a ValueError.
     """
     # TODO: handle failure.
     bucket, key = parse_s3_url(s3_url)
@@ -129,7 +134,47 @@ def fetch_from_s3(s3_url, output_path=None):
         os.close(fd)
     output_path = Path(output_path).resolve()
     get_s3_bucket(bucket).download_file(key, str(output_path))
+
+    if sha256_hash:
+        actual_hash, size = get_hash_and_size_of_file(output_path)
+        if actual_hash != sha256_hash:
+            output_path.unlink()
+            raise ValueError(
+                f"Checksum verification failed on file downloaded from {s3_url}"
+            )
+
     return output_path
+
+
+# Fetching from S3 and writing to disk is I/O bound, so, we don't have a theoretical way of deciding how many threads to
+# use (if it was compute bound, then $NUM_CORES threads would be a good place to start).
+# But, in practise, 8 threads seems to be fast.
+_FETCH_MULTIPLE_FROM_S3_WORKER_COUNT = 8
+
+
+def fetch_multiple_from_s3(s3_urls_and_paths, quiet=False):
+    """
+    Given a list of tuples [(s3_url, pathlib_Path, sha256_hash), ...] downloads each URL to the given output path,
+    and verifies that the downloaded file has the appropriate hash, using _FETCH_MULTIPLE_FROM_S3_WORKER_COUNT worker threads.
+    The sha_256 is optional, it can be set to None or ommitted from the tuple entirely.
+
+    Displays a progress bar unless disabled using quiet=True.
+    """
+    disable = True if quiet else None
+    progress = progress_bar(
+        total=len(s3_urls_and_paths),
+        unit="object",
+        desc="Fetching S3 objects",
+        disable=disable,
+    )
+
+    with progress as p, concurrent.futures.ThreadPoolExecutor(
+        max_workers=_FETCH_MULTIPLE_FROM_S3_WORKER_COUNT
+    ) as executor:
+        futures = [executor.submit(fetch_from_s3, *args) for args in s3_urls_and_paths]
+        for future in concurrent.futures.as_completed(futures):
+            assert future.result() is not None
+            p.update(1)
 
 
 def expand_s3_glob(source_spec):

--- a/tests/point_cloud/test_workingcopy.py
+++ b/tests/point_cloud/test_workingcopy.py
@@ -1031,7 +1031,9 @@ def test_lfs_fetch(cli_runner, data_archive):
         r = cli_runner.invoke(["lfs+", "fetch", "HEAD", "--dry-run"])
         assert r.exit_code == 0, r.stderr
         assert r.stdout.splitlines() == [
-            "Running fetch with --dry-run: fetching 16 LFS blobs",
+            "Running fetch with --dry-run:",
+            "  Found 16 blobs to fetch from the remote",
+            "",
             "LFS blob OID:                                                    (Pointer file OID):",
             "0a696f35ab1404bbe9663e52774aaa800b0cf308ad2e5e5a9735d1c8e8b0a8c4 (7e8e0ec75c9c6b6654ebfc3b73f525a53f9db1de)",
             "0fd4dc03d2e9963658cf70e9d52fa1eaa7292da71d89d0188cfa88d5afb75ab6 (c395c80aed369e277b14a59f1b2381ed2e144da4)",
@@ -1061,7 +1063,7 @@ def test_lfs_gc(cli_runner, data_archive, monkeypatch):
         r = cli_runner.invoke(["lfs+", "gc", "--dry-run"])
         assert r.exit_code == 0, r.stderr
         assert r.stdout.splitlines() == [
-            "Running gc with --dry-run: deleting 0 LFS blobs (0B) from the cache"
+            "Running gc with --dry-run: found 0 LFS blobs (0B) to delete from the cache"
         ]
 
         r = cli_runner.invoke(["commit", "-m", "Delete auckland_3_*"])
@@ -1071,7 +1073,7 @@ def test_lfs_gc(cli_runner, data_archive, monkeypatch):
         assert r.exit_code == 0, r.stderr
         assert r.stdout.splitlines() == [
             "Can't delete 4 LFS blobs (82KiB) from the cache since they have not been pushed to the remote",
-            "Running gc with --dry-run: deleting 0 LFS blobs (0B) from the cache",
+            "Running gc with --dry-run: found 0 LFS blobs (0B) to delete from the cache",
         ]
 
         # Simulate pushing the latest commit to the remote (we don't actually have a remote set up):
@@ -1086,7 +1088,7 @@ def test_lfs_gc(cli_runner, data_archive, monkeypatch):
         r = cli_runner.invoke(["lfs+", "gc", "--dry-run"])
         assert r.exit_code == 0, r.stderr
         assert r.stdout.splitlines() == [
-            "Running gc with --dry-run: deleting 4 LFS blobs (82KiB) from the cache",
+            "Running gc with --dry-run: found 4 LFS blobs (82KiB) to delete from the cache",
             "0a696f35ab1404bbe9663e52774aaa800b0cf308ad2e5e5a9735d1c8e8b0a8c4",
             "0fd4dc03d2e9963658cf70e9d52fa1eaa7292da71d89d0188cfa88d5afb75ab6",
             "27411724d0de7c09913eb3d22b4f1d352afb8fa5b786403f59474e47c7492d9d",
@@ -1106,7 +1108,9 @@ def test_lfs_gc(cli_runner, data_archive, monkeypatch):
         r = cli_runner.invoke(["lfs+", "fetch", "HEAD^", "--dry-run"])
         assert r.exit_code == 0, r.stderr
         assert r.stdout.splitlines() == [
-            "Running fetch with --dry-run: fetching 4 LFS blobs",
+            "Running fetch with --dry-run:",
+            "  Found 4 blobs to fetch from the remote",
+            "",
             "LFS blob OID:                                                    (Pointer file OID):",
             "0a696f35ab1404bbe9663e52774aaa800b0cf308ad2e5e5a9735d1c8e8b0a8c4 (7e8e0ec75c9c6b6654ebfc3b73f525a53f9db1de)",
             "0fd4dc03d2e9963658cf70e9d52fa1eaa7292da71d89d0188cfa88d5afb75ab6 (c395c80aed369e277b14a59f1b2381ed2e144da4)",


### PR DESCRIPTION
## Description

A working copy checkout of a dataset backed by S3 will have to fetch from S3, not the remote - there may not even be a remote.
This adds code for fetching using S3, and adds to `kart lfs+ fetch` which is used internally to fetch missing tiles when needed for checkout.
Still TODO is to add more configuration for when a dataset should or should not be checked out, making it possible to work with datasets backed by S3 without checking them out.

## Related links:

https://github.com/koordinates/kart/issues/905

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
