### PR TITLE
Properly hide "hidden" commands from kart help

### DIFF
--- a/kart/cli.py
+++ b/kart/cli.py
@@ -296,7 +296,14 @@ def gc(ctx, args):
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def git(ctx, args):
     """
-    Run an arbitrary Git command, using kart's packaged Git
+    Kart-internal. Run an arbitrary Git command, using Kart's packaged Git.
+
+    Since Git does not understand all parts of a Kart repository (summarised, the object database is Git-compatible but
+    the working copy is not) this may not work as intended. The following guidelines apply:
+    - if the Git command is read-only (eg `git log`) and will not modify the repository, it can safely be attempted, but
+      may not have the expected output.
+    - if the Git command could modify the Kart repository, it is not safe to run as it could leave the repository
+      in an invalid state from which Kart may or may not be able to recover.
     """
     repo_params = []
     if ctx.obj.user_repo_path:

--- a/kart/meta.py
+++ b/kart/meta.py
@@ -215,7 +215,7 @@ def meta_set(ctx, message, amend, dataset, items):
     )
 
 
-@click.command("commit-files", hidden=True, cls=KartCommand)
+@click.command("commit-files", cls=KartCommand)
 @click.option(
     "--message",
     "-m",

--- a/kart/meta.py
+++ b/kart/meta.py
@@ -215,7 +215,7 @@ def meta_set(ctx, message, amend, dataset, items):
     )
 
 
-@click.command("commit-files", cls=KartCommand)
+@click.command("commit-files", hidden=True, cls=KartCommand)
 @click.option(
     "--message",
     "-m",

--- a/scripts/doc_gen.py
+++ b/scripts/doc_gen.py
@@ -39,6 +39,8 @@ def generate_help_pages(
 
     commands = getattr(cli, "commands", {})
     for name, command in commands.items():
+        if command.hidden:
+            continue
         generate_help_pages(
             name,
             input_dir,


### PR DESCRIPTION
Document more about why `kart git` is dangerous.
Unhide `kart commit-files` since it's a safer alternative to various things you'd need `kart git` for otherwise: amending commits and attaching files.

## Related links:

https://github.com/koordinates/kart/issues/917

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
