### PR TITLE
Improve existing --no-checkout flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## 0.14.3 (UNRELEASED)
 
+- Adds support for disabling the working-copy checkout of specific datasets using the commands `kart import DATASET --no-checkout` or `kart checkout --not-dataset=DATASET`, and re-enabling it using `kart checkout --dataset=DATASET`. [#926](https://github.com/koordinates/kart/pull/926)
 - Adds information on referencing and citing Kart to `CITATION`. [#914](https://github.com/koordinates/kart/pull/914)
 - Fixes a bug where Kart would misidentify a non-Kart repo as a Kart V1 repo in some circumstances. [#918](https://github.com/koordinates/kart/issues/918)
 

--- a/kart/byod/point_cloud_import.py
+++ b/kart/byod/point_cloud_import.py
@@ -25,7 +25,11 @@ L = logging.getLogger(__name__)
     "do_checkout",
     is_flag=True,
     default=True,
-    help="Whether to create a working copy once the import is finished, if no working copy exists yet.",
+    help=(
+        "Whether to check out the dataset once the import is finished. If false, the dataset will be configured as "
+        "not being checked out and will never be written to the working copy, until this decision is reversed by "
+        "running `kart checkout --dataset=DATASET-PATH`."
+    ),
 )
 @click.option(
     "--replace-existing",

--- a/kart/byod/raster_import.py
+++ b/kart/byod/raster_import.py
@@ -25,7 +25,11 @@ L = logging.getLogger(__name__)
     "do_checkout",
     is_flag=True,
     default=True,
-    help="Whether to create a working copy once the import is finished, if no working copy exists yet.",
+    help=(
+        "Whether to check out the dataset once the import is finished. If false, the dataset will be configured as "
+        "not being checked out and will never be written to the working copy, until this decision is reversed by "
+        "running `kart checkout --dataset=DATASET-PATH`."
+    ),
 )
 @click.option(
     "--replace-existing",

--- a/kart/import_.py
+++ b/kart/import_.py
@@ -51,7 +51,11 @@ def list_import_formats(ctx):
     "do_checkout",
     is_flag=True,
     default=True,
-    help="Whether to create a working copy once the import is finished, if no working copy exists yet.",
+    help=(
+        "Whether to check out the dataset once the import is finished. If false, the dataset will be configured as "
+        "not being checked out and will never be written to the working copy, until this decision is reversed by "
+        "running `kart checkout --dataset=DATASET-PATH`."
+    ),
 )
 @click.option(
     "--dataset-path", "--dataset", "ds_path", help="The dataset's path once imported"

--- a/kart/point_cloud/import_.py
+++ b/kart/point_cloud/import_.py
@@ -41,7 +41,11 @@ L = logging.getLogger(__name__)
     "do_checkout",
     is_flag=True,
     default=True,
-    help="Whether to create a working copy once the import is finished, if no working copy exists yet.",
+    help=(
+        "Whether to check out the dataset once the import is finished. If false, the dataset will be configured as "
+        "not being checked out and will never be written to the working copy, until this decision is reversed by "
+        "running `kart checkout --dataset=DATASET-PATH`."
+    ),
 )
 @click.option(
     "--replace-existing",

--- a/kart/raster/import_.py
+++ b/kart/raster/import_.py
@@ -41,7 +41,11 @@ L = logging.getLogger(__name__)
     "do_checkout",
     is_flag=True,
     default=True,
-    help="Whether to create a working copy once the import is finished, if no working copy exists yet.",
+    help=(
+        "Whether to check out the dataset once the import is finished. If false, the dataset will be configured as "
+        "not being checked out and will never be written to the working copy, until this decision is reversed by "
+        "running `kart checkout --dataset=DATASET-PATH`."
+    ),
 )
 @click.option(
     "--replace-existing",

--- a/kart/repo.py
+++ b/kart/repo.py
@@ -592,7 +592,11 @@ class KartRepo(pygit2.Repository):
         result = set()
         config = self.config
         for entry in config:
-            parts = entry.name.split(".")
+            parts = entry.name.split(".", maxsplit=3)
+            if len(parts) > 3:
+                # Handle a name-containing-dots ie "dataset.NAME.CONTAINING.DOTS.checkout"
+                prefix, rest = entry.name.split(".", maxsplit=1)
+                parts = [prefix, *rest.rsplit(".", maxsplit=1)]
             if (
                 len(parts) == 3
                 and parts[0] == "dataset"

--- a/kart/repo.py
+++ b/kart/repo.py
@@ -577,6 +577,31 @@ class KartRepo(pygit2.Repository):
 
         return SpatialFilter.from_repo_config(self)
 
+    def configure_do_checkout_datasets(self, dataset_paths, do_checkout):
+        for dataset_path in dataset_paths:
+            key = f"dataset.{dataset_path}.checkout"
+            if do_checkout:
+                # Checking out a dataset is the default, we don't clutter the config with it.
+                self.del_config(key)
+            else:
+                # Specifically mark this dataset as do-not-checkout.
+                self.config[key] = False
+
+    @property
+    def non_checkout_datasets(self):
+        result = set()
+        config = self.config
+        for entry in config:
+            parts = entry.name.split(".")
+            if (
+                len(parts) == 3
+                and parts[0] == "dataset"
+                and parts[2] == "checkout"
+                and not config.get_bool(entry.name)
+            ):
+                result.add(parts[1])
+        return result
+
     def get_config_str(self, key, default=None):
         return self.config[key] if key in self.config else default
 

--- a/kart/structure.py
+++ b/kart/structure.py
@@ -468,6 +468,9 @@ class Datasets:
         self.filter_dataset_type = filter_dataset_type
         self.force_dataset_class = force_dataset_class
 
+    def __contains__(self, ds_path):
+        return self.get(ds_path) is not None
+
     def __getitem__(self, ds_path):
         """Get a specific dataset by path."""
         result = self.get(ds_path)

--- a/kart/tabular/import_.py
+++ b/kart/tabular/import_.py
@@ -154,7 +154,11 @@ def any_at_all(iterable):
     "do_checkout",
     is_flag=True,
     default=True,
-    help="Whether to create a working copy once the import is finished, if no working copy exists yet.",
+    help=(
+        "Whether to check out the dataset once the import is finished. If false, the dataset will be configured as "
+        "not being checked out and will never be written to the working copy, until this decision is reversed by "
+        "running `kart checkout --dataset=DATASET-PATH`."
+    ),
 )
 @click.option(
     "--num-workers",
@@ -346,6 +350,7 @@ def table_import(
 
     # During imports we can keep old changes since they won't conflict with newly imported datasets.
     parts_to_create = [PartType.TABULAR] if do_checkout else []
+    repo.configure_do_checkout_datasets(new_ds_paths, do_checkout)
     repo.working_copy.reset_to_head(
         repo_key_filter=RepoKeyFilter.datasets(new_ds_paths),
         create_parts_if_missing=parts_to_create,

--- a/kart/tabular/working_copy/base.py
+++ b/kart/tabular/working_copy/base.py
@@ -500,7 +500,9 @@ class TableWorkingCopy(WorkingCopyPart):
             return DatasetDiff()
 
         feature_filter = ds_filter.get("feature", ds_filter.child_type())
-        with self.session():
+        with self.session() as sess:
+            if self._is_noncheckout_dataset(sess, dataset):
+                return DatasetDiff()
             meta_diff = self.diff_dataset_to_working_copy_meta(dataset, raise_if_dirty)
             feature_diff = self.diff_dataset_to_working_copy_feature(
                 dataset, feature_filter, meta_diff, raise_if_dirty
@@ -1181,12 +1183,12 @@ class TableWorkingCopy(WorkingCopyPart):
 
     def _do_reset_datasets(
         self,
+        *,
         base_datasets,
         target_datasets,
         ds_inserts,
         ds_updates,
         ds_deletes,
-        *,
         base_tree=None,
         target_tree=None,
         target_commit=None,

--- a/kart/tile/importer.py
+++ b/kart/tile/importer.py
@@ -333,6 +333,7 @@ class TileImporter:
             self.repo.references[fast_import_on_branch].delete()
 
         parts_to_create = [PartType.WORKDIR] if self.do_checkout else []
+        self.repo.configure_do_checkout_datasets([self.dataset_path], self.do_checkout)
         # During imports we can keep old changes since they won't conflict with newly imported datasets.
         self.repo.working_copy.reset_to_head(
             repo_key_filter=RepoKeyFilter.datasets([self.dataset_path]),

--- a/kart/tile/tile_dataset.py
+++ b/kart/tile/tile_dataset.py
@@ -395,6 +395,11 @@ class TileDataset(BaseDataset):
             The resulting diffs are missing almost all of the info about the new tiles,
             but this is faster and more reliable if this information is not needed.
         """
+        workdir = self.repo.working_copy.workdir
+        with workdir.state_session() as sess:
+            if workdir._is_noncheckout_dataset(sess, self.path):
+                return DatasetDiff()
+
         tile_filter = ds_filter.get("tile", ds_filter.child_type())
 
         current_metadata = self.tile_metadata
@@ -684,7 +689,6 @@ class TileDataset(BaseDataset):
         """
         with object_builder.chdir(self.inner_path):
             for delta in tile_diff.values():
-
                 if delta.type in ("insert", "update"):
                     new_val = delta.new_value
                     name = new_val.get("name")

--- a/kart/workdir.py
+++ b/kart/workdir.py
@@ -290,12 +290,12 @@ class FileSystemWorkingCopy(WorkingCopyPart):
 
     def _do_reset_datasets(
         self,
+        *,
         base_datasets,
         target_datasets,
         ds_inserts,
         ds_updates,
         ds_deletes,
-        *,
         base_tree=None,
         target_tree=None,
         target_commit=None,

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -18,7 +18,6 @@ H = pytest.helpers.helpers()
 )
 def test_checkout_branches(data_archive, cli_runner, chdir, tmp_path, working_copy):
     with data_archive("points") as remote_path:
-
         r = cli_runner.invoke(["checkout", "-b", "one"])
         assert r.exit_code == 0, r.stderr
         r = cli_runner.invoke(["checkout", "-b", "two", "HEAD^"])
@@ -47,7 +46,6 @@ def test_checkout_branches(data_archive, cli_runner, chdir, tmp_path, working_co
         head = CommitWithReference.resolve(repo, "HEAD")
 
         with chdir(tmp_path):
-
             r = cli_runner.invoke(["branch"])
             assert r.exit_code == 0, r.stderr
             assert r.stdout.splitlines() == ["* four"]
@@ -126,3 +124,50 @@ def test_reset(data_working_copy, cli_runner, edit_points):
         assert r.stdout.splitlines() == [
             f"{H.POINTS.HEAD1_SHA} (HEAD -> main) Import from nz-pa-points-topo-150k.gpkg",
         ]
+
+
+def _check_workingcopy_contains_tables(repo, expected_tables):
+    with repo.working_copy.tabular.session() as sess:
+        r = sess.execute("""SELECT name FROM sqlite_master SM WHERE type='table';""")
+        sqlite_table_names = set(row[0] for row in r)
+
+        census_tables = set(t for t in sqlite_table_names if t.startswith("census"))
+        assert census_tables == expected_tables
+
+        r = sess.execute("""SELECT table_name FROM gpkg_contents;""")
+        gpkg_contents_table_names = set(row[0] for row in r)
+        assert gpkg_contents_table_names == expected_tables
+
+
+def test_non_checkout_datasets(data_working_copy, cli_runner):
+    with data_working_copy("au-census") as (repo_path, wc):
+        repo = KartRepo(repo_path)
+        _check_workingcopy_contains_tables(
+            repo, {"census2016_sdhca_ot_sos_short", "census2016_sdhca_ot_ra_short"}
+        )
+
+        r = cli_runner.invoke(
+            ["checkout", "--not-dataset=census2016-sdhca-ot-sos-short"]
+        )
+        assert r.exit_code == 2
+        assert "No dataset census2016-sdhca-ot-sos-short" in r.stderr
+
+        r = cli_runner.invoke(
+            ["checkout", "--not-dataset=census2016_sdhca_ot_sos_short"]
+        )
+        assert r.exit_code == 0
+
+        _check_workingcopy_contains_tables(repo, {"census2016_sdhca_ot_ra_short"})
+
+        # No WC changes are returned.
+        r = cli_runner.invoke(["diff", "--exit-code"])
+        assert r.exit_code == 0
+
+        r = cli_runner.invoke(
+            ["checkout", "main", "--dataset=census2016_sdhca_ot_sos_short"]
+        )
+        assert r.exit_code == 0
+
+        _check_workingcopy_contains_tables(
+            repo, {"census2016_sdhca_ot_sos_short", "census2016_sdhca_ot_ra_short"}
+        )


### PR DESCRIPTION
kart import supports --no-checkout, but it merely postpones creating a working copy. As of this commit, it will add also add the dataset to a set of non-checkout datasets in the config, so the dataset will stay out of the WC indefinitely.

Also adds `kart checkout --dataset=foo --not-dataset=bar` flags to add and remove datasets from the set of non-checkout datasets

Still TODO: show what the current set of non-checkout datasets is in `kart status`

## Related links:

https://github.com/koordinates/kart/issues/905

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
