### PR TITLE
Apple Silicon Builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
   # Linux development build on modern Ubuntu
   #
   Linux-dev:
-    name: "Build Linux dev"
+    name: "Linux dev"
     runs-on: ubuntu-22.04
 
     # We want to run on external PRs, but not on our own internal PRs as they'll be run
@@ -229,7 +229,7 @@ jobs:
             arch: arm64
             arch_triplet: arm64-linux
 
-    name: Build Linux package ${{ matrix.os.arch }}
+    name: Linux ${{ matrix.os.arch }}
     runs-on: ${{ matrix.os.base }}
 
     # We want to run on external PRs, but not on our own internal PRs as they'll be run
@@ -598,7 +598,7 @@ jobs:
   # Linux development build using vendor archive & host python
   #
   Linux-dev-vendor:
-    name: "Build Linux dev+vendor"
+    name: "Linux dev+vendor"
     needs: ["Linux-Package"]
     runs-on: ubuntu-22.04
 
@@ -723,8 +723,8 @@ jobs:
           - id: macos-12
             label: "12/x86_64"
             arch_triplet: x64-osx
-          - id: macos-13-xlarge
-            label: "13/arm64"
+          - id: "ghcr.io/cirruslabs/macos-monterey-xcode:14"
+            label: "12/arm64"
             arch_triplet: arm64-osx
     runs-on: ${{ matrix.os.id }}
     name: macOS ${{ matrix.os.label }}
@@ -780,6 +780,9 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '^1.21.1'
+
+      - name: "setup: rust"
+        uses: dtolnay/rust-toolchain@stable
 
       - name: "setup: homebrew cache"
         id: cache-brew
@@ -883,7 +886,7 @@ jobs:
           cd apfs-clone-checker
           gcc clone_checker.c -o clone_checker
           chmod +x clone_checker
-          mv clone_checker /usr/local/bin/
+          sudo mv clone_checker /usr/local/bin/
 
       - name: "test: unit tests"
         uses: lukka/run-cmake@v10

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -719,7 +719,13 @@ jobs:
   macOS:
     strategy:
       matrix:
-        os: [{id: macos-12, label: "12/x86_64"}]
+        os:
+          - id: macos-12
+            label: "12/x86_64"
+            arch_triplet: x64-osx
+          - id: macos-13-xlarge
+            label: "13/arm64"
+            arch_triplet: arm64-osx
     runs-on: ${{ matrix.os.id }}
     name: macOS ${{ matrix.os.label }}
 
@@ -735,6 +741,7 @@ jobs:
     env:
       CCACHE_DIR: ${{ github.workspace }}/.cache/ccache
       CCACHE_COMPRESS: "1"
+      ARCH_TRIPLET: ${{ matrix.os.arch_triplet }}
       HOMEBREW_CACHE: ${{ github.workspace }}/.cache/brew
       HOMEBREW_NO_INSTALL_CLEANUP: "1"
       MACOS_CODESIGN_ID: ${{ secrets.MACOS_CODESIGN_ID }}
@@ -769,6 +776,11 @@ jobs:
           python -V --version
           echo /Library/Frameworks/Python.framework/Versions/${PY_VER}/bin >> $GITHUB_PATH
 
+      - name: "setup: golang"
+        uses: actions/setup-go@v4
+        with:
+          go-version: '^1.21.1'
+
       - name: "setup: homebrew cache"
         id: cache-brew
         uses: actions/cache@v3
@@ -790,17 +802,16 @@ jobs:
 
       - name: "setup: misc"
         run: |
-          brew install -q autoconf automake ccache pandoc pkg-config
+          brew install -q autoconf automake ccache pandoc pkg-config libtool
           mkdir -p ${{ env.CCACHE_DIR }}
           echo "$(brew --prefix)/opt/ccache/libexec" >> $GITHUB_PATH
 
       - name: "setup: vcpkg"
-        uses: lukka/run-vcpkg@v10
+        uses: lukka/run-vcpkg@v11
         with:
           vcpkgDirectory: "${{ github.workspace }}/vcpkg-vendor/vcpkg"
           vcpkgJsonGlob: "**/vcpkg-vendor/vcpkg.json"
-          prependedCacheKey: "20221110a"
-          appendedCacheKey: "C${{ env.CMAKE_VERSION}}:${{ hashFiles('vcpkg-vendor/vcpkg-overlay-triplets/**', 'vcpkg-vendor/vcpkg-overlay-ports/**', 'vcpkg-vendor/vcpkg-toolchain-setup.cmake') }}"
+          doNotCache: false  # do-cache
 
       #
       # App Build
@@ -844,11 +855,6 @@ jobs:
         uses: lukka/run-cmake@v10
         with:
           configurePreset: ci-macos
-
-      - name: "check for vcpkg errors"
-        if: failure() || cancelled()
-        run: |
-          echo "RUNVCPKG_NO_CACHE=1" >> $GITHUB_ENV
 
       - name: "app: build"
         uses: lukka/run-cmake@v10
@@ -959,7 +965,7 @@ jobs:
           sudo installer -pkg build/dist/Kart-*.pkg -dumplog -target /
           readlink $(which kart)
           # make sure good sqlite is in path
-          export PATH="$(pwd)/build/vcpkg_installed/x64-osx/tools:$PATH"
+          export PATH="$(pwd)/build/vcpkg_installed/${{ env.ARCH_TRIPLET }}/tools:$PATH"
           tests/scripts/e2e-1.sh
 
       - name: "release"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## 0.14.3 (UNRELEASED)
 
+- Native Apple Silicon builds are now available for macOS 12 and newer. [#927](https://github.com/koordinates/kart/pull/927)
 - Adds support for disabling the working-copy checkout of specific datasets using the commands `kart import DATASET --no-checkout` or `kart checkout --not-dataset=DATASET`, and re-enabling it using `kart checkout --dataset=DATASET`. [#926](https://github.com/koordinates/kart/pull/926)
 - Adds information on referencing and citing Kart to `CITATION`. [#914](https://github.com/koordinates/kart/pull/914)
 - Fixes a bug where Kart would misidentify a non-Kart repo as a Kart V1 repo in some circumstances. [#918](https://github.com/koordinates/kart/issues/918)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ $ apt-get install autoconf build-essential curl git golang libtool patchelf pyth
 ```
 On macOS (with [Homebrew](https://brew.sh)):
 ```console
-brew install automake autoconf cmake git python go ninja rust pandoc
+brew install automake autoconf cmake git python go ninja rust pandoc pkg-config libtool
 ```
 Clone Kart from Github:
 ```console
@@ -49,7 +49,7 @@ When using CI artifacts to build this is not just recommended, but required.
 
 Then configure Kart:
 ```console
-$ cmake -B build -S . -DPython3_EXECUTABLE=/path/to/python310 -DUSE_VCPKG=ON
+$ cmake -B build -S . -DPython3_EXECUTABLE=/path/to/python3.10 -DUSE_VCPKG=ON
 ```
 
 Configuration builds all the dependencies using [VCPKG](https://github.com/microsoft/vcpkg)
@@ -83,12 +83,12 @@ To do this, take the following steps:
 1. Select a commit - ideally the commit that you have checked out locally, but if you don't see it, just choosing the top one will generally work.
 1. Click through the commit and scroll down to the bottom to see the artifacts.\
 (Scrolling down is best achieved with your mouse curson on the left side of the page - see this [GitHub ticket](https://github.com/community/community/discussions/18035))
-1. Download the vendor-archive artifact for your platform.
+1. Download the vendor-archive artifact for your platform and CPU architecture.
 
 Then:
 
 ```console
-$ cmake -B build -S . -DPython3_EXECUTABLE=/path/to/python310 -DVENDOR_ARCHIVE=/path/to/downloaded/vendor-macos-X64-py3.10.zip -DUSE_VCPKG=OFF
+$ cmake -B build -S . -DPython3_EXECUTABLE=/path/to/python3.10 -DVENDOR_ARCHIVE=/path/to/downloaded/vendor-{os}-{arch}-py3.10.zip -DUSE_VCPKG=OFF
 $ cmake --build build
 $ build/kart --version
 ```
@@ -178,8 +178,6 @@ $ .\build\venv\Scripts\pytest.exe -v
 ## CI
 
 Continuous integration builds apps, tests, and installers for every commit on supported platforms. Artifacts are published to Github Actions, including vendor library bundles, test results, and unsigned installers.
-
-To only run CI for a particular platform (ie. when debugging CI), add `[ci only posix]` (for macOS + Linux) or `[ci only windows]` to commit messages.
 
 ## Code formatting
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -30,7 +30,7 @@ docutils==0.17.1
     #   rst2txt
 #gdal==3.6.3
     # via -r vendor-wheels.txt
-greenlet==2.0.1
+greenlet==2.0.1 ; os_name != "posix"
     # via sqlalchemy
 jmespath==1.0.1
     # via


### PR DESCRIPTION
## Description

Add Apple Silicon (arm64) macOS builds to CI.

Uses [Cirrus Runners](https://tart.run/integrations/github-actions/). The base macOS images are from https://github.com/cirruslabs/macos-image-templates. Is setup to build on Monterey (macOS 12) for maximum compatibility. 

* bc6e237 shows how to configure it for [Github's M1 runners](https://github.blog/changelog/2023-10-02-github-actions-apple-silicon-m1-macos-runners-are-now-available-in-public-beta/) and the next commit shows additional changes for the Cirrus runners.

## Related links:

* Homebrew formula changes for next release: https://github.com/koordinates/homebrew-kart/pull/2

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
