### PR TITLE
Fix `kart lfs+ gc` to work with BYOD datasets

### DIFF
--- a/tests/byod/test_imports.py
+++ b/tests/byod/test_imports.py
@@ -127,6 +127,21 @@ def test_byod_point_cloud_import(
             "  Found nothing to fetch",
         ]
 
+        r = cli_runner.invoke(["lfs+", "gc", "--dry-run"])
+        assert r.exit_code == 0, r.stderr
+        assert r.stdout.splitlines() == [
+            "Running gc with --dry-run: found 0 LFS blobs (0B) to delete from the cache"
+        ]
+
+        r = cli_runner.invoke(["checkout", "--not-dataset=auckland"])
+        assert r.exit_code == 0, r.stderr
+
+        r = cli_runner.invoke(["lfs+", "gc"])
+        assert r.stdout.splitlines() == [
+            "Deleting 16 LFS blobs (373KiB) from the cache..."
+        ]
+        check_lfs_hashes(repo, expected_file_count=0)
+
 
 @pytest.mark.slow
 def test_byod_raster_import(

--- a/tests/point_cloud/test_workingcopy.py
+++ b/tests/point_cloud/test_workingcopy.py
@@ -1142,7 +1142,7 @@ def test_lfs_gc(cli_runner, data_archive, monkeypatch):
         r = cli_runner.invoke(["lfs+", "gc", "--dry-run"])
         assert r.exit_code == 0, r.stderr
         assert r.stdout.splitlines() == [
-            "Can't delete 4 LFS blobs (82KiB) from the cache since they have not been pushed to the remote",
+            "Can't delete 4 LFS blobs (82KiB) from the cache since they have not been pushed to a remote",
             "Running gc with --dry-run: found 0 LFS blobs (0B) to delete from the cache",
         ]
 


### PR DESCRIPTION
## Description

LFS tiles can be gc'd even if they are not pushed to a remote -
- as long as they have a URL (so can be refetched from the URL)
- and, as long as they are not being used (includes not checked out due to `kart checkout --not-dataset`

## Related links:

https://github.com/koordinates/kart/issues/905

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
