### PR TITLE
Don't push blobs with URLs to the remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Adds information on referencing and citing Kart to `CITATION`. [#914](https://github.com/koordinates/kart/pull/914)
 - Fixes a bug where Kart would misidentify a non-Kart repo as a Kart V1 repo in some circumstances. [#918](https://github.com/koordinates/kart/issues/918)
 - Improve schema extraction for point cloud datasets. [#924](https://github.com/koordinates/kart/issues/924)
+- Some tweaks to `--dry-run` output of Kart LFS commands. [#932](https://github.com/koordinates/kart/pull/932)
 
 ## 0.14.2
 

--- a/tests/point_cloud/test_imports.py
+++ b/tests/point_cloud/test_imports.py
@@ -174,7 +174,7 @@ def test_import_single_las__convert(
             )
             assert (
                 stdout.splitlines()[0]
-                == "Running pre-push with --dry-run: pushing 1 LFS blobs"
+                == "Running pre-push with --dry-run: found 1 LFS blob (3.5KiB) to push"
             )
 
             assert (repo_path / "autzen" / "autzen.copc.laz").is_file()
@@ -316,7 +316,7 @@ def test_import_several_laz__convert(
             )
             assert (
                 stdout.splitlines()[0]
-                == "Running pre-push with --dry-run: pushing 16 LFS blobs"
+                == "Running pre-push with --dry-run: found 16 LFS blobs (410KiB) to push"
             )
 
             for x in range(4):

--- a/tests/point_cloud/test_workingcopy.py
+++ b/tests/point_cloud/test_workingcopy.py
@@ -1102,7 +1102,7 @@ def test_lfs_fetch(cli_runner, data_archive):
         assert r.exit_code == 0, r.stderr
         assert r.stdout.splitlines() == [
             "Running fetch with --dry-run:",
-            "  Found 16 blobs to fetch from the remote",
+            "  Found 16 LFS blobs (410KiB) to fetch from the remote",
             "",
             "LFS blob OID:                                                    (Pointer file OID):",
             "0a696f35ab1404bbe9663e52774aaa800b0cf308ad2e5e5a9735d1c8e8b0a8c4 (7e8e0ec75c9c6b6654ebfc3b73f525a53f9db1de)",
@@ -1179,7 +1179,7 @@ def test_lfs_gc(cli_runner, data_archive, monkeypatch):
         assert r.exit_code == 0, r.stderr
         assert r.stdout.splitlines() == [
             "Running fetch with --dry-run:",
-            "  Found 4 blobs to fetch from the remote",
+            "  Found 4 LFS blobs (82KiB) to fetch from the remote",
             "",
             "LFS blob OID:                                                    (Pointer file OID):",
             "0a696f35ab1404bbe9663e52774aaa800b0cf308ad2e5e5a9735d1c8e8b0a8c4 (7e8e0ec75c9c6b6654ebfc3b73f525a53f9db1de)",


### PR DESCRIPTION
Also makes lfs command output more standardized across the various commands,
ie, always use "found x LFS blobs (y KiB)"

https://github.com/koordinates/kart/issues/905

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
