### PR TITLE
Fix import-from-s3 for sidecar files.

### DIFF
--- a/kart/raster/import_.py
+++ b/kart/raster/import_.py
@@ -211,7 +211,9 @@ class RasterImporter(TileImporter):
 
     def sidecar_files(self, source):
         source = str(source)
-        if self.DATASET_CLASS.remove_tile_extension(source) == source:
+        if source.startswith("s3://"):
+            # Can't directly check if this S3 object exists, but here's where it should be:
+            yield source + PAM_SUFFIX, PAM_SUFFIX
             return
 
         pam_path = source + PAM_SUFFIX

--- a/kart/tile/importer.py
+++ b/kart/tile/importer.py
@@ -39,7 +39,7 @@ from kart.lfs_util import (
 )
 from kart.list_of_conflicts import ListOfConflicts
 from kart.meta_items import MetaItemFileType
-from kart.s3_util import expand_s3_glob, fetch_from_s3
+from kart.s3_util import expand_s3_glob, fetch_from_s3, get_error_code
 from kart.progress_util import progress_bar
 from kart.output_util import (
     format_json_for_output,
@@ -456,7 +456,11 @@ class TileImporter:
                         local_path.with_name(local_path.name + suffix),
                     )
                 except botocore.exceptions.ClientError as e:
-                    pass  # This kind of sidecar file doesn't exist for this tile. That's okay.
+                    if get_error_code(e) == 404:
+                        # Not having any particular type of sidecar for any particular tile is allowed.
+                        continue
+                    else:
+                        raise e
         else:
             local_path = None
             tile_path = source


### PR DESCRIPTION
Fix `kart import s3://bucket/path-to-tile.tif` so that it finds any PAM (.aux.xml files) that may exist for the source TIFFs.
Adds raster tests, with a focus on importing rasters with a PAM file (the rest of the import flow is basically identical to point-cloud so testing the PAM file is most important).

## Related links:

https://github.com/koordinates/kart/issues/905

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
