### PR TITLE
contrib: add experimental/proof of concept OGR drivers

### DIFF
--- a/contrib/gdal/README.md
+++ b/contrib/gdal/README.md
@@ -1,0 +1,97 @@
+GDAL/OGR Plugins
+================
+
+Experimental [GDAL/OGR](https://gdal.org) plugin drivers for Kart repositories. These are mostly to provide a proof of concept for discussion and to support future feature development in Kart.
+
+They are implemented using the [OGR Python Drivers](https://gdal.org/development/rfc/rfc76_ogrpythondrivers.html#rfc-76-ogr-python-drivers) mechanism in GDAL which is fairly rough & inefficient. It also means the drivers are read-only.
+
+> **ℹ️** These plugins require GDAL v3.8.0 or newer.
+
+CLI
+---
+
+The CLI plugin calls Kart CLI commands to find and expose features/layers, and diffs between revisions. Since Kart _uses_ GDAL this provides a relatively clean process boundary, similar to how VSCode, Github Desktop, and other IDEs interact with Git — and how it's used server-side for many forge operations at the likes of Github & Gitlab.
+
+As long as the interprocess communication is efficient using this mechanism should be a relatively smooth path to implement a fully-featured GDAL/OGR driver in the future.
+
+### Usage
+
+```console
+# Tell GDAL where to find the Kart driver
+$ export GDAL_PYTHON_DRIVER_PATH=/path/to/kart/contrib/gdal/cli
+
+# KART should appear at the bottom of the list
+$ ogrinfo --formats
+
+# list datasets
+$ ogrinfo /path/to/kart/repo
+
+# list information about a dataset
+$ ogrinfo -so -al /path/to/kart/repo mydataset
+
+# convert the dataset to another OGR format
+$ ogr2ogr -f SHP mydataset.shp /path/to/kart/repo mydataset
+```
+
+You can pass the dataset open option `GEOMTYPE=MULTILINESTRING`/etc to override the layer geometry type for operations that require a single geometry type: Kart datasets can support generic geometry types.
+
+> **ℹ️** If you run into odd behaviour, set the environment variable `CPL_DEBUG=ON` and debug messages will be printed to stderr.
+
+> **ℹ️** If you get an error `ERROR 1: Cannot find python/libpython. You can set the PYTHONSO configuration option to point to the a python .so/.dll/.dylib` then you need to set the `PYTHONSO` environment variable:
+> ```console
+> # Linux: find path to the appropriate libpython3.*.so
+> $ export PYTHONSO=$(python3 -c 'from sysconfig import get_config_var; print("%s/%s" % (get_config_var("LIBDIR"), get_config_var("INSTSONAME")))')
+>
+> # macOS: the interpreter works as libpython
+> $ export PYTHONSO=$(command -v python3)
+> ```
+
+### Referring to specific revisions
+
+You can use the `/path/to/repo@COMMITISH` syntax, where commitish is one of the options from [Revision Selection](https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#_revision_selection). By default the commit used is the `HEAD` of the current branch (or the default branch for a bare repository).
+
+* `/path/to/repo@main` tip of the `main` branch
+* `/path/to/repo@v1.2` the `v1.2` tag
+* `/path/to/repo@c0ffeebde6b7a4f2e39bd23ffb6b70637b5b3db8` a full commit hash
+* `/path/to/repo@c0ffee` an abbreviated commit hash
+* `/path/to/repo@main~3` the 3rd ancestor of main
+
+### Changesets as OGR layers
+
+You can use the `/path/to/repo@RANGE` syntax, where range is a double-dot or triple-dot [commit range](https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#_commit_ranges):
+
+* `/path/to/repo@main..new` Changes in the `new` branch that aren't in `main`.
+* `/path/to/repo@new..main` Changes in the `main` branch that aren't in `new`.
+* `/path/to/repo@main...new` Changes that occurred on either branch since when the branches diverged.
+* `/path/to/repo@HEAD^..HEAD` Changes between the previous and current commit.
+
+You can use any commitish on either side of the range to refer to a commit. If ommitted, a commitish defaults to the `HEAD` of the current branch (or the default branch for a bare repository).
+
+
+In-Process
+----------
+
+The in-process plugin uses Kart internal Python APIs to find and expose features/layers. Since Kart uses GDAL and GDAL is calling Kart, you can only use the GDAL library, tools, and associated drivers bundled with Kart.
+
+### Usage
+
+This currently only works from a local build tree in `/path/to/kart/build/`. See [CONTRIBUTING](../../CONTRIBUTING.md) for details. GDAL v3.8.0 isn't currently built with Kart currently, so this will require some changes in `vcpkg-vendor/` to make it work.
+
+```console
+# Configure paths
+$ source /path/to/kart/contrib/gdal/in_process/devenv.sh
+
+# KART should appear at the bottom of the list
+$ ogrinfo --formats
+
+# list datasets
+$ ogrinfo /path/to/kart/repo
+
+# list information about a dataset
+$ ogrinfo -so -al /path/to/kart/repo mydataset
+
+# convert the dataset to another OGR format
+$ ogr2ogr -f SHP mydataset.shp /path/to/kart/repo mydataset
+```
+
+Changesets as OGR layers aren't available for the in-process plugin, though the same approach as in the CLI plugin is possible to implement.

--- a/contrib/gdal/README.md
+++ b/contrib/gdal/README.md
@@ -75,7 +75,8 @@ The in-process plugin uses Kart internal Python APIs to find and expose features
 
 ### Usage
 
-This currently only works from a local build tree in `/path/to/kart/build/`. See [CONTRIBUTING](../../CONTRIBUTING.md) for details. GDAL v3.8.0 isn't currently built with Kart currently, so this will require some changes in `vcpkg-vendor/` to make it work.
+This currently only works from a local build tree in `/path/to/kart/build/`. See [CONTRIBUTING](../../CONTRIBUTING.md) for details. GDAL v3.8.0 is built with Kart,
+but currently the `ogrinfo` and `ogr2ogr` GDAL tools are not - you will currently need to modify the build so that these tools are also bundled.
 
 ```console
 # Configure paths

--- a/contrib/gdal/cli/gdal_kart.py
+++ b/contrib/gdal/cli/gdal_kart.py
@@ -1,0 +1,636 @@
+#!/usr/bin/env python3
+
+###############################################################################
+#
+# Purpose:  Kart OGR driver
+# Author:   Robert Coup <robert.coup@koordinates.com>
+#
+###############################################################################
+# Copyright (c) Koordinates Limited
+# SPDX-License-Identifier: LGPL-2.1+
+###############################################################################
+
+# Metadata parsed by GDAL C++ code at driver pre-loading, starting with '# gdal: '
+# gdal: DRIVER_NAME = "KART"
+# gdal: DRIVER_SUPPORTED_API_VERSION = [1]
+# gdal: DRIVER_DCAP_VECTOR = "YES"
+# gdal: DRIVER_DMD_LONGNAME = "Kart version control repository"
+# gdal: DRIVER_DMD_OPENOPTIONLIST = "<OpenOptionList><Option name='GEOMTYPE' type='string' description='Geometry type override' /></OpenOptionList>"
+
+import json
+import re
+import shlex
+import subprocess
+import traceback
+from functools import wraps
+from pathlib import Path
+from typing import Tuple
+
+from osgeo import gdal, ogr
+
+from gdal_python_driver import BaseDataset, BaseDriver, BaseLayer
+
+
+OGR_DATATYPE_MAP = {
+    "boolean": ogr.OFTInteger,
+    "blob": ogr.OFTBinary,
+    "date": ogr.OFTDate,
+    "float": ogr.OFTReal,
+    "integer": ogr.OFTInteger64,
+    "interval": ogr.OFTInteger64,
+    "numeric": ogr.OFTString,
+    "text": ogr.OFTString,
+    "time": ogr.OFTTime,
+    "timestamp": ogr.OFTDateTime,
+}
+OGR_GEOMTYPE_MAP = {
+    "POINT": ogr.wkbPoint,
+    "LINESTRING": ogr.wkbLineString,
+    "POLYGON": ogr.wkbPolygon,
+    "MULTIPOINT": ogr.wkbMultiPoint,
+    "MULTILINESTRING": ogr.wkbMultiLineString,
+    "MULTIPOLYGON": ogr.wkbMultiPolygon,
+    "GEOMETRYCOLLECTION": ogr.wkbGeometryCollection,
+    "GEOMETRY": ogr.wkbUnknown,
+    # TODO? Z/M types
+}
+
+
+def invoke_kart(
+    cmd: list, stdout=subprocess.PIPE, check=True, as_json=False, **run_kwargs
+):
+    full_cmd = ["kart"] + list(map(str, cmd))
+    gdal.Debug("KART", f"$ {shlex.join(full_cmd)} {run_kwargs}")
+    try:
+        p = subprocess.run(
+            ["kart"] + cmd, check=check, stdout=stdout, encoding="utf-8", **run_kwargs
+        )
+    except subprocess.CalledProcessError as ex:
+        gdal.Error(f"KART $! {ex.returncode}\n{ex.stderr.decode('utf-8')}")
+        raise
+    except OSError as ex:
+        gdal.Error(f"KART $! {ex}")
+        raise
+    else:
+        if p.returncode == 0 and as_json:
+            return json.loads(p.stdout)
+
+    return p
+
+
+# decorator to wrap gdal api calls with debug output
+def gdal_api_wrapper(func):
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        try:
+            gdal.Debug("KART", f">{func.__name__}({args}, {kwargs})")
+            result = func(*args, **kwargs)
+        except Exception as ex:
+            gdal.Error(f"KART !{func.__name__}() {ex}\n{traceback.format_exc()}")
+            raise
+        else:
+            gdal.Debug("KART", f"<{func.__name__}() {result}")
+            return result
+
+    return wrapped
+
+
+class Layer(BaseLayer):
+    def __init__(self, name: str, dataset, options: dict):
+        self.dataset = dataset
+        self.name = name
+        self.options = options
+
+        self._ds_info = self._kart_get_dataset_info()
+        self._parse_schema()
+        self._feature_count = None
+
+        # self.iterator_honour_spatial_filter = self.dataset.is_spatial
+        # self.kart_spatial_filter = None
+
+    def _kart_get_dataset_info(self):
+        data = invoke_kart(
+            [
+                "-C",
+                self.dataset.repo_path,
+                "meta",
+                "get",
+                "--with-dataset-types",
+                "-o",
+                "json",
+                "--ref",
+                self.dataset.commit,
+                self.name,
+            ],
+            as_json=True,
+        )
+        return data[self.name]
+
+    def _kart_epsg(self, crs_id):
+        if not crs_id.startswith("EPSG:"):
+            raise NotImplementedError("Support for non-EPSG CRS")
+        return int(crs_id.split(":")[1])
+
+    def _parse_schema(self):
+        schema = self._ds_info["schema.json"]
+
+        fields = []
+        geom_fields = []
+        self.geom_columns = []
+        self.pk_column = None
+
+        for col_schema in schema:
+            if col_schema["dataType"] == "geometry":
+                override_geom_type = self.options.get("GEOMTYPE", None)
+                if override_geom_type:
+                    gdal.Debug(
+                        "KART",
+                        f"{self.name} overriding geometry type to {override_geom_type}",
+                    )
+                    ogr_type = OGR_GEOMTYPE_MAP[override_geom_type.upper()]
+                else:
+                    ogr_type = OGR_GEOMTYPE_MAP[col_schema["geometryType"]]
+
+                geom_fields.append(
+                    {
+                        "name": col_schema["name"],
+                        "type": ogr_type,
+                        "srs": col_schema["geometryCRS"],
+                    }
+                )
+                self.geom_columns.append(col_schema["name"])
+            else:
+                ogr_type = OGR_DATATYPE_MAP[col_schema["dataType"]]
+                fields.append({"name": col_schema["name"], "type": ogr_type})
+
+            if col_schema.get("primaryKeyIndex", -1) == 0:
+                self.pk_column = col_schema["name"]
+
+        # GDAL accesses these attributes
+        self.fid_name = self.pk_column
+        self.fields = fields
+        self.geometry_fields = geom_fields
+
+    @gdal_api_wrapper
+    def test_capability(self, cap):
+        if cap in (ogr.OLCStringsAsUTF8, ogr.OLCRandomRead):
+            return True
+        else:
+            return False
+
+    @gdal_api_wrapper
+    def feature_count(self, force_computation):
+        if force_computation or self._feature_count is None:
+            d = invoke_kart(
+                [
+                    "-C",
+                    self.dataset.repo_path,
+                    "diff",
+                    "-o",
+                    "json",
+                    "--only-feature-count=exact",
+                    "[EMPTY]",
+                    self.dataset.commit,
+                    "--",
+                    self.name,  # doesn't actually filter
+                ],
+                as_json=True,
+            )
+
+            self._feature_count = d[self.name]
+        return self._feature_count
+
+    def _as_ogr_feature(self, kart_diff_feature):
+        feature = kart_diff_feature["change"]["+"]
+
+        f = {
+            "type": "OGRFeature",
+            "fields": {},
+            "geometry_fields": {},
+        }
+
+        if self.pk_column:
+            f["id"] = feature[self.pk_column]
+
+        for col, value in feature.items():
+            if col in self.geom_columns:
+                if value:
+                    f["geometry_fields"][col] = bytes.fromhex(value)
+                else:
+                    f["geometry_fields"][col] = None
+            else:
+                f["fields"][col] = value
+
+        return f
+
+    @gdal_api_wrapper
+    def feature_by_id(self, fid):
+        fd = invoke_kart(
+            [
+                "-C",
+                self.dataset.repo_path,
+                "diff",
+                "-o",
+                "json",
+                "[EMPTY]",
+                self.dataset.commit,
+                "--",
+                f"{self.name}:{fid}",
+            ],
+            as_json=True,
+        )
+
+        f = fd["kart.diff/v1+hexwkb"].get(fid)
+        if f is None:
+            return None
+
+        return self._as_ogr_feature(f)
+
+    @gdal_api_wrapper
+    def __iter__(self):
+        cmd = [
+            "kart",
+            "-C",
+            self.dataset.repo_path,
+            "diff",
+            "-o",
+            "json-lines",
+            "[EMPTY]",
+            self.dataset.commit,
+            "--",
+            self.name,
+        ]
+        popen_params = {
+            "stdout": subprocess.PIPE,
+            "encoding": "utf-8",
+            "bufsize": 1,
+        }
+        gdal.Debug("KART", f"__iter__() $ {shlex.join(map(str, cmd))}")
+        try:
+            with subprocess.Popen(cmd, **popen_params) as p:
+                count = 0
+                for line in p.stdout:
+                    record = json.loads(line)
+                    if record["type"] == "version":
+                        # first row
+                        assert record["version"] == "kart.diff/v2"
+                        assert record["outputFormat"] == "JSONL+hexwkb"
+                    elif record["type"] == "feature":
+                        count += 1
+                        try:
+                            yield self._as_ogr_feature(record)
+                        except Exception as ex:
+                            gdal.Error(
+                                f"KART !__iter__() {ex}\n{traceback.format_exc()}"
+                            )
+                            raise
+            gdal.Debug("KART", f"__iter__() yielded {count} features")
+        except OSError as ex:
+            gdal.Error(f"KART !__iter__() {ex}")
+            raise
+
+    # @gdal_api_wrapper
+    # def spatial_filter_changed(self):
+    #     filter_wkt = self.spatial_filter
+    #     if filter_wkt is None:
+    #         self.kart_spatial_filter = None
+    #     else:
+    #         ogr_geom = ogr.CreateGeometryFromWkt(filter_wkt)
+    #         self.kart_spatial_filter = spatial_filter.SpatialFilter(self.geom_crs_id, ogr_geom)
+
+
+class DiffLayer(BaseLayer):
+    def __init__(self, name: str, dataset, options: dict):
+        self.dataset = dataset
+        self.name = name
+        self.options = options
+
+        self._schema = None
+        self._feature_count = None
+
+        self._schema = next(self._kart_diff_iter(schema=True))
+
+    def _kart_epsg(self, crs_id):
+        if not crs_id.startswith("EPSG:"):
+            raise NotImplementedError("Support for non-EPSG CRS")
+        return int(crs_id.split(":")[1])
+
+    def _parse_schema(self, schema):
+        fields = [
+            {"name": "__id__", "type": ogr.OFTString},
+            {"name": "__change__", "type": ogr.OFTString},
+        ]
+        geom_fields = []
+        self.geom_columns = []
+
+        for col_schema in schema:
+            if col_schema["dataType"] == "geometry":
+                override_geom_type = self.options.get("GEOMTYPE", None)
+                if override_geom_type:
+                    gdal.Debug(
+                        "KART",
+                        f"{self.name} overriding geometry type to {override_geom_type}",
+                    )
+                    ogr_type = OGR_GEOMTYPE_MAP[override_geom_type.upper()]
+                else:
+                    ogr_type = OGR_GEOMTYPE_MAP[col_schema["geometryType"]]
+
+                geom_fields.append(
+                    {
+                        "name": col_schema["name"],
+                        "type": ogr_type,
+                        "srs": col_schema["geometryCRS"],
+                    }
+                )
+                self.geom_columns.append(col_schema["name"])
+            else:
+                ogr_type = OGR_DATATYPE_MAP[col_schema["dataType"]]
+                fields.append({"name": col_schema["name"], "type": ogr_type})
+
+        # GDAL accesses these attributes
+        self.fid_name = "__id__"
+        self.fields = fields
+        self.geometry_fields = geom_fields
+
+        return schema
+
+    @gdal_api_wrapper
+    def test_capability(self, cap):
+        if cap in (ogr.OLCStringsAsUTF8, ogr.OLCRandomRead):
+            return True
+        else:
+            return False
+
+    @gdal_api_wrapper
+    def feature_count(self, force_computation):
+        if force_computation or self._feature_count is None:
+            d = invoke_kart(
+                [
+                    "-C",
+                    self.dataset.repo_path,
+                    "diff",
+                    "-o",
+                    "json",
+                    "--only-feature-count=exact",
+                    self.dataset.range,
+                    "--",
+                    self.name,  # doesn't actually filter
+                ],
+                as_json=True,
+            )
+
+            self._feature_count = d[self.name]
+        return self._feature_count
+
+    def _as_ogr_feature(self, kart_diff_feature, index=0):
+        change = kart_diff_feature["change"]
+
+        if "+" in change and "-" in change:
+            change_type = "UPDATE"
+            change_feature = change["+"]
+        elif "+" in change:
+            change_type = "INSERT"
+            change_feature = change["+"]
+        elif "-" in change:
+            change_type = "DELETE"
+            change_feature = change["-"]
+        else:
+            assert False, "Unknown change type"
+
+        pk = f"{self.name}.{index}"
+        f = {
+            "type": "OGRFeature",
+            "fields": {
+                "__change__": change_type,
+                "__id__": pk,
+            },
+            "geometry_fields": {},
+            "id": pk,
+        }
+
+        for col, value in change_feature.items():
+            if col in self.geom_columns:
+                if value:
+                    f["geometry_fields"][col] = bytes.fromhex(value)
+                else:
+                    f["geometry_fields"][col] = None
+            else:
+                f["fields"][col] = value
+
+        return f
+
+    @gdal_api_wrapper
+    def feature_by_id(self, fid):
+        fd = invoke_kart(
+            [
+                "-C",
+                self.dataset.repo_path,
+                "diff",
+                "-o",
+                "json",
+                self.dataset.range,
+                "--",
+                f"{self.name}:{fid}",
+            ],
+            as_json=True,
+        )
+
+        f = fd["kart.diff/v1+hexwkb"].get(fid)
+        if f is None:
+            return None
+
+        return self._as_ogr_feature(f)
+
+    @gdal_api_wrapper
+    def __iter__(self):
+        yield from self._kart_diff_iter()
+
+    def _kart_diff_iter(self, schema=False):
+        cmd = [
+            "kart",
+            "-C",
+            self.dataset.repo_path,
+            "diff",
+            "-o",
+            "json-lines",
+            self.dataset.range,
+            "--",
+            self.name,
+        ]
+        popen_params = {
+            "stdout": subprocess.PIPE,
+            "encoding": "utf-8",
+            "bufsize": 1,
+        }
+        gdal.Debug("KART", f"diff_iter $ {shlex.join(map(str, cmd))}")
+        try:
+            with subprocess.Popen(cmd, **popen_params) as p:
+                index = 0
+                for line in p.stdout:
+                    record = json.loads(line)
+                    if record["type"] == "version":
+                        # first row
+                        gdal.Debug("KART", "diff_iter: version")
+                        assert record["version"] == "kart.diff/v2"
+                        assert record["outputFormat"] == "JSONL+hexwkb"
+
+                    elif record["type"] == "metaInfo" and schema:
+                        gdal.Debug("KART", f"diff_iter: metaInfo: {record['key']}")
+                        p.terminate()
+                        if record["key"] == "schema.json":
+                            yield self._parse_schema(record["value"])
+                            raise StopIteration()
+
+                    elif record["type"] == "feature":
+                        if schema:
+                            raise ValueError("Expexcted metaInfo by now")
+                        assert self._schema is not None, "expected headers by now"
+
+                        try:
+                            yield self._as_ogr_feature(record, index)
+                        except Exception as ex:
+                            gdal.Error(
+                                f"KART !__iter__() {ex}\n{traceback.format_exc()}"
+                            )
+                            raise
+                        index += 1
+
+            gdal.Debug("KART", f"diff_iter yielded {index} features")
+        except OSError as ex:
+            gdal.Error(f"KART !diff_iter {ex}")
+            raise
+
+
+class Dataset(BaseDataset):
+    def __init__(self, repo_path, commit, ref, options):
+        self.repo_path = repo_path
+        self.commit = commit
+        self.ref = ref
+        self.options = options
+        self.layers = [
+            Layer(layer, self, options=options) for layer in self._kart_get_layers()
+        ]
+
+    def _kart_get_layers(self):
+        data = invoke_kart(
+            [
+                "-C",
+                self.repo_path,
+                "data",
+                "ls",
+                "--with-dataset-types",
+                "-o",
+                "json",
+                self.commit,
+            ],
+            as_json=True,
+        )
+        return [d["path"] for d in data["kart.data.ls/v2"] if d["type"] == "table"]
+
+
+class DiffDataset(BaseDataset):
+    def __init__(self, repo_path, range, options):
+        self.repo_path = repo_path
+        self.range = range
+        self.options = options
+        self.layers = [
+            DiffLayer(layer, self, options=options) for layer in self._kart_get_layers()
+        ]
+
+    def _kart_get_layers(self):
+        data = invoke_kart(
+            [
+                "-C",
+                self.repo_path,
+                "diff",
+                "--only-feature-count=veryfast",
+                "-o",
+                "json",
+                self.range,
+                "--",
+            ],
+            as_json=True,
+        )
+        return data.keys()
+
+
+class Driver(BaseDriver):
+    @gdal_api_wrapper
+    def identify(self, filename, first_bytes, open_flags, open_options={}):
+        if filename.startswith("KART:"):
+            filename = filename[5:]
+
+        file_path = Path(filename)
+        if file_path.is_dir():
+            return self._kart_validate(file_path)
+        return False
+
+    def _kart_validate(self, repo_path: Path) -> bool:
+        try:
+            p = invoke_kart(
+                ["-C", repo_path, "data", "ls", "--with-dataset-types", "-o", "json"],
+                check=False,
+            )
+        except subprocess.CalledProcessError as ex:
+            gdal.Error(f"KART Error checking path {repo_path}: {ex}")
+            return False
+        else:
+            if p.returncode == 0:
+                # Success!
+                return True
+            elif p.returncode == 41:
+                # Normal error for not-a-kart-repo
+                return False
+            else:
+                gdal.Error(
+                    f"KART Error checking path {repo_path} [{p.returncode}]: {p.stderr.decode('utf-8')}"
+                )
+                return False
+
+    @gdal_api_wrapper
+    def open(self, filename, first_bytes, open_flags, open_options={}):
+        if filename.startswith("KART:"):
+            filename = filename[5:]
+
+        parts = filename.split("@", 1)
+        file_path = Path(parts[0])
+
+        if not file_path.is_dir():
+            return None
+
+        try:
+            if not self._kart_validate(file_path):
+                return None
+        except Exception:
+            return None
+
+        refish = parts[1] if len(parts) == 2 else "HEAD"
+        if ".." in refish:
+            assert not re.search(r"\s", refish)
+            assert not refish.startswith("-")
+            return DiffDataset(file_path, refish, options=open_options)
+
+        else:
+            commit, ref = self._kart_resolve_refish(file_path, refish)
+            gdal.Debug("KART", f"Resolved {refish!r} to {commit}")
+            return Dataset(file_path, commit, ref, options=open_options)
+
+    def _kart_resolve_refish(
+        self, repo_path: Path, refish: str
+    ) -> Tuple[str, str | None]:
+        p = invoke_kart(
+            [
+                "-C",
+                repo_path,
+                "git",
+                "rev-parse",
+                "--verify",
+                "--end-of-options",
+                f"{refish}^{{commit}}",
+            ],
+            check=False,
+        )
+        if p.returncode == 0:
+            return p.stdout.strip(), refish
+        else:
+            raise ValueError(f"{refish} does not resolve to a commit")

--- a/contrib/gdal/in_process/devenv.sh
+++ b/contrib/gdal/in_process/devenv.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+# check we're running via `source /path/todevenv.sh`
+if ! (return 0 2>/dev/null); then
+    echo "This script must be sourced, not executed."
+    exit 1
+fi
+
+# find the path to the `python3` executable with respect to the location of this
+# script. We're in a build tree, so it's effectively ../../build/venv/bin/python3
+SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+BUILD_PATH="${SCRIPT_PATH}/../../../build"
+
+if [ "$(uname)" == "Darwin" ]; then
+    export PYTHONSO="${BUILD_PATH}/venv/bin/python3"
+elif [ "$(expr substr "$(uname -s)" 1 5)" == "Linux" ]; then
+    PYTHONSO=$("${BUILD_PATH}/venv/bin/python3" -c 'from sysconfig import get_config_var; print("%s/%s" % (get_config_var("LIBDIR"), get_config_var("INSTSONAME")))')
+    export PYTHONSO
+else
+    echo "Unsupported OS"
+    exit 1
+fi
+
+echo "PYTHONSO library: ${PYTHONSO}"
+TRIPLET=$(cmake -B build -L 2>/dev/null | grep VCPKG_TARGET_TRIPLET | awk -F= '{print $2}')
+echo "VCPKG triplet: ${TRIPLET}"
+
+export GDAL_PYTHON_DRIVER_PATH="${SCRIPT_PATH}"
+export CPL_DEBUG=ON
+
+# Add the Kart-vendored GDAL tools to the path
+export PATH="${BUILD_PATH}/vcpkg_installed/${TRIPLET}/tools/gdal/:$PATH"
+
+# Activate the virtualenv too
+source "${BUILD_PATH}/venv/bin/activate"

--- a/contrib/gdal/in_process/gdal_kart.py
+++ b/contrib/gdal/in_process/gdal_kart.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+
+###############################################################################
+#
+# Purpose:  Kart OGR driver
+# Author:   Robert Coup <robert.coup@koordinates.com>
+#
+###############################################################################
+# Copyright (c) Koordinates Limited
+# SPDX-License-Identifier: LGPL-2.1+
+###############################################################################
+
+# Metadata parsed by GDAL C++ code at driver pre-loading, starting with '# gdal: '
+# gdal: DRIVER_NAME = "KART"
+# gdal: DRIVER_SUPPORTED_API_VERSION = [1]
+# gdal: DRIVER_DCAP_VECTOR = "YES"
+# gdal: DRIVER_DMD_LONGNAME = "Kart"
+# gdal: DRIVER_DMD_OPENOPTIONLIST = "<OpenOptionList><Option name='GEOMTYPE' type='string' description='Geometry type override' /></OpenOptionList>"
+
+from functools import wraps
+import sys
+import traceback
+from pathlib import Path
+
+from kart.repo import KartRepo
+from kart import crs_util
+from kart import spatial_filter
+
+from osgeo import gdal, ogr
+
+from gdal_python_driver import BaseDataset, BaseDriver, BaseLayer
+
+
+OGR_DATATYPE_MAP = {
+    "boolean": ogr.OFTInteger,
+    "blob": ogr.OFTBinary,
+    "date": ogr.OFTDate,
+    "float": ogr.OFTReal,
+    "integer": ogr.OFTInteger64,
+    "interval": ogr.OFTInteger64,
+    "numeric": ogr.OFTString,
+    "text": ogr.OFTString,
+    "time": ogr.OFTTime,
+    "timestamp": ogr.OFTDateTime,
+}
+OGR_GEOMTYPE_MAP = {
+    "POINT": ogr.wkbPoint,
+    "LINESTRING": ogr.wkbLineString,
+    "POLYGON": ogr.wkbPolygon,
+    "MULTIPOINT": ogr.wkbMultiPoint,
+    "MULTILINESTRING": ogr.wkbMultiLineString,
+    "MULTIPOLYGON": ogr.wkbMultiPolygon,
+    "GEOMETRYCOLLECTION": ogr.wkbGeometryCollection,
+    "GEOMETRY": ogr.wkbUnknown,
+    # TODO? Z/M types
+}
+
+
+# decorator to wrap gdal api calls with debug output
+def gdal_api_wrapper(func):
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        try:
+            gdal.Debug("KART", f">{func.__name__}({args}, {kwargs})")
+            result = func(*args, **kwargs)
+        except Exception as ex:
+            gdal.Error(f"KART !{func.__name__}() {ex}\n{traceback.format_exc()}")
+            raise
+        else:
+            gdal.Debug("KART", f"<{func.__name__}() {result}")
+            return result
+
+    return wrapped
+
+
+class Layer(BaseLayer):
+    def __init__(self, dataset, options):
+        self.dataset = dataset
+        self.options = options
+
+        self.name = self.dataset.path
+        self._parse_schema()
+
+        self.iterator_honour_spatial_filter = self.dataset.is_spatial
+        self.kart_spatial_filter = None
+
+    def _parse_schema(self):
+        schema = self.dataset.schema
+
+        fields = []
+        geom_fields = []
+        self.geom_columns = []
+        for col_schema in schema:
+            if col_schema.data_type == "geometry":
+                override_geom_type = self.options.get("GEOMTYPE", None)
+                if override_geom_type:
+                    gdal.Debug(
+                        "KART",
+                        f"{self.name} overriding geometry type to {override_geom_type}",
+                    )
+                    ogr_type = OGR_GEOMTYPE_MAP[override_geom_type.upper()]
+                else:
+                    ogr_type = OGR_GEOMTYPE_MAP[col_schema["geometryType"]]
+
+                geom_fields.append(
+                    {
+                        "name": col_schema.name,
+                        "type": ogr_type,
+                        "srs": col_schema["geometryCRS"],
+                    }
+                )
+                self.geom_columns.append(col_schema.name)
+            else:
+                ogr_type = OGR_DATATYPE_MAP[col_schema.data_type]
+                fields.append({"name": col_schema.name, "type": ogr_type})
+
+        # TODO: handle multiple pk fields
+        self.pk_column = self.dataset.primary_key
+        if self.geom_columns:
+            self.geom_crs_id = crs_util.get_identifier_int_from_dataset(
+                self.dataset, schema.geometry_columns[0]["geometryCRS"]
+            )
+
+        # GDAL accesses these attributes
+        self.fid_name = self.pk_column
+        self.fields = fields
+        self.geometry_fields = geom_fields
+
+    @gdal_api_wrapper
+    def test_capability(self, cap):
+        if cap in (ogr.OLCStringsAsUTF8, ogr.OLCRandomRead):
+            return True
+        else:
+            return False
+
+    @gdal_api_wrapper
+    def feature_count(self, force_computation):
+        return self.dataset.feature_count
+
+    def _as_ogr_feature(self, kart_feature):
+        f = {
+            "type": "OGRFeature",
+            "fields": {},
+            "geometry_fields": {},
+        }
+
+        if self.pk_column:
+            f["id"] = kart_feature[self.pk_column]
+
+        for col, value in kart_feature.items():
+            if col in self.geom_columns:
+                if value:
+                    f["geometry_fields"][col] = value.to_wkb()
+                else:
+                    f["geometry_fields"][col] = None
+            else:
+                f["fields"][col] = value
+
+        return f
+
+    @gdal_api_wrapper
+    def feature_by_id(self, fid):
+        try:
+            f = self.dataset.get_feature_with_crs_id([fid])
+        except KeyError:
+            return None
+        else:
+            return self._as_ogr_feature(f)
+
+    @gdal_api_wrapper
+    def __iter__(self):
+        sf = self.kart_spatial_filter or spatial_filter.SpatialFilter.MATCH_ALL
+
+        for kart_feature in self.dataset.features_with_crs_ids(spatial_filter=sf):
+            try:
+                yield self._as_ogr_feature(kart_feature)
+            except Exception as ex:
+                gdal.Error(f"KART !__iter__() {ex}\n{traceback.format_exc()}")
+                raise
+
+    @gdal_api_wrapper
+    def spatial_filter_changed(self):
+        filter_wkt = self.spatial_filter
+        if filter_wkt is None:
+            self.kart_spatial_filter = None
+        else:
+            ogr_geom = ogr.CreateGeometryFromWkt(filter_wkt)
+            self.kart_spatial_filter = spatial_filter.SpatialFilter(
+                self.geom_crs_id, ogr_geom
+            )
+
+
+class Dataset(BaseDataset):
+    def __init__(self, repo, commit, ref, options):
+        self.repo = repo
+        self.commit = commit
+        self.ref = ref
+        self.layers = [
+            Layer(dataset, options=options)
+            for dataset in self.repo.datasets(
+                refish=commit, filter_dataset_type="table"
+            )
+        ]
+        self.options = options
+
+
+class Driver(BaseDriver):
+    @gdal_api_wrapper
+    def identify(self, filename, first_bytes, open_flags, open_options={}):
+        if filename.startswith("KART:"):
+            filename = filename[5:]
+
+        file_path = Path(filename)
+        if file_path.is_dir():
+            KartRepo(file_path, validate=True)
+            return True
+
+        return False
+
+    @gdal_api_wrapper
+    def open(self, filename, first_bytes, open_flags, open_options={}):
+        if filename.startswith("KART:"):
+            filename = filename[5:]
+
+        parts = filename.split("@", 1)
+        file_path = Path(parts[0])
+
+        if not file_path.is_dir():
+            return None
+
+        try:
+            repo = KartRepo(file_path, validate=True)
+        except Exception:
+            return None
+
+        if len(parts) == 2:
+            commit, ref = repo.resolve_refish(parts[1])
+        else:
+            commit, ref = repo.resolve_refish("HEAD")
+
+        return Dataset(repo, commit, ref, options=open_options)


### PR DESCRIPTION
Experimental [GDAL/OGR](https://gdal.org) plugin drivers for Kart repositories. These are mostly to provide a proof of concept for discussion and to support future feature development in Kart.

They are implemented using the [OGR Python Drivers](https://gdal.org/development/rfc/rfc76_ogrpythondrivers.html#rfc-76-ogr-python-drivers) mechanism in GDAL which is fairly rough & inefficient. It also means the drivers are read-only.

These plugins require GDAL v3.8.0 or newer. The `contrib/gdal/README.md` file contains usage information.

### CLI (`contrib/gdal/cli/`)

This plugin calls Kart CLI commands to find and expose features/layers, and diffs between revisions. Since Kart _uses_ GDAL this approach provides a safe and relatively clean process boundary. It's similar to how VSCode, Github Desktop, and other IDEs interact with Git — and how it's used server-side for many operations at the likes of Github & Gitlab. As long as the interprocess communication is efficient using this approach could be a relatively smooth path to implement a fully-featured C++ GDAL/OGR driver in the future.

### In-process (`contrib/gdal/in_process/`)

The in-process plugin uses Kart internal/private Python APIs to find and expose features/layers. Since Kart uses GDAL and GDAL is calling Kart, you can only use the GDAL library, tools, and associated drivers bundled with Kart. 

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
