### PR TITLE
checkout: Smoother progress bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Some tweaks to `--dry-run` output of Kart LFS commands. [#932](https://github.com/koordinates/kart/pull/932)
 - Now using Python 3.11 to build Kart, and vendored dependencies have been updated to newer versions. [#933](https://github.com/koordinates/kart/pull/933)
 - Adds support for importing point-cloud and raster tiles directly from an S3 URL. [#940](https://github.com/koordinates/kart/pull/940)
+- `checkout`: Smoother progressbar updates
 
 ## 0.14.2
 

--- a/kart/progress_util.py
+++ b/kart/progress_util.py
@@ -12,8 +12,9 @@ def progress_bar(*args, show_progress=None, disable=None, **kwargs):
     elif disable is None and os.environ.get("KART_SHOW_PROGRESS"):
         disable = False
 
+    kwargs = {"smoothing": 0.1, **kwargs}
+    tqdm_progress_bar = tqdm.tqdm(*args, disable=disable, **kwargs)
     try:
-        tqdm_progress_bar = tqdm.tqdm(*args, disable=disable, **kwargs)
         yield tqdm_progress_bar
     finally:
         tqdm_progress_bar.close()

--- a/kart/tabular/working_copy/base.py
+++ b/kart/tabular/working_copy/base.py
@@ -989,8 +989,7 @@ class TableWorkingCopy(WorkingCopyPart):
                 sql = self.insert_into_dataset_cmd(dataset)
                 t0 = time.monotonic()
 
-                CHUNK_SIZE = 10000
-
+                CHUNK_SIZE = 2000
                 for row_dicts in chunk(
                     dataset.features_with_crs_ids(
                         self.repo.spatial_filter, show_progress=True


### PR DESCRIPTION

## Description

* reduce chunk size of full working copy checkout iteration. This doesn't seem to have any noticeable effect on performance, and means the progress bar can update more smoothly
* Apply more smoothing to the progress (closer to average features/s) to paper over the apparent stalls from fetching 2000 features from the kart dataset every so often. This avoids the 'F/s' rate bouncing up and down several times a second - it stays more consistent now

```
# chunk size of 10000
nz_primary_land_parcels:  21%|█████████████▊                                                     | 489999/2375572 [00:32<02:05, 14996.98F/s]
```

```
# chunk size of 2000 - ~ same speed, less memory, smoother progress bar
nz_primary_land_parcels:  21%|██████████████                                                     | 498000/2375572 [00:33<02:04, 15022.69F/s]
```



## Related links:

<!-- If you have links to [issues](https://github.com/koordinates/kart/issues) etc, link them here. -->

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
