### PR TITLE
gdal: add support for WEBP & ZSTD compressed GeoTIFFs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Now using Python 3.11 to build Kart, and vendored dependencies have been updated to newer versions. [#933](https://github.com/koordinates/kart/pull/933)
 - Adds support for importing point-cloud and raster tiles directly from an S3 URL. [#940](https://github.com/koordinates/kart/pull/940)
 - `checkout`: Smoother progressbar updates
+- Add library support for WEBP & ZSTD compression with GeoTIFF raster datasets. [#951](https://github.com/koordinates/kart/pull/951)
 
 ## 0.14.2
 

--- a/vcpkg-vendor/vcpkg.json
+++ b/vcpkg-vendor/vcpkg.json
@@ -28,6 +28,13 @@
             "features": ["ssl", "http2"]
         },
         {
+            "name": "tiff",
+            "features": [
+                "webp",
+                "zstd"
+            ]
+        },
+        {
             "name": "proj",
             "features": [
                 "tools"
@@ -41,7 +48,10 @@
                 "tools",
                 "postgresql",
                 "geos",
-                "curl"
+                "curl",
+                "lzma",
+                "webp",
+                "zstd"
             ]
         },
         {


### PR DESCRIPTION
## Description

Support WEBP & ZSTD compression in GDAL/libtiff so you can import existing raster datasets using those compression methods. This doesn't implement any user-level changes wrt COG creation/etc.

- enable webp support in libtiff/gdal to support WebP COGs
- enable zstd support in libtiff/gdal to support ZSTD COGs
- enable lzma support in gdal (was already enabled for libtiff)

## Checklist:

- [x] Have you reviewed your own change?
- Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
