### PR TITLE
[WIP] point-clouds: generate virtual point cloud (.vpc)

### DIFF
--- a/kart/point_cloud/mosaic_util.py
+++ b/kart/point_cloud/mosaic_util.py
@@ -1,0 +1,38 @@
+import logging
+
+from tempfile import NamedTemporaryFile
+from kart.subprocess_util import check_output
+
+
+L = logging.getLogger("kart.point_cloud")
+
+
+def write_vpc_for_directory(directory_path):
+    """
+    Given a folder containing some LAZ/LAS files, write a mosaic file that
+    combines them all into a single Virtual Point Cloud (VPC). The VPC will
+    contain references to the tiles, rather than replicating their contents.
+    """
+    vrt_path = directory_path / f"{directory_path.name}.vpc"
+
+    tiles = [str(p) for p in directory_path.glob("*.copc.laz")]
+    if not tiles:
+        vrt_path.unlink(missing_ok=True)
+        return
+
+    with NamedTemporaryFile("w+t", suffix=".kart_tiles", encoding="utf-8") as tile_list:
+        tile_list.write("\n".join(tiles))
+        tile_list.flush()
+
+        try:
+            check_output(
+                [
+                    "pdal_wrench",
+                    "build_vpc",
+                    f"--output={vrt_path}",
+                    f"--input-file-list={tile_list.name}",
+                ]
+            )
+        except FileNotFoundError:
+            L.warning("pdal_wrench not found. Skipping VPC generation.")
+            return

--- a/kart/point_cloud/v1.py
+++ b/kart/point_cloud/v1.py
@@ -1,3 +1,7 @@
+import logging
+import os
+import time
+
 from kart.tile.tile_dataset import TileDataset
 from kart.list_of_conflicts import ListOfConflicts, InvalidNewValue
 from kart.point_cloud.metadata_util import (
@@ -14,6 +18,9 @@ from kart.point_cloud.tilename_util import (
     set_tile_extension,
     get_tile_path_pattern,
 )
+
+
+L = logging.getLogger("kart.point_cloud")
 
 
 class PointCloudV1(TileDataset):
@@ -66,8 +73,12 @@ class PointCloudV1(TileDataset):
 
     @classmethod
     def write_mosaic_for_directory(cls, directory_path):
-        # TODO: Not yet implemented
-        pass
+        from kart.point_cloud.mosaic_util import write_vpc_for_directory
+
+        if os.environ.get("KART_POINT_CLOUD_VPCS"):
+            t0 = time.time()
+            write_vpc_for_directory(directory_path)
+            L.info("Generated VPC in %ss", (time.time() - t0))
 
     def get_dirty_dataset_paths(self, workdir_diff_cache):
         # TODO - improve finding and handling of non-standard tile filenames.


### PR DESCRIPTION
Proof of concept generating a [Virtual Point Cloud (VPC)](https://www.lutraconsulting.co.uk/blog/2023/06/08/virtual-point-clouds/) file for datasets based on tiles present in the current working copy. The VPC can be opened in eg: QGIS rather than loading individual tiles, and works similarly to VRT files for rasters.

1. Currently uses `pdal_wrench` to generate the files, and we're not building/distributing that, needs to be in the PATH.
2. You also need to set `KART_POINT_CLOUD_VPCS=1`

Still need to decide either to bundle `pdal_wrench`, or write minimal VPC files ourselves.

## Related links:

* https://www.lutraconsulting.co.uk/blog/2023/06/08/virtual-point-clouds/
* https://github.com/PDAL/wrench/#virtual-point-clouds-vpc

## Checklist:

- [ ] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
