### PR TITLE
Fixes a bug where minor XML changes are not suppressed properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 - Prevented committing local changes to linked datasets. [#953](https://github.com/koordinates/kart/pull/953)
 - Fixes a bug where even datasets marked as `--no-checkout` are checked out when the working copy is first created. [#954](https://github.com/koordinates/kart/pull/954)
+- Fixes a bug where minor changes to auxiliary metadata (.aux.xml) files that Kart is supposed to ignore were preventing branch changes. [#957](https://github.com/koordinates/kart/pull/957)
 
 ## 0.15.0
 

--- a/kart/tile/tile_dataset.py
+++ b/kart/tile/tile_dataset.py
@@ -434,6 +434,12 @@ class TileDataset(BaseDataset):
                 new_half_delta = tilename, new_tile_summary
             else:
                 new_half_delta = tilename, {"sourceName": workdir_path.name}
+                expected_pam_path = workdir_path.with_name(
+                    workdir_path.name + PAM_SUFFIX
+                )
+                pams = find_similar_files_case_insensitive(expected_pam_path)
+                if len(pams) == 1:
+                    new_half_delta[1]["pamSourceName"] = pams[0].name
 
             if old_half_delta is None and new_half_delta is None:
                 # This can happen by eg editing a .tif.aux.xml file that's not attached to anything.

--- a/tests/raster/test_pam_util.py
+++ b/tests/raster/test_pam_util.py
@@ -149,6 +149,11 @@ def test_add_stats_to_new_pam(
         r = cli_runner.invoke(["diff", "--exit-code"])
         assert r.exit_code == 0
 
+        r = cli_runner.invoke(["reset", "--discard-changes"])
+        assert r.exit_code == 0
+
+        assert not pam_path.exists()
+
         # Real changes are not suppressed:
         pam_path.write_text("<whatever />")
 
@@ -168,6 +173,11 @@ def test_add_stats_to_new_pam(
 
         r = cli_runner.invoke(["diff", "--exit-code"])
         assert r.exit_code == 1
+
+        r = cli_runner.invoke(["reset", "--discard-changes"])
+        assert r.exit_code == 0
+
+        assert not pam_path.exists()
 
 
 def test_add_stats_to_existing_pam(


### PR DESCRIPTION
Statistics-only changes to PAM files are considered minor and do not show up in diffs - this is because various tools generate them as a side effect without the user actually trying to modify the working copy.

However, working-copy.is_dirty() checks are performed more efficiently than status or diff commands - they just search for a single dirty path and then do an early exit. The find-any-dirty-path logic did not (until now) properly suppress minor XML changes.

This resulted in a bug whereby `kart status` and `kart diff` showed no changes, but attempting to switch branch would not work due to a the is_dirty() check returning True.

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
