### PR TITLE
Faster diffs: Don't always run pygit2.Tree.diff_tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Prevented committing local changes to linked datasets. [#953](https://github.com/koordinates/kart/pull/953)
 - Fixes a bug where even datasets marked as `--no-checkout` are checked out when the working copy is first created. [#954](https://github.com/koordinates/kart/pull/954)
 - Fixes a bug where minor changes to auxiliary metadata (.aux.xml) files that Kart is supposed to ignore were preventing branch changes. [#957](https://github.com/koordinates/kart/pull/957)
+- Improved performance when the user filters a diff request to only show certain features. [#962](https://github.com/koordinates/kart/pull/962)
 
 ## 0.15.0
 

--- a/kart/tabular/rich_table_dataset.py
+++ b/kart/tabular/rich_table_dataset.py
@@ -163,6 +163,7 @@ class RichTableDataset(TableDataset):
             "feature",
             key_filter=feature_filter,
             key_decoder_method="decode_path_to_1pk",
+            key_encoder_method="encode_1pk_to_path",
             value_decoder_method="get_feature_promise_from_path",
             reverse=reverse,
         )

--- a/kart/tabular/v3_paths.py
+++ b/kart/tabular/v3_paths.py
@@ -37,7 +37,7 @@ def _make_format_str(length, separator="", group_length=1):
 
 def _calculate_group_length(encoding, base, branches):
     group_length = int(math.log(max(branches, 1)) / math.log(max(base, 1)))
-    if base ** group_length != branches:
+    if base**group_length != branches:
         raise ValueError(
             f"Invalid path specification: {encoding} encoding and {branches} branches are incompatible"
         )
@@ -144,7 +144,7 @@ class PathEncoder:
         base = len(self.alphabet)
         self.group_length = _calculate_group_length(encoding, base, branches)
 
-        self.max_trees = self.branches ** self.levels
+        self.max_trees = self.branches**self.levels
 
         self._path_int_encoder = FixedLengthIntEncoder(
             self.alphabet, self.levels * self.group_length, "/", self.group_length
@@ -285,8 +285,12 @@ class IntPathEncoder(PathEncoder):
     DISTRIBUTED_FEATURES = False
 
     def encode_pks_to_path(self, pk_values):
-        assert len(pk_values) == 1
-        pk = pk_values[0]
+        if len(pk_values) != 1:
+            raise TypeError("IntPathEncoder can only encode a single integer value")
+        if not isinstance(pk_values[0], int):
+            raise TypeError("IntPathEncoder can only encode a single integer value")
+
+        pk = int(pk_values[0])
         tree_path = self._path_int_encoder.encode_int(
             (pk // self.branches) % self.max_trees
         )
@@ -320,7 +324,7 @@ class IntPathEncoder(PathEncoder):
             paths_fully_explored.add(path)
             return len(diff)
 
-        for (name, (child1, child2)) in diff_items:
+        for name, (child1, child2) in diff_items:
             child_path = f"{path}/{name}"
             if child_path in paths_fully_explored:
                 continue

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1587,7 +1587,7 @@ def test_diff_filtered_text(
 ):
     def _get_raw_diff_for_subtree(self, *args, **kwargs):
         # When only nz_pa_points_topo_150k:1182 is requested, a different more efficient code-path should be used.
-        raise AssertionError(
+        pytest.fail(
             "This method should not be called when only a single feature is required"
         )
 

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -10,6 +10,7 @@ import html5lib
 import pytest
 
 import kart
+from kart.tabular.v3 import TableV3
 from kart.diff_format import DiffFormat
 from kart.diff_structs import Delta, DeltaDiff
 from kart.html_diff_writer import HtmlDiffWriter
@@ -1581,7 +1582,17 @@ def test_show_points_HEAD(output_format, data_archive_readonly, cli_runner):
         ["show", "HEAD", "--", "nz_pa_points_topo_150k:1182"],
     ],
 )
-def test_diff_filtered_text(diff_command, data_archive_readonly, cli_runner):
+def test_diff_filtered_text(
+    diff_command, data_archive_readonly, cli_runner, monkeypatch
+):
+    def _get_raw_diff_for_subtree(self, *args, **kwargs):
+        # When only nz_pa_points_topo_150k:1182 is requested, a different more efficient code-path should be used.
+        raise AssertionError(
+            "This method should not be called when only a single feature is required"
+        )
+
+    monkeypatch.setattr(TableV3, "get_raw_diff_for_subtree", _get_raw_diff_for_subtree)
+
     with data_archive_readonly("points"):
         r = cli_runner.invoke(diff_command)
         assert r.exit_code == 0, r.stderr


### PR DESCRIPTION
<img src="https://media4.giphy.com/media/fBEMsUeGHdpsClFsxM/giphy.gif"/>

Don't run it when the user requests the diff of a particular feature
- we can look up the feature for both revs quicker than pygit2 can find all diffs in the entire revision.

There will be an extremely great speedup in the extreme case where the user wants to see a single feature that has changed, across a revision-range where a million features have changed.

If the user requests enough features, eventually there will be a crossover where this code path is slower. Eg if the user requests to see more features than have actually changed. However, mostly the size of the list of features requested will be much smaller than the size of the layer / size of the changes.

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
