### PR TITLE
Clean up empty folders if a clone fails immediately.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Fixes a bug where even datasets marked as `--no-checkout` are checked out when the working copy is first created. [#954](https://github.com/koordinates/kart/pull/954)
 - Fixes a bug where minor changes to auxiliary metadata (.aux.xml) files that Kart is supposed to ignore were preventing branch changes. [#957](https://github.com/koordinates/kart/pull/957)
 - Improved performance when the user filters a diff request to only show certain features. [#962](https://github.com/koordinates/kart/pull/962)
+- Clean up the empty directory if a clone fails outright [#963](https://github.com/koordinates/kart/issues/963)
 
 ## 0.15.0
 

--- a/kart/clone.py
+++ b/kart/clone.py
@@ -147,9 +147,6 @@ def clone(
         wc_location, PotentialRepo(repo_path)
     )
 
-    if not repo_path.exists():
-        repo_path.mkdir(parents=True)
-
     args = ["--progress" if do_progress else "--quiet"]
     if depth is not None:
         args.append(f"--depth={depth}")


### PR DESCRIPTION
Behaviour is unchanged if the clone succeeds enough to populate or partially populate the new directory - data is left where it is (but the repo is not "activated").

## Related links:

https://github.com/koordinates/kart/issues/963

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
