### PR TITLE
Fix add-dataset for PostGIS working copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Fixes a bug where even datasets marked as `--no-checkout` are checked out when the working copy is first created. [#954](https://github.com/koordinates/kart/pull/954)
 - Fixes a bug where minor changes to auxiliary metadata (.aux.xml) files that Kart is supposed to ignore were preventing branch changes. [#957](https://github.com/koordinates/kart/pull/957)
 - Improved performance when the user filters a diff request to only show certain features. [#962](https://github.com/koordinates/kart/pull/962)
-- Clean up the empty directory if a clone fails outright [#963](https://github.com/koordinates/kart/issues/963)
+- Clean up the empty directory if a clone fails outright. [#963](https://github.com/koordinates/kart/issues/963)
+- Fixes `add-dataset` to work for PostGIS working copies. [#965](https://github.com/koordinates/kart/issues/965)
 
 ## 0.15.0
 

--- a/kart/status.py
+++ b/kart/status.py
@@ -155,7 +155,7 @@ def get_untracked_tables(repo):
 
     if wc is not None and wc.session() is not None:
         with wc.session() as sess:
-            wc_items = wc.adapter.list_tables(sess)
+            wc_items = wc.adapter.list_tables(sess, db_schema=wc.db_schema)
         # Get all tables in working copy
         all_tables = [table_name for table_name, title in wc_items.items()]
         # Get tables shown in kart data ls

--- a/tests/test_add_dataset.py
+++ b/tests/test_add_dataset.py
@@ -232,10 +232,12 @@ def test_add_dataset__postgis(data_archive, cli_runner, new_postgis_db_schema):
             assert r.exit_code == 0, r.stderr
 
             output = json.loads(r.stdout)
+            COMMIT_SHA = output["kart.commit/v1"]["commit"]
+            ABBREV_COMMIT_SHA = output["kart.commit/v1"]["abbrevCommit"]
             assert output == {
                 "kart.commit/v1": {
-                    "commit": "58ea88e1efafe329e43ca856e00f2e1efd0375f3",
-                    "abbrevCommit": "58ea88e",
+                    "commit": COMMIT_SHA,
+                    "abbrevCommit": ABBREV_COMMIT_SHA,
                     "author": "user@example.com",
                     "committer": "committer@example.com",
                     "branch": "main",

--- a/tests/test_add_dataset.py
+++ b/tests/test_add_dataset.py
@@ -8,6 +8,10 @@ from kart.exceptions import (
 )
 from kart.repo import KartRepo
 
+import pytest
+
+H = pytest.helpers.helpers()
+
 
 def test_add_dataset_json_output__gpkg(cli_runner, data_working_copy):
     new_table = "test_table"
@@ -190,3 +194,56 @@ def test_add_dataset_triggers__gpkg(cli_runner, data_working_copy):
         }
 
         assert output["kart.diff/v1+hexwkb"] == expected
+
+
+def test_add_dataset__postgis(data_archive, cli_runner, new_postgis_db_schema):
+    with data_archive("points") as repo_path:
+        repo = KartRepo(repo_path)
+        H.clear_working_copy()
+        with new_postgis_db_schema() as (postgres_url, postgres_schema):
+            r = cli_runner.invoke(["create-workingcopy", postgres_url])
+            assert r.exit_code == 0, r.stderr
+
+            with repo.working_copy.tabular.session() as sess:
+                sess.execute(
+                    f"""CREATE TABLE {postgres_schema}.dupe AS (SELECT * FROM {postgres_schema}.{H.POINTS.LAYER});"""
+                )
+                sess.execute(
+                    f"""ALTER TABLE {postgres_schema}.dupe ADD PRIMARY KEY ({H.POINTS.LAYER_PK});"""
+                )
+
+            r = cli_runner.invoke(["status", "-ojson", "--list-untracked-tables"])
+            assert r.exit_code == 0, r.stderr
+
+            output = json.loads(r.stdout)
+            assert output["kart.status/v2"]["workingCopy"]["untrackedTables"] == [
+                "dupe"
+            ]
+
+            r = cli_runner.invoke(
+                ["add-dataset", "dupe", "-ojson", "-m" "test commit"],
+                env={
+                    "GIT_AUTHOR_DATE": "2010-1-1T00:00:00Z",
+                    "GIT_COMMITTER_DATE": "2010-1-1T00:00:00Z",
+                    "GIT_AUTHOR_EMAIL": "user@example.com",
+                    "GIT_COMMITTER_EMAIL": "committer@example.com",
+                },
+            )
+            assert r.exit_code == 0, r.stderr
+
+            output = json.loads(r.stdout)
+            assert output == {
+                "kart.commit/v1": {
+                    "commit": "58ea88e1efafe329e43ca856e00f2e1efd0375f3",
+                    "abbrevCommit": "58ea88e",
+                    "author": "user@example.com",
+                    "committer": "committer@example.com",
+                    "branch": "main",
+                    "message": "test commit",
+                    "changes": {
+                        "dupe": {"meta": {"inserts": 2}, "feature": {"inserts": 2143}}
+                    },
+                    "commitTime": "2010-01-01T00:00:00Z",
+                    "commitTimeOffset": "+00:00",
+                }
+            }


### PR DESCRIPTION
Unlike for GPKGs, we need to be looking for tables only in the appropriate schema. Happily, the code is all mostly in-place.
Added test.

## Related links:

Fixes https://github.com/koordinates/kart/issues/965

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
