### PR TITLE
diff estimator: don't crash at empty feature tree

### DIFF
--- a/kart/tabular/v3_paths.py
+++ b/kart/tabular/v3_paths.py
@@ -315,9 +315,15 @@ class IntPathEncoder(PathEncoder):
             diff = self._nonrecursive_diff(tree1, tree2)
             diffs_by_path[path] = diff
 
-        diff_items = list(diff.items())
-        rand.shuffle(diff_items)
+        if not diff:
+            # This can happen after a delete-all-features commit - at some level there may be an empty tree.
+            # Since tree1=None and tree2=EMPTY_TREE, we'll get here (tree1 != tree2) but diff will actually be empty.
+            paths_fully_explored.add(path)
+            return 0
 
+        diff_items = list(diff.items())
+
+        rand.shuffle(diff_items)
         child1, child2 = diff_items[0][1]
         if isinstance(child1, pygit2.Blob) or isinstance(child2, pygit2.Blob):
             # we're at the bottom level


### PR DESCRIPTION
If user deletes all the features in a dataset, we end up with a tree that looks like
```
datasetname/feature/A/A/A/A
```
... with no features in it. The final `A` is an empty tree.

This causes the following crash in diff:

```
$ kart diff --only-feature-count=medium
4b825dc642cb6eb9a060e54bf8d69288fbee4904...HEAD -o json
kart helper: unhandled exception
Traceback (most recent call last):
  File "kart/helper.py", line 240, in helper
  File "click/core.py", line 1157, in __call__
  File "click/core.py", line 1078, in main
  File "kart/cli_util.py", line 72, in invoke
  File "click/core.py", line 1688, in invoke
  File "click/core.py", line 1434, in invoke
  File "click/core.py", line 783, in invoke
  File "click/decorators.py", line 34, in new_func
  File "kart/diff.py", line 194, in diff
  File "kart/diff.py", line 34, in feature_count_diff
  File "kart/diff_estimation.py", line 156, in
estimate_diff_feature_counts
  File "kart/diff_estimation.py", line 60, in
get_approximate_diff_blob_count
  File "kart/tabular/v3_paths.py", line 374, in diff_estimate
  File "kart/tabular/v3_paths.py", line 331, in
_recursive_depth_first_diff_estimate
  File "kart/tabular/v3_paths.py", line 331, in
_recursive_depth_first_diff_estimate
  File "kart/tabular/v3_paths.py", line 331, in
_recursive_depth_first_diff_estimate
  [Previous line repeated 1 more time]
  File "kart/tabular/v3_paths.py", line 321, in
_recursive_depth_first_diff_estimate
IndexError: list index out of range
```

This change fixes the issue so that command can deal with these repos.

Whether they should have empty trees committed to them is another matter I guess


## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
