### PR TITLE
Fix setup-rust action in github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -296,9 +296,11 @@ jobs:
           cmakeVersion: "${{ env.CMAKE_VERSION }}"
 
       - name: "setup: rust"
-        uses: ATiltedTree/setup-rust@v1
-        with:
-          rust-version: stable
+        run: |
+          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh -s -- -y
+          . "$HOME/.cargo/env"
+          rustc --version
+
 
       - name: "setup: misc"
         shell: bash


### PR DESCRIPTION
## Description

<!-- Thanks for your contribution! Describe your changes in a few sentences. Try to include discussion of tradeoffs or alternatives you considered when writing this code. -->

Uses rustup to install rust  in the Linux build, rather than the recently-deleted `ATiltedTree/setup-rust` action.

The MacOS build uses `dtolnay/rust-toolchain@stable` - I _tried_ to use this, but the ancient manylinux2014 image doesn't have a new-enough `curl` version, so that action dies. So I just curled it manually; seems to work

## Related links:

<!-- If you have links to [issues](https://github.com/koordinates/kart/issues) etc, link them here. -->

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
