### PR TITLE
Fix build issue involving macos major/minor versions

### DIFF
--- a/cmake/PythonGetABIInfo.cmake
+++ b/cmake/PythonGetABIInfo.cmake
@@ -73,8 +73,11 @@ function(PythonGetABIInfo)
         set(py_MACOSX_DEPLOYMENT_TARGET "${py_INTERPRETER_MACOSX_DEPLOYMENT_TARGET}")
       endif()
 
+      # We need MAJOR.MINOR for both these variables - if we have MAJOR but not .MINOR, append ".0" to the end.
+      if(py_INTERPRETER_MACOSX_DEPLOYMENT_TARGET MATCHES "^[0-9]+$")
+        set(py_INTERPRETER_MACOSX_DEPLOYMENT_TARGET "${py_INTERPRETER_MACOSX_DEPLOYMENT_TARGET}.0")
+      endif()
       if(py_MACOSX_DEPLOYMENT_TARGET MATCHES "^[0-9]+$")
-        # We need MAJOR.MINOR - if we have MAJOR but not .MINOR, append ".0" to the end.
         set(py_MACOSX_DEPLOYMENT_TARGET "${py_MACOSX_DEPLOYMENT_TARGET}.0")
       endif()
 


### PR DESCRIPTION
Minimal fix for hidden build issue (not causing CI failures, but is causing local failures) - just makes sure we replace a string like "13.0" with another string like "14.0" - that is, we always replace MAJOR.MINOR with another string MAJOR.MINOR

Otherwise, the resulting substitution could cause unwanted digit to disappear (this was already fixed a year ago in aae2585 ) or appear (the symmetrical fix is added here).
