### PR TITLE
Gdal tools

### DIFF
--- a/kart.spec
+++ b/kart.spec
@@ -84,7 +84,10 @@ binaries = [
     (f'{BINARY_DIR}/venv/lib/mod_spatialite.{lib_suffix_glob}', '.'),
     (f'{BINARY_DIR}/venv/{VENV_BIN_DIR}/git-lfs{exe_suffix}', '.'),
     (f'{BINARY_DIR}/venv/{VENV_BIN_DIR}/pdal{exe_suffix}', '.'),
-    (f'{BINARY_DIR}/venv/tools/gdal/*{exe_suffix}', 'tools/gdal'),
+    # We put all exes in the same directory as DLLs on windows, so that they still
+    # work if run from outside Kart - note that this works on other systems due to RPATH,
+    # and when run from within Kart we can use os.add_dll_directory in kart/__init__.py
+    (f'{BINARY_DIR}/venv/tools/gdal/*{exe_suffix}', '.' if is_win else "tools/gdal"),
 ]
 if not is_win:
     binaries += [

--- a/kart.spec
+++ b/kart.spec
@@ -84,6 +84,7 @@ binaries = [
     (f'{BINARY_DIR}/venv/lib/mod_spatialite.{lib_suffix_glob}', '.'),
     (f'{BINARY_DIR}/venv/{VENV_BIN_DIR}/git-lfs{exe_suffix}', '.'),
     (f'{BINARY_DIR}/venv/{VENV_BIN_DIR}/pdal{exe_suffix}', '.'),
+    (f'{BINARY_DIR}/venv/tools/gdal/*{exe_suffix}', 'tools/gdal'),
 ]
 if not is_win:
     binaries += [

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,25 @@
+import os
+import re
+import subprocess
+
+from kart import prefix, is_frozen, is_windows
+
+
+def test_ogr_tools_bundled():
+    # GDAL tools are normally in prefix/tools/gdal
+    # Exception is pyinstaller windows build where we put them in the prefix directory,
+    # alongside the libs that they need so that they still work even when run from outside of Kart.
+    ogr_tools_dir = (
+        prefix if (is_frozen and is_windows) else os.path.join(prefix, "tools/gdal")
+    )
+
+    # Where-ever they are, they should run without error (at least when run from within Kart).
+    for toolname in ("ogrinfo", "ogr2ogr"):
+        toolpath = os.path.join(ogr_tools_dir, toolname)
+        output = subprocess.check_output(
+            [str(toolpath), "--version"], text=True
+        ).splitlines()
+        match = re.match(r"GDAL (\d+)\.(\d+)\.(\d+)", output[0])
+        assert match
+        version_tuple = tuple(int(match.group(x)) for x in range(1, 4))
+        assert version_tuple >= (3, 8, 0)

--- a/vcpkg-vendor/CMakeLists.txt
+++ b/vcpkg-vendor/CMakeLists.txt
@@ -142,12 +142,6 @@ list(APPEND WHEEL_LIST ${CFFI_WHEEL})
 #
 find_package(GDAL REQUIRED)
 
-file(
-  GLOB GDAL_DATA_FILES
-  RELATIVE ${CURRENT_PACKAGES_DIR}
-  "share/gdal/*")
-list(APPEND ENV_FILE_LIST ${GDAL_DATA_FILES})
-
 if(WIN32)
   set(GDAL_CONFIG_EXE "")
 else()
@@ -414,11 +408,6 @@ list(APPEND WHEEL_LIST ${INSTALL_DIR}/reflink-${REFLINK_WHEEL_VER}-${Python3_WHE
 # Proj
 #
 find_package(PROJ CONFIG REQUIRED)
-file(
-  GLOB PROJ_DATA_FILES
-  RELATIVE ${CURRENT_PACKAGES_DIR}
-  "share/proj/*")
-list(APPEND ENV_FILE_LIST ${PROJ_DATA_FILES})
 
 #
 # mod_spatialite
@@ -630,10 +619,11 @@ add_custom_command(
   OUTPUT ${VENDOR_ARCHIVE}
   DEPENDS vendor_wheels git git-lfs ${VENDOR_CONFIG} fix_vendor_libs.py
   COMMAND ${CMAKE_COMMAND} -E rm -rf env/share/git-gui
-  COMMAND ${CMAKE_COMMAND} -E make_directory wheelhouse env env/lib env/share env/${EXE_DIR}
+  COMMAND ${CMAKE_COMMAND} -E make_directory wheelhouse env env/lib env/tools env/share env/${EXE_DIR}
   COMMAND ${CMAKE_COMMAND} -E copy ${WHEEL_LIST} wheelhouse
   COMMAND ${CMAKE_COMMAND} -E copy ${LIB_LIST} env/lib
   COMMAND ${CMAKE_COMMAND} -E copy ${EXE_LIST} env/${EXE_DIR}
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${CURRENT_PACKAGES_DIR}/tools/gdal/ env/tools/gdal
   COMMAND ${CMAKE_COMMAND} -E copy_directory ${CURRENT_PACKAGES_DIR}/share/gdal/ env/share/gdal
   COMMAND ${CMAKE_COMMAND} -E copy_directory ${CURRENT_PACKAGES_DIR}/share/proj/ env/share/proj
   COMMAND ${EXTRA_COPY_COMMAND}

--- a/vcpkg-vendor/fix_vendor_libs.py
+++ b/vcpkg-vendor/fix_vendor_libs.py
@@ -71,7 +71,7 @@ if PLATFORM == "Windows":
     RPATH_PREFIX = ""
     LIB_EXTENSIONS = [".lib", ".dll", ".pyd"]
     SYSTEM_PREFIXES = []
-    EXE_PATHS = ["env/scripts"]
+    EXE_PATHS = ["env/scripts", "env/tools/gdal"]
     EXE_EXTENSION = ".exe"
     TOP_LEVEL_DIRECTORIES += ["git"]
     NOFIX_PATHS = ["git"]
@@ -81,7 +81,7 @@ elif PLATFORM == "Darwin":
     RPATH_PREFIX = "@rpath/"
     LIB_EXTENSIONS = [".dylib", ".so"]
     SYSTEM_PREFIXES = ["/usr/lib/"]
-    EXE_PATHS = ["env/bin", "env/libexec/git-core"]
+    EXE_PATHS = ["env/bin", "env/libexec/git-core", "env/tools/gdal"]
     EXE_EXTENSION = ""
 elif PLATFORM == "Linux":
     VENDOR_ARCHIVE_NAME = "vendor-Linux.tar.gz"
@@ -89,7 +89,7 @@ elif PLATFORM == "Linux":
     RPATH_PREFIX = ""
     LIB_EXTENSIONS = [".so", ".so.*"]
     SYSTEM_PREFIXES = []
-    EXE_PATHS = ["env/bin", "env/libexec/git-core"]
+    EXE_PATHS = ["env/bin", "env/libexec/git-core", "env/tools/gdal"]
     EXE_EXTENSION = ""
 
 if PLATFORM == "Windows":


### PR DESCRIPTION
## Description

Bundling gdal tools with Kart - particularly concerned with ogrinfo and ogr2ogr, but included them all.

Note that:
- executables work on macos and linux as long as the rpath is set properly (it is).
- executables work on windows as long as they are in the same directory as the DLLs they need, or, a program is run before hand that adds the relevant lib directory to the DLL path (ie, Kart).

With these two facts in hand, I made the following design choices for the various environments we create:
### Development environment aka venv aka temporary environment during building:
The gdal tools always go in $PREFIX/tools/gdal, ie, venv/tools/gdal
This means that:
- they work on all platforms when run from within Kart
- they don't work on Windows when run standalone
- they're kept separate from the other files - which means we can easily find them all during the pyinstaller step by doing a globbing rule

### Pyinstaller aka release environment
The gdal tools still go in $PREFIX/tools/gdal on macos and linux
They go in $PREFIX on windows
This means that:
- they work on all platforms when run from Kart or run standalone
- on windows they're cluttered in with all our other files, but this is a tradeoff I made to have them work standalone. Inevitably we'll end up telling some windows user to run them directly for debugging purposes etc.

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
