### PR TITLE
Added delta-filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please note that compatibility for 0.x releases (software or repositories) isn't
 
 _When adding new entries to the changelog, please include issue/PR numbers wherever possible._
 
+## 0.15.3 (UNRELEASED)
+
+- Replaces minimal patches with delta-filters - a more general-purpose way of filtering parts (inserts, updates, deletes) of JSON diffs when not all parts are required. [#998](https://github.com/koordinates/kart/pull/998)
+
 ## 0.15.2
 
 - Adds a new command `kart export` which enables export of vector or tabular datasets to any OGR format. [#992](https://github.com/koordinates/kart/issues/992)

--- a/kart/base_diff_writer.py
+++ b/kart/base_diff_writer.py
@@ -78,6 +78,7 @@ class BaseDiffWriter:
         output_path="-",
         *,
         json_style="pretty",
+        delta_filter=None,
         target_crs=None,
         # used by json-lines diffs only
         diff_estimate_accuracy=None,

--- a/kart/cli_util.py
+++ b/kart/cli_util.py
@@ -397,6 +397,34 @@ class OutputFormatType(click.ParamType):
         ]
 
 
+class DeltaFilterType(click.ParamType):
+    """
+    Filters parts of individual deltas - new or old values for inserts, updates, or deletes.
+    "--" is the key for old values of deletes
+    "-" is the key for old values of updates
+    "+" is the key for new values of updates
+    "++" is they key for new values of inserts
+    """
+
+    name = "string"
+
+    ALLOWED_KEYS = ("--", "-", "+", "++")
+
+    def convert(self, value, param, ctx):
+        from kart.key_filters import DeltaFilter
+
+        if value is None:
+            return None
+        if value.lower() == "all":
+            return DeltaFilter.MATCH_ALL
+        pieces = value.split(",")
+        if any(p for p in pieces if p not in self.ALLOWED_KEYS):
+            self.fail(
+                "Delta filter only accepts any subset of the following comma separated keys: --,-,+,++"
+            )
+        return DeltaFilter(pieces)
+
+
 def find_param(ctx_or_params, name):
     """Given the click context / command / list of params - find the param with the given name."""
     ctx = ctx_or_params

--- a/kart/diff.py
+++ b/kart/diff.py
@@ -132,7 +132,6 @@ def feature_count_diff(
 @click.option(
     "--delta-filter",
     type=DeltaFilterType(),
-    hidden=True,
     help="Filter out particular parts of each delta - for example, --delta-filter=+ only shows new values of updates. "
     "Setting this option modifies Kart's behaviour when outputting JSON diffs - "
     "instead using minus to mean old value and plus to mean new value, it uses a more specific scheme: "

--- a/kart/diff.py
+++ b/kart/diff.py
@@ -3,7 +3,7 @@ import sys
 import click
 
 from kart import diff_estimation
-from kart.cli_util import OutputFormatType
+from kart.cli_util import OutputFormatType, DeltaFilterType
 from kart.completion_shared import ref_or_repo_path_completer
 from kart.crs_util import CoordinateReferenceString
 from kart.output_util import dump_json_output
@@ -130,6 +130,19 @@ def feature_count_diff(
     help="Show changes to file contents (instead of just showing the object IDs of changed files)",
 )
 @click.option(
+    "--delta-filter",
+    type=DeltaFilterType(),
+    hidden=True,
+    help="Filter out particular parts of each delta - for example, --delta-filter=+ only shows new values of updates. "
+    "Setting this option modifies Kart's behaviour when outputting JSON diffs - "
+    "instead using minus to mean old value and plus to mean new value, it uses a more specific scheme: "
+    "-- (minus-minus) means deleted value, ++ (plus-plus) means inserted value, "
+    "and - and + still mean old and new value but are only used for updates (not for inserts and deletes). "
+    "These keys are used when outputting the diffs, and these keys can be whitelisted using this flag to minimise the "
+    "size of the diff if some types of values are not required. "
+    "As a final example, --delta-filter=all is equivalent to --delta-filter=--,-,+,++",
+)
+@click.option(
     "--html-template",
     default=None,
     help="Provide a user defined/specific html template for diff representation",
@@ -153,6 +166,7 @@ def diff(
     add_feature_count_estimate,
     convert_to_dataset_format,
     diff_files,
+    delta_filter,
     html_template,
     args,
 ):
@@ -210,6 +224,7 @@ def diff(
         filters,
         output_path,
         json_style=fmt,
+        delta_filter=delta_filter,
         target_crs=crs,
         diff_estimate_accuracy=add_feature_count_estimate,
         html_template=html_template,

--- a/kart/json_diff_writers.py
+++ b/kart/json_diff_writers.py
@@ -44,12 +44,9 @@ class JsonDiffWriter(BaseDiffWriter):
     which contains information about the commit object.
     """
 
-    def __init__(self, *args, patch_type="full", delta_filter=None, **kwargs):
+    def __init__(self, *args, delta_filter=None, **kwargs):
         super().__init__(*args, **kwargs)
-        if patch_type == "minimal":
-            self.delta_filter = DeltaFilter.MINIMAL_WITH_STARS
-        else:
-            self.delta_filter = delta_filter
+        self.delta_filter = delta_filter
 
     @classmethod
     def _check_output_path(cls, repo, output_path):

--- a/kart/key_filters.py
+++ b/kart/key_filters.py
@@ -307,3 +307,24 @@ class NegateKeyFilter:
 
 
 RepoKeyFilter.MATCH_ALL = RepoKeyFilter(match_all=True)
+
+
+class DeltaFilter(set):
+    """
+    Filters parts of individual deltas - new or old values for inserts, updates, or deletes.
+    "--" is the key for old values of deletes
+    "-" is the key for old values of updates
+    "+" is the key for new values of updates
+    "++" is they key for new values of inserts
+    """
+
+    def __init__(self, *args, match_all=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.match_all = match_all
+
+    def __contains__(self, key):
+        return self.match_all or super().__contains__(key)
+
+
+DeltaFilter.MATCH_ALL = DeltaFilter(match_all=True)
+DeltaFilter.MINIMAL_WITH_STARS = DeltaFilter(["MINIMAL_WITH_STARS"])

--- a/kart/key_filters.py
+++ b/kart/key_filters.py
@@ -327,4 +327,3 @@ class DeltaFilter(set):
 
 
 DeltaFilter.MATCH_ALL = DeltaFilter(match_all=True)
-DeltaFilter.MINIMAL_WITH_STARS = DeltaFilter(["MINIMAL_WITH_STARS"])

--- a/kart/show.py
+++ b/kart/show.py
@@ -86,7 +86,6 @@ from kart.repo import KartRepoState
 @click.option(
     "--delta-filter",
     type=DeltaFilterType(),
-    hidden=True,
     help="Filter out particular parts of each delta - for example, --delta-filter=+ only shows new values of updates. "
     "Setting this option modifies Kart's behaviour when outputting JSON diffs - "
     "instead using minus to mean old value and plus to mean new value, it uses a more specific scheme: "
@@ -178,16 +177,6 @@ def show(
     type=click.Path(writable=True, allow_dash=True),
 )
 @click.option(
-    "--patch-type",
-    type=click.Choice(["full", "minimal"]),
-    default="full",
-    help=(
-        "Style of patch to produce. 'full' is the default and most applyable, but is quite a verbose patch. "
-        "'minimal' creates a much smaller patch by omitting the 'old' version of edits, "
-        "but 'minimal' patches are only applyable if the parent commit is present in the target repo."
-    ),
-)
-@click.option(
     "--diff-format",
     type=click.Choice(["none", "full", "no-data-changes"]),
     default="full",
@@ -202,7 +191,6 @@ def create_patch(
     refish,
     json_style,
     output_path,
-    patch_type,
     diff_format=DiffFormat.FULL,
     **kwargs,
 ):
@@ -226,7 +214,6 @@ def create_patch(
         [],
         output_path,
         json_style=json_style,
-        patch_type=patch_type,
     )
     diff_writer.full_file_diffs(True)
     diff_writer.include_target_commit_as_header()

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
-from kart.exceptions import NO_TABLE, PATCH_DOES_NOT_APPLY
+from kart.exceptions import NO_TABLE, PATCH_DOES_NOT_APPLY, NOT_YET_IMPLEMENTED
 from kart.repo import KartRepo
 
 
@@ -284,74 +284,7 @@ def test_apply_minimal_style_patch_without_base(data_archive, cli_runner, tmp_pa
         assert r.exit_code == PATCH_DOES_NOT_APPLY, r.stderr
 
 
-def test_apply_minimal_style_meta_patch_with_update(data_archive, cli_runner, tmp_path):
-    patch = points_patch(
-        {
-            "meta": {
-                "title": {
-                    "*": "new title:",
-                }
-            }
-        }
-    )
-    with data_archive("points"):
-        with write_patch(patch, tmp_path) as patch_path:
-            r = cli_runner.invoke(["apply", patch_path])
-        assert r.exit_code == 0, r.stderr
-
-        # Check that the change was actually applied
-        r = cli_runner.invoke(["show", "-o", "json", "HEAD"])
-        assert r.exit_code == 0
-        show = json.loads(r.stdout)
-        meta = show["kart.diff/v1+hexwkb"]["nz_pa_points_topo_150k"]["meta"]
-        assert meta == {"title": {"+": "new title:", "-": "NZ Pa Points (Topo, 1:50k)"}}
-
-        # now check that a conflict gets rejected
-        # note: we change the title here but don't change the base,
-        # so this change now conflicts with the change we just applied.
-        patch = points_patch(
-            {
-                "meta": {
-                    "title": {
-                        "*": "differently new title:",
-                    }
-                }
-            }
-        )
-        with write_patch(patch, tmp_path) as patch_path:
-            r = cli_runner.invoke(["apply", patch_path])
-        assert r.exit_code == PATCH_DOES_NOT_APPLY, r.stderr
-
-
-def test_apply_minimal_style_meta_patch_with_delete(data_archive, cli_runner, tmp_path):
-    patch = points_patch(
-        {
-            "meta": {
-                "description": {
-                    # content is ignored, so this must work
-                    "-": None,
-                }
-            }
-        }
-    )
-    with data_archive("points"):
-        with write_patch(patch, tmp_path) as patch_path:
-            r = cli_runner.invoke(["apply", patch_path])
-        assert r.exit_code == 0, r.stderr
-
-        # Check that the change was actually applied
-        r = cli_runner.invoke(["show", "-o", "json", "HEAD"])
-        assert r.exit_code == 0
-        show = json.loads(r.stdout)
-        meta = show["kart.diff/v1+hexwkb"]["nz_pa_points_topo_150k"]["meta"]
-        # description was deleted
-        assert meta["description"].keys() == {"-"}
-
-
-def test_apply_minimal_style_feature_patch_with_edit(
-    data_archive, cli_runner, tmp_path
-):
-
+def test_apply_minimal_style_patch(data_archive, cli_runner, tmp_path):
     patch = points_patch(
         {
             "feature": [
@@ -374,60 +307,12 @@ def test_apply_minimal_style_feature_patch_with_edit(
     with data_archive("points"):
         with write_patch(patch, tmp_path) as patch_path:
             r = cli_runner.invoke(["apply", patch_path])
-        assert r.exit_code == 0, r.stderr
-
-        # Check that the change was actually applied
-        r = cli_runner.invoke(["show", "-o", "json", "HEAD"])
-        assert r.exit_code == 0
-        show = json.loads(r.stdout)
-        features = show["kart.diff/v1+hexwkb"]["nz_pa_points_topo_150k"]["feature"]
-        assert len(features) == 1
-        assert features[0]["-"] == {
-            "fid": 1182,
-            "geom": "01010000009933726825F76540140C370F236742C0",
-            "t50_fid": 2427426,
-            "name_ascii": "Ko Te Ra Matiti (Wharekaho)",
-            "macronated": "Y",
-            "name": "Ko Te Rā Matiti (Wharekaho)",
-        }
-        assert features[0]["+"] == {
-            "fid": 1182,
-            "geom": "01010000009933726825F76540140C370F236742C0",
-            "t50_fid": 9999999,
-            "name_ascii": "Ko Te Ra Matiti (Wharekaho)",
-            "macronated": "Y",
-            "name": "Ko Te Rā Matiti (Wharekaho)",
-        }
-
-        # now check that a conflict gets rejected
-        # note: we change the feature here but don't change the base,
-        # so this change now conflicts with the change we just applied.
-        patch = points_patch(
-            {
-                "feature": [
-                    {
-                        "*": {
-                            "fid": 1182,
-                            "geom": "01010000009933726825F76540140C370F236742C0",
-                            "t50_fid": 2427426,
-                            "name_ascii": "Ko Te Ra Matiti (Wharekaho)",
-                            "name": "Ko Te Rā Matiti (Wharekaho)",
-                            # this is the edit
-                            "macronated": "N",
-                        }
-                    },
-                ]
-            }
-        )
-        with write_patch(patch, tmp_path) as patch_path:
-            r = cli_runner.invoke(["apply", patch_path])
-        assert r.exit_code == PATCH_DOES_NOT_APPLY, r.stderr
+        assert r.exit_code == NOT_YET_IMPLEMENTED, r.stderr
 
 
 def test_apply_minimal_style_feature_patch_with_insert(
     data_archive, cli_runner, tmp_path
 ):
-
     patch = points_patch(
         {
             "feature": [


### PR DESCRIPTION
Backwards compatible in that they do nothing unless you specify --delta-filter=<some-value>
A bit like minimal-patches which we implemented a couple years back, but more powerful - more general-purpose - to avoid having to implement them again at some point.
Basically, lets a consumer of JSON or JSON-LINES diff opt in or out of any of the following:
- inserts
- updates (old values)
- updates (new values)
- deletes 
But still see where the filtered out data is.

Useful for generating changeset views of the data that don't need to show old values.

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
