### PR TITLE
Fix mssql instance names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 ## 0.15.3 (UNRELEASED)
 
 - Replaces minimal patches with delta-filters - a more general-purpose way of filtering parts (inserts, updates, deletes) of JSON diffs when not all parts are required. [#998](https://github.com/koordinates/kart/pull/998)
+- Remove automatic resolution of `localhost` before calling MSSQL driver. Fixes SQL Server instance names issue. [#999](https://github.com/koordinates/kart/issues/999)
 
 ## 0.15.2
 

--- a/kart/sqlalchemy/base.py
+++ b/kart/sqlalchemy/base.py
@@ -53,13 +53,6 @@ class BaseDb:
         return NullPool if "PYTEST_CURRENT_TEST" in os.environ else None
 
     @classmethod
-    def _replace_localhost_with_ip(cls, url_netloc):
-        def _get_localhost_ip(*args, **kwargs):
-            return socket.gethostbyname("localhost")
-
-        return re.sub(r"\blocalhost\b", _get_localhost_ip, url_netloc)
-
-    @classmethod
     def _append_query_to_url(cls, uri, new_query_dict):
         url = urlsplit(uri)
         url_query = cls._append_to_query(url.query, new_query_dict)

--- a/kart/sqlalchemy/sqlserver.py
+++ b/kart/sqlalchemy/sqlserver.py
@@ -31,10 +31,7 @@ class Db_SqlServer(BaseDb):
             {"driver": cls.get_sqlserver_driver(), "Application Name": "kart"},
         )
 
-        # SQL Server driver prefers 127.0.0.1 or similar to localhost.
-        url_netloc = cls._replace_localhost_with_ip(url.netloc)
-
-        msurl = urlunsplit([cls.INTERNAL_SCHEME, url_netloc, url.path, url_query, ""])
+        msurl = urlunsplit([cls.INTERNAL_SCHEME, url.netloc, url.path, url_query, ""])
 
         engine = sqlalchemy.create_engine(msurl, poolclass=cls._pool_class())
         return engine

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -50,7 +50,7 @@ pygments==2.13.0
     #   rst2txt
 pymysql==1.0.2
     # via -r requirements.in
-pyodbc==5.0.1
+pyodbc==5.1.0
     # via -r vendor-wheels.txt
 pyrsistent==0.19.2
     # via jsonschema

--- a/requirements/vendor-wheels.txt
+++ b/requirements/vendor-wheels.txt
@@ -3,6 +3,6 @@ cryptography==42.0.4
 gdal==3.8.0
 psycopg2==2.9.9
 pygit2==1.12.1
-pyodbc==5.0.1
+pyodbc==5.1.0
 pysqlite3==0.5.2
 reflink==0.2.2

--- a/vcpkg-vendor/CMakeLists.txt
+++ b/vcpkg-vendor/CMakeLists.txt
@@ -289,12 +289,12 @@ include_dirs=${BUILD_WHEEL_INCLUDE_DIRS}
 library_dirs=${BUILD_WHEEL_LIBRARY_DIRS}
 ")
 
-set(PYODBC_WHEEL_VER 5.0.1)
+set(PYODBC_WHEEL_VER 5.1.0)
 ExternalProject_Add(
   pyodbc
   # if you build from a git repository, pyodbc adds +commit0c0ffee to the wheel version
-  URL https://files.pythonhosted.org/packages/22/6f/012f32aecf744e439980257be0ba4dd8c70a4e03c9f86f5fcd986fbfb012/pyodbc-5.0.1.tar.gz
-  URL_HASH SHA256=03d7d0b04d5a9156099ce8d03e92f3956783746fa9234eb6f5b5cfc12b645011
+  URL https://files.pythonhosted.org/packages/d5/5b/a93f7017d4df84c3971cf60ee935149f12e0d1e111febc67ba2e23015a79/pyodbc-5.1.0.tar.gz
+  URL_HASH SHA256=397feee44561a6580be08cedbe986436859563f4bb378f48224655c8e987ea60
   DOWNLOAD_NO_PROGRESS ON
   BUILD_IN_SOURCE ON
   DEPENDS wheelBuildEnv ${PYODBC_BUILD_DEPENDS}


### PR DESCRIPTION
## Description

Removes code that automatically translates `localhost` to `127.0.0.1` or similar, before using the MSSQL driver.

This code was previously useful but I can't find any evidence that it currently is, and it is preventing MSSQL instance names from working. That code may have been useful for older MSSQL drivers... or if localhost is using only IPv4 or IPv6... but it needs to be removed since it's causing issues, and supporting exactly what the MSSQL driver supports is a better non-surprising behaviour.

## Related links:

https://github.com/koordinates/kart/issues/999

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
