### PR TITLE
Patch PDAL to respect AWS_VIRTUAL_HOSTING=FALSE

### DIFF
--- a/vcpkg-vendor/vcpkg-overlay-ports/pdal/arbiter-aws-virtual-hosting-var.patch
+++ b/vcpkg-vendor/vcpkg-overlay-ports/pdal/arbiter-aws-virtual-hosting-var.patch
@@ -1,0 +1,81 @@
+diff --git a/vendor/arbiter/arbiter.cpp b/vendor/arbiter/arbiter.cpp
+index a4427be2a..9a71fd3d7 100644
+--- a/vendor/arbiter/arbiter.cpp
++++ b/vendor/arbiter/arbiter.cpp
+@@ -2547,7 +2547,7 @@ S3::Resource::Resource(std::string base, std::string fullPath)
+     : m_baseUrl(base)
+     , m_bucket()
+     , m_object()
+-    , m_virtualHosted(true)
++    , m_virtualHosted()
+ {
+     fullPath = sanitize(fullPath);
+     const std::size_t split(fullPath.find("/"));
+@@ -2555,6 +2555,10 @@ S3::Resource::Resource(std::string base, std::string fullPath)
+     m_bucket = fullPath.substr(0, split);
+     if (split != std::string::npos) m_object = fullPath.substr(split + 1);
+ 
++    // By default, we use virtual-hosted URLs if the bucket name contains no dots.
++    // This can be overridden with the AWS_VIRTUAL_HOSTING environment variable
++    // (set to "TRUE" or "FALSE")
++    //
+     // We would prefer to use virtual-hosted URLs all the time since path-style
+     // URLs are being deprecated in 2020.  We also want to use HTTPS all the
+     // time, which is required for KMS-managed server-side encryption.  However,
+@@ -2573,7 +2577,10 @@ S3::Resource::Resource(std::string base, std::string fullPath)
+     // 2021 note: the deprecation date got delayed, and buckets containing
+     // dots still has no fix - see the note at the top of the first link above.
+     // So for the time being, we'll keep this forked logic below.
+-    m_virtualHosted = m_bucket.find_first_of('.') == std::string::npos;
++    m_virtualHosted = parseBoolFromEnv(
++        "AWS_VIRTUAL_HOSTING",
++        m_bucket.find_first_of('.') == std::string::npos
++    );
+ }
+ 
+ std::string S3::Resource::canonicalUri() const
+@@ -5921,6 +5928,29 @@ std::unique_ptr<std::string> env(const std::string& var)
+     return result;
+ }
+ 
++bool parseBoolFromEnv(const std::string& var, bool defaultValue)
++{
++    auto value = env(var);
++    if (!value)
++    {
++        // env var is not set
++        return defaultValue;
++    }
++    if (value->empty())
++    {
++        // env var is set to the empty string; interpret as false
++        return false;
++    }
++
++    const char firstChar = std::tolower((*value)[0]);
++    if (firstChar == 't' || firstChar == 'T' || firstChar == '1')
++        return true;
++    else if (firstChar == 'f' || firstChar == 'F' || firstChar == '0')
++        return false;
++    else
++        return defaultValue;
++}
++
+ std::vector<std::string> split(const std::string& in, const char delimiter)
+ {
+     std::size_t index(0);
+diff --git a/vendor/arbiter/arbiter.hpp b/vendor/arbiter/arbiter.hpp
+index 3d5e18820..02099de01 100644
+--- a/vendor/arbiter/arbiter.hpp
++++ b/vendor/arbiter/arbiter.hpp
+@@ -3599,6 +3599,10 @@ inline std::string join(std::string path, Paths&&... paths)
+  */
+ ARBITER_DLL std::unique_ptr<std::string> env(const std::string& var);
+ 
++/** Parses a boolean value from an environment variable.
++ * Values are like "TRUE"/"FALSE"/"0"/"1" */
++ARBITER_DLL bool parseBoolFromEnv(const std::string& var, bool defaultValue);
++
+ /** @brief Split a string on a token. */
+ ARBITER_DLL std::vector<std::string> split(
+         const std::string& s,

--- a/vcpkg-vendor/vcpkg-overlay-ports/pdal/portfile.cmake
+++ b/vcpkg-vendor/vcpkg-overlay-ports/pdal/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
         no-pkgconfig-requires.patch
         no-rpath.patch
         install-dimbuilder.patch
+        arbiter-aws-virtual-hosting-var.patch  # https://github.com/connormanning/arbiter/pull/57
 )
 
 # Prefer pristine CMake find modules + wrappers and config files from vcpkg.


### PR DESCRIPTION
## Description

PDAL has trouble talking to non-AWS services providing the S3 API when using bucket names not containing a `.`

This change adds my fix for the vendored arbiter library so that callers can specify `AWS_VIRTUAL_HOSTING=FALSE` to workaround the problem.

## Related links:

https://github.com/connormanning/arbiter/pull/57
<!-- If you have links to [issues](https://github.com/koordinates/kart/issues) etc, link them here. -->

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
