### PR TITLE
Implement --diff-format for json-lines output diffs

### DIFF
--- a/kart/json_diff_writers.py
+++ b/kart/json_diff_writers.py
@@ -323,7 +323,16 @@ class JsonLinesDiffWriter(BaseDiffWriter):
             )
 
         self.write_meta_deltas(ds_path, ds_diff)
-        self.write_filtered_dataset_deltas(ds_path, ds_diff)
+        if diff_format == DiffFormat.FULL.value:
+            self.write_filtered_dataset_deltas(ds_path, ds_diff)
+        elif diff_format == DiffFormat.NO_DATA_CHANGES.value:
+            self.dump(
+                {
+                    "type": "dataChanges",
+                    "dataset": ds_path,
+                    "value": ds_diff["data_changes"],
+                }
+            )
 
     def write_meta_deltas(self, ds_path, ds_diff):
         if "meta" not in ds_diff:


### PR DESCRIPTION
## Description

Implements `--diff-format=no-data-changes` when used in conjunction with `-o json-lines`
## Related links:

followup to #1008 

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
