### PR TITLE
`import`: Numeric table selection choices

### DIFF
--- a/kart/tabular/ogr_import_source.py
+++ b/kart/tabular/ogr_import_source.py
@@ -244,7 +244,7 @@ class OgrTableImportSource(TableImportSource):
             layers[layer.GetName()] = layer
         return layers
 
-    def print_table_list(self, do_json=False):
+    def print_table_list(self, *, do_json=False):
         names = {}
         for table_name, ogrlayer in self.get_tables().items():
             try:
@@ -256,8 +256,8 @@ class OgrTableImportSource(TableImportSource):
             dump_json_output({"kart.tables/v1": names}, sys.stdout)
         else:
             click.secho(f"Tables found:", bold=True)
-            for table_name, pretty_name in names.items():
-                click.echo(f"  {table_name} - {pretty_name}")
+            for i, (table_name, pretty_name) in enumerate(names.items(), 1):
+                click.echo(f"{i}. {table_name} - {pretty_name}")
         return names
 
     def __str__(self):

--- a/kart/tabular/sqlalchemy_import_source.py
+++ b/kart/tabular/sqlalchemy_import_source.py
@@ -157,17 +157,17 @@ class SqlAlchemyTableImportSource(TableImportSource):
         else:
             return tables
 
-    def print_table_list(self, do_json=False):
+    def print_table_list(self, *, do_json=False):
         tables = self.get_tables()
         if do_json:
             dump_json_output({"kart.tables/v1": tables}, sys.stdout)
         else:
             click.secho("Tables found:", bold=True)
-            for table_name, title in tables.items():
+            for i, (table_name, title) in enumerate(tables.items(), 1):
                 if title:
-                    click.echo(f"  {table_name} - {title}")
+                    click.echo(f"{i}. {table_name} - {title}")
                 else:
-                    click.echo(f"  {table_name}")
+                    click.echo(f"{i}. {table_name}")
         return tables
 
     def validate_table(self, table):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -101,7 +101,7 @@ def test_import_table_with_prompt(data_archive_readonly, tmp_path, cli_runner, c
             assert r.exit_code == 0, r
         assert "Tables found:" in r.stdout
         assert (
-            "  census2016_sdhca_ot_ced_short - census2016_sdhca_ot_ced_short"
+            "1. census2016_sdhca_ot_ced_short - census2016_sdhca_ot_ced_short"
             in r.stdout
         )
         assert "to census2016_sdhca_ot_ced_short/ ..." in r.stdout
@@ -174,7 +174,7 @@ def test_import_table_with_prompt_with_no_input(
             assert r.exit_code == NO_TABLE, r
         assert "Tables found:" in r.stdout
         assert (
-            "  census2016_sdhca_ot_ced_short - census2016_sdhca_ot_ced_short"
+            "1. census2016_sdhca_ot_ced_short - census2016_sdhca_ot_ced_short"
             in r.stdout
         )
         assert "No table specified" in r.stderr


### PR DESCRIPTION

## Description

When importing from a database containing multiple tables, this gives you the option of choosing a table to import numerically, so that you don't have to type out the name of the table.

This is backwards compatible; table names are still accepted

⚠️ I made this change using AI (while trying out http://codebuff.com/ ). (But I have reviewed it myself and it seems correct)

## Related links:


Fixes #881


## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
