### PR TITLE
Add kart diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 - Upgrade to PDAL 2.7 [#1005](https://github.com/koordinates/kart/pull/1005)
 - Adds a `--drop-empty-geometry-features` option to `kart export`. [#1007](https://github.com/koordinates/kart/pull/1007)
+- Adds diagnostic output to Kart when `KART_DIAGNOSTICS=1` environment variable is set. [#1013](https://github.com/koordinates/kart/pull/1013)
 
 ## 0.15.3
 

--- a/kart/__init__.py
+++ b/kart/__init__.py
@@ -15,6 +15,7 @@ import os
 import platform
 import sys
 
+
 L = logging.getLogger("kart.__init__")
 
 # These env vars are retained in the helper process, rather than being clobbered
@@ -165,6 +166,15 @@ osr.UseExceptions()
 
 # Libgit2 options
 import pygit2  # noqa
+
+try:
+    if "KART_DIAGNOSTICS" in os.environ or pygit2.Config.get_global_config()["kart.diagnostics"]:
+        from kart.diagnostics import print_diagnostics
+
+        print_diagnostics()
+except:
+    pass
+
 
 pygit2.option(pygit2.GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION, 0)
 

--- a/kart/base_dataset.py
+++ b/kart/base_dataset.py
@@ -124,7 +124,7 @@ class BaseDataset(DatasetDiffMixin, metaclass=BaseDatasetMetaClass):
         # the same as any other unsupported dataset.
         capabilities = self.get_meta_item("capabilities.json", missing_ok=True)
         if capabilities is not None:
-            from .cli import get_version
+            from .version import get_version
             from .output_util import dump_json_output
 
             click.echo(

--- a/kart/cli.py
+++ b/kart/cli.py
@@ -15,6 +15,7 @@ import click
 import pygit2
 
 from . import core, is_darwin, is_linux, is_windows  # noqa
+from kart.version import get_version_info_text
 from kart.cli_util import (
     add_help_subcommand,
     call_and_exit_flag,
@@ -78,82 +79,8 @@ def load_all_commands():
         _load_commands_from_module(mod)
 
 
-def get_version():
-    import kart
-
-    with open(Path(kart.package_data_path) / "VERSION") as version_file:
-        return version_file.read().strip()
-
-
-def get_version_tuple():
-    return tuple(get_version().split("."))
-
-
 def print_version(ctx):
-    import osgeo
-    import psycopg2
-    import pysqlite3
-
-    import sqlalchemy
-    from kart.sqlalchemy.gpkg import Db_GPKG
-
-    click.echo(f"Kart v{get_version()}, Copyright (c) Kart Contributors")
-
-    git_version = (
-        subprocess.check_output(["git", "--version"])
-        .decode("ascii")
-        .strip()
-        .split()[-1]
-    )
-
-    gitlfs_version = re.match(
-        r"git-lfs/([^ ]+) \(",
-        subprocess.check_output(["git-lfs", "version"], text=True),
-    ).group(1)
-
-    pdal_version = (
-        subprocess.check_output(["pdal", "--version"])
-        .decode("ascii")
-        .strip()
-        .split()[2]
-    )
-
-    engine = Db_GPKG.create_engine(":memory:")
-    with engine.connect() as conn:
-        spatialite_version = conn.scalar("SELECT spatialite_version();")
-
-    pq_version = psycopg2.__libpq_version__
-    pq_version = "{}.{}.{}".format(
-        *[int(k) for k in re.findall(r"\d\d", str(psycopg2.__libpq_version__))]
-    )
-
-    proj_version = "{}.{}.{}".format(
-        osgeo.osr.GetPROJVersionMajor(),
-        osgeo.osr.GetPROJVersionMinor(),
-        osgeo.osr.GetPROJVersionMicro(),
-    )
-
-    click.echo(
-        (
-            f"» GDAL v{osgeo._gdal.__version__}; "
-            f"PROJ v{proj_version}; "
-            f"PDAL v{pdal_version}\n"
-            f"» PyGit2 v{pygit2.__version__}; "
-            f"Libgit2 v{pygit2.LIBGIT2_VERSION}; "
-            f"Git v{git_version}; "
-            f"Git LFS v{gitlfs_version}\n"
-            f"» SQLAlchemy v{sqlalchemy.__version__}; "
-            f"pysqlite3 v{pysqlite3.version}/v{pysqlite3.sqlite_version}; "
-            f"SpatiaLite v{spatialite_version}; "
-            f"Libpq v{pq_version}"
-        )
-    )
-
-    # report on whether this was run through helper mode
-    helper_pid = os.environ.get("KART_HELPER_PID")
-    if helper_pid:
-        click.echo(f"Executed via helper, SID={os.getsid(0)} PID={helper_pid}")
-
+    click.echo("\n".join(get_version_info_text()))
     ctx.exit()
 
 

--- a/kart/diagnostics.py
+++ b/kart/diagnostics.py
@@ -1,0 +1,92 @@
+from datetime import datetime
+import os
+from pathlib import Path
+import platform
+import re
+import shlex
+import sys
+
+def win_quote(arg, force=False):
+    if force or re.search(r'["\s^&|<>]', arg):
+        arg = arg.replace('"', '""')
+        return f'"{arg}"'
+    return arg
+
+def get_executable_path():
+    def good_executable_path(exe_path):
+        return ("kart" in os.path.basename(exe_path), os.path.isabs(exe_path))
+
+    return max(sys.executable, sys.argv[0], key=good_executable_path)
+
+def print_diagnostics():
+    if platform.system() == "Windows":
+        quote = win_quote
+    else:
+        quote = shlex.quote
+
+    output = ["==== KART DIAGNOSTICS ===="]
+
+    try:
+        from kart.version import get_version_info_text
+
+        output += get_version_info_text()
+    except:
+        raise
+
+    cmd = [get_executable_path()] + sys.argv[1:]
+    cmd = " ".join(quote(c) for c in cmd)
+    output.append("\n==== COMMAND ====")
+    output.append(cmd)
+
+    output.append("\n==== PROCESS ====")
+    other_info = {
+        "now": str(datetime.now()),
+        "ppid": os.getppid(),
+        "sid": os.getsid(0),
+        "kart_helper_pid": os.environ.get("KART_HELPER_PID"),
+        "pid": os.getpid(),
+    }
+    output.append(repr(other_info))
+
+    environ = dict(sorted(os.environ.items()))
+    output.append("\n==== ENVIRONMENT ====")
+    output.append("(as python dict)")
+    output.append(repr(environ))
+
+    # Manually setting this variable crashes zsh for some reason, so, we won't put it in the standalone command
+    environ.pop("XPC_SERVICE_NAME", None)
+
+    if platform.system() == "Windows":
+        # Powershell syntax
+        ps_env_vars = "; ".join(
+            f"${{env:{key}}}={win_quote(value, force=True)}"
+            for key, value in environ.items()
+        )
+        output.append("\n==== STANDALONE POWERSHELL COMMAND ====")
+        output.append(f"{ps_env_vars}; & {cmd}")
+
+        # CMD syntax
+        cmd_env_vars = " && ".join(
+            "set " + win_quote(f"{key}={value}", force=True)
+            for key, value in environ.items()
+        )
+        output.append("\n==== STANDALONE CMD COMMAND ====")
+        output.append(f"{cmd_env_vars} && {cmd}")
+    else:
+        # Linux / macOS syntax
+        env_vars = " ".join(
+            f"{shlex.quote(key)}={quote(value)}"
+            for key, value in environ.items()
+        )
+        standalone_cmd = f"{env_vars} {cmd}"
+        output.append("\n==== STANDALONE COMMAND ====")
+        output.append(standalone_cmd)
+
+    output.append("\n==== END DIAGNOSTICS ====\n\n")
+
+    output = "\n".join(output)
+    print(output, file=sys.stderr)
+    try:
+        Path(os.path.expanduser("~"), "kart-diagnostics.txt").write_text(output)
+    except:
+        pass

--- a/kart/tabular/version.py
+++ b/kart/tabular/version.py
@@ -100,7 +100,7 @@ def dataset_class_for_version(version):
 
 
 def ensure_supported_repo_wide_version(version):
-    from kart.cli import get_version
+    from kart.version import get_version
 
     if not MIN_SUPPORTED_VERSION <= version <= MAX_SUPPORTED_VERSION:
         message = (

--- a/kart/version.py
+++ b/kart/version.py
@@ -1,0 +1,82 @@
+import click
+import os
+from pathlib import Path
+import re
+from kart import subprocess_util as subprocess
+
+
+def get_version():
+    import kart
+
+    with open(Path(kart.package_data_path) / "VERSION") as version_file:
+        return version_file.read().strip()
+
+
+def get_version_tuple():
+    return tuple(get_version().split("."))
+
+
+def get_version_info_text():
+    import osgeo
+    import psycopg2
+    import pysqlite3
+    import pygit2
+    import sqlalchemy
+    from kart.sqlalchemy.gpkg import Db_GPKG
+
+    output = [f"Kart v{get_version()}, Copyright (c) Kart Contributors"]
+
+    git_version = (
+        subprocess.check_output(["git", "--version"])
+        .decode("ascii")
+        .strip()
+        .split()[-1]
+    )
+
+    gitlfs_version = re.match(
+        r"git-lfs/([^ ]+) \(",
+        subprocess.check_output(["git-lfs", "version"], text=True),
+    ).group(1)
+
+    pdal_version = (
+        subprocess.check_output(["pdal", "--version"])
+        .decode("ascii")
+        .strip()
+        .split()[2]
+    )
+
+    engine = Db_GPKG.create_engine(":memory:")
+    with engine.connect() as conn:
+        spatialite_version = conn.scalar("SELECT spatialite_version();")
+
+    pq_version = psycopg2.__libpq_version__
+    pq_version = "{}.{}.{}".format(
+        *[int(k) for k in re.findall(r"\d\d", str(psycopg2.__libpq_version__))]
+    )
+
+    proj_version = "{}.{}.{}".format(
+        osgeo.osr.GetPROJVersionMajor(),
+        osgeo.osr.GetPROJVersionMinor(),
+        osgeo.osr.GetPROJVersionMicro(),
+    )
+
+    output += [
+        f"» GDAL v{osgeo._gdal.__version__}; "
+        f"PROJ v{proj_version}; "
+        f"PDAL v{pdal_version}",
+        f"» PyGit2 v{pygit2.__version__}; "
+        f"Libgit2 v{pygit2.LIBGIT2_VERSION}; "
+        f"Git v{git_version}; "
+        f"Git LFS v{gitlfs_version}",
+        f"» SQLAlchemy v{sqlalchemy.__version__}; "
+        f"pysqlite3 v{pysqlite3.version}/v{pysqlite3.sqlite_version}; "
+        f"SpatiaLite v{spatialite_version}; "
+        f"Libpq v{pq_version}"
+    ]
+
+    # report on whether this was run through helper mode
+    helper_pid = os.environ.get("KART_HELPER_PID")
+    if helper_pid:
+        output.append(f"Executed via helper, SID={os.getsid(0)} PID={helper_pid}")
+
+    return output

--- a/scripts/doc_gen.py
+++ b/scripts/doc_gen.py
@@ -98,7 +98,7 @@ class Doc:
     INDENT = ""
 
     def __init__(self, ctx: click.Context, doc: t.Optional[str] = None) -> None:
-        from kart.cli import get_version
+        from kart.version import get_version
 
         self.command = ctx.command_path
         self.version = get_version()

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from kart.cli import get_version
+from kart.version import get_version
 from kart.exceptions import UNSUPPORTED_VERSION
 from kart.repo import KartRepo
 


### PR DESCRIPTION
Most useful for when Kart is being run as a plugin: gives diagnostic output about the environment in which Kart was run, such that any issues can be reproduced when running kart from the command line.

Enable kart diagnostics:
set `KART_DIAGNOSTICS=1` in the environment.
or set 
```
[kart]
    diagnostics = true
``` 
in your gitconfig.

Find the diagnostics:
Kart outputs it to stderr and to $HOME/kart-diagnostics.txt

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
