### PR TITLE
merge: Add `--into <ref>`

### DIFF
--- a/kart/apply.py
+++ b/kart/apply.py
@@ -275,7 +275,7 @@ def apply_patch(
     if ref != "HEAD":
         if not do_commit:
             raise click.UsageError("--no-commit and --ref are incompatible")
-        if not ref.startswith("refs/heads/"):
+        if not ref.startswith("refs/"):
             ref = f"refs/heads/{ref}"
         try:
             repo.references[ref]


### PR DESCRIPTION
## Description

Adds the ability to merge into a branch that isn't pointed at by HEAD. This makes the merge command more machine-friendly.

Makes it easier to provide an API for merging branches, that doesn't require first checking out the target branch.

In case of conflict we avoid putting the repo in a 'merging' state, as would happen when merging to HEAD. Additionally I have added the `--fail-on-conflict` option, which revives the `MERGE_CONFLICT` exit code rather than exiting with code 0.

There is currently no way to resolve conflicts during such a merge.
## Related links:

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
