### PR TITLE
merge: Don't output commit message when merging ancestor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Upgrade to PDAL 2.7 [#1005](https://github.com/koordinates/kart/pull/1005)
 - Adds a `--drop-empty-geometry-features` option to `kart export`. [#1007](https://github.com/koordinates/kart/pull/1007)
 - Adds diagnostic output to Kart when `KART_DIAGNOSTICS=1` environment variable is set. [#1013](https://github.com/koordinates/kart/pull/1013)
+- In `kart merge --output-format=json`, the `message` field is now `null` if the merge is a no-op. [#1021](https://github.com/koordinates/kart/pull/1021)
 
 ## 0.15.3
 

--- a/kart/merge.py
+++ b/kart/merge.py
@@ -102,6 +102,7 @@ def do_merge(
     # We're up-to-date if we're trying to merge our own common ancestor.
     if ancestor_id == theirs.id:
         merge_jdict["noOp"] = True
+        merge_jdict["message"] = None
         return merge_jdict
 
     # "dryRun": True means we didn't actually do this

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -501,3 +501,27 @@ def test_merge_into_branch_with_conflict(data_archive, tmp_path, cli_runner):
             "conflicts": {"nz_pa_points_topo_150k": {"feature": 1}},
             "dryRun": False,
         }
+
+
+def test_merge_ancestor_text(data_archive, cli_runner):
+    with data_archive("points") as repo_path:
+        # merge an ancestor commit
+        r = cli_runner.invoke(["merge", "HEAD^"])
+        assert r.exit_code == 0, r
+
+        # No merge commit is created, because the commit is an ancestor of the target branch
+        assert "Already up to date\n" in r.stdout
+        repo = KartRepo(repo_path)
+        assert repo.head.target.hex == H.POINTS.HEAD_SHA
+
+
+def test_merge_ancestor_json(data_archive, cli_runner):
+    with data_archive("points") as repo_path:
+        repo = KartRepo(repo_path)
+        # new branch
+        r = cli_runner.invoke(["merge", "--output-format=json", "HEAD^"])
+        assert r.exit_code == 0, r
+        output = json.loads(r.stdout)["kart.merge/v1"]
+
+        assert output["noOp"]
+        assert output["message"] is None


### PR DESCRIPTION

## Description

When attempting to merge an ancestor of the current HEAD, no changes are made. However, `kart merge -o json` will output a commit message anyway, which is a bit misleading since no commit was made with that message.

This change sets the `message` in the JSON output to `null`

## Related links:

<!-- If you have links to [issues](https://github.com/koordinates/kart/issues) etc, link them here. -->

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
