### PR TITLE
merge: Fix errors when setting author/committer from env vars

### DIFF
--- a/kart/merge.py
+++ b/kart/merge.py
@@ -161,7 +161,6 @@ def do_merge(
         merge_tree_id = index.write_tree(repo, write_merged_index_flags(repo))
         L.debug(f"Merge tree: {merge_tree_id}")
 
-        user = repo.default_signature
         if not message:
             message = get_commit_message(
                 merge_context,
@@ -170,10 +169,11 @@ def do_merge(
                 launch_editor=launch_editor,
                 quiet=quiet,
             )
+
         merge_commit_id = repo.create_commit(
             ours.reference.name,
-            user,
-            user,
+            repo.author_signature(),
+            repo.committer_signature(),
             message,
             merge_tree_id,
             [ours.id, theirs.id],


### PR DESCRIPTION
## Description

I found an exception when trying to run `kart merge` with the author/committer set via env vars:

```
$ GIT_AUTHOR_NAME=a GIT_AUTHOR_EMAIL=a@example.com kart merge --no-ff --into=refs/heads/main --fail-on-conflict --output-format=json 3972f9fbe477575ec1169070ab849bf261b82fb0
kart helper: unhandled exception
Traceback (most recent call last):
  File "kart/helper.py", line 240, in helper
  File "click/core.py", line 1157, in __call__
  File "click/core.py", line 1078, in main
  File "kart/cli_util.py", line 72, in invoke
  File "click/core.py", line 1688, in invoke
  File "click/core.py", line 1434, in invoke
  File "click/core.py", line 783, in invoke
  File "click/decorators.py", line 33, in new_func
  File "kart/merge.py", line 403, in merge
  File "kart/merge.py", line 163, in do_merge
KeyError: "config value 'user.name' was not found"
```

This change fixes the issue and adds a test.

## Related links:

<!-- If you have links to [issues](https://github.com/koordinates/kart/issues) etc, link them here. -->

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
