### PR TITLE
msgspec - faster tabular dataset access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## Unreleased
 
+- Much faster access to tabular/vector datasets (about 75% more features processed per second) by switching to [msgspec](https://jcristharif.com/msgspec/) - [#1025](https://github.com/koordinates/kart/pull/1025)
+- diff: Faster JSON-Lines output (also using msgspec)
 - Linux builds now require glibc 2.28+ [#1027](https://github.com/koordinates/kart/pull/1027) - This means minimum distro versions are:
     - Debian 10+
     - Ubuntu 18.10+
     - Fedora 29+
     - RHEL/Rocky/AlmaLinux 8+
-- Much faster access to tabular/vector datasets (about 75% more features processed per second) by switching to [msgspec](https://jcristharif.com/msgspec/) - [#1025](https://github.com/koordinates/kart/pull/1025)
-- diff: Faster JSON-Lines output (also using msgspec)
 - Upgrade to PDAL 2.7 [#1005](https://github.com/koordinates/kart/pull/1005)
 - Adds a `--drop-empty-geometry-features` option to `kart export`. [#1007](https://github.com/koordinates/kart/pull/1007)
 - Adds diagnostic output to Kart when `KART_DIAGNOSTICS=1` environment variable is set. [#1013](https://github.com/koordinates/kart/pull/1013)

--- a/kart/serialise_util.py
+++ b/kart/serialise_util.py
@@ -4,7 +4,7 @@ import json
 import logging
 import struct
 
-import msgpack
+from msgspec import msgpack as _msgpack
 
 from kart.geometry import Geometry
 
@@ -16,35 +16,26 @@ _EXTENSION_G = ord("G")
 
 def _msg_pack_default(obj):
     if isinstance(obj, Geometry):
-        return msgpack.ExtType(_EXTENSION_G, bytes(obj))
+        return _msgpack.Ext(_EXTENSION_G, bytes(obj))
     if isinstance(obj, tuple):
         return list(obj)
-    return obj
+    raise NotImplementedError
 
 
-def _msg_unpack_ext_hook(code, data):
+def _msg_unpack_ext_hook(code: int, data: memoryview):
     if code == _EXTENSION_G:
         return Geometry.of(data)
     else:
         L.warning("Unexpected msgpack extension: %d", code)
-        return msgpack.ExtType(code, data)
+        return _msgpack.Ext(code, data)
 
 
-def msg_pack(data):
-    """data (any type) -> bytes"""
-    return msgpack.packb(
-        data,
-        use_bin_type=True,
-        strict_types=True,
-        default=_msg_pack_default,
-    )
+_msgpack_decoder = _msgpack.Decoder(ext_hook=_msg_unpack_ext_hook)
+_msgpack_encoder = _msgpack.Encoder(enc_hook=_msg_pack_default)
 
 
-def msg_unpack(bytestring_or_memoryview):
-    """bytes/memoryview -> data (any type)"""
-    return msgpack.unpackb(
-        bytestring_or_memoryview, raw=False, ext_hook=_msg_unpack_ext_hook
-    )
+msg_pack = _msgpack_encoder.encode
+msg_unpack = _msgpack_decoder.decode
 
 
 # json_pack and json_unpack have the same signature and capabilities as msg_pack and msg_unpack,

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -3,7 +3,6 @@ certifi
 click~=8.1.7
 docutils<0.18
 msgspec~=0.18.6
-orjson
 Pygments
 pymysql
 rst2txt

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -2,7 +2,7 @@ boto3>=1.29.1
 certifi
 click~=8.1.7
 docutils<0.18
-msgpack~=0.6.1
+msgspec~=0.18.6
 orjson
 Pygments
 pymysql

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -38,8 +38,6 @@ jsonschema==4.17.3
     # via -r requirements.in
 msgspec==0.18.6
     # via -r requirements.in
-orjson==3.10.11
-    # via -r requirements.in
 #psycopg2==2.9.9
     # via -r requirements/vendor-wheels.txt
 pycparser==2.21

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -36,7 +36,7 @@ jmespath==1.0.1
     #   botocore
 jsonschema==4.17.3
     # via -r requirements.in
-msgpack==0.6.2
+msgspec==0.18.6
     # via -r requirements.in
 orjson==3.10.11
     # via -r requirements.in


### PR DESCRIPTION
## Description

* Fixes #1018 
* supersedes #1019
* relies on #1027


On a large repo this change causes a 75% increase in throughput (in addition to previous gains from #1019) when generating a large JSONL diff via:
```
time kart diff '[EMPTY]...HEAD' -o json-lines | pv > /dev/null
```

* orjson, msgpack: 16.7 MiB/s
* orjson, msgspec: 28.3 MiB/s
* msgspec only (for both msgpack+json): 29.4 MiB/s <-- **this PR**

## Related links:

<!-- If you have links to [issues](https://github.com/koordinates/kart/issues) etc, link them here. -->

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
