### PR TITLE
vendor python/ffi build fixes

### DIFF
--- a/vcpkg-vendor/CMakeLists.txt
+++ b/vcpkg-vendor/CMakeLists.txt
@@ -105,7 +105,7 @@ endif()
 #
 # cffi wheel
 #
-find_package(libffi REQUIRED)
+find_package(unofficial-libffi CONFIG REQUIRED)
 
 file(
   GENERATE
@@ -124,7 +124,7 @@ ExternalProject_Add(
   URL_HASH SHA256=bcb3ef43e58665bbda2fb198698fcae6776483e0c4a631aa5647806c25e02cc0
   DOWNLOAD_NO_PROGRESS ON
   BUILD_IN_SOURCE ON
-  DEPENDS wheelBuildEnv libffi
+  DEPENDS wheelBuildEnv unofficial::libffi::libffi
   EXCLUDE_FROM_ALL ON
   BUILD_BYPRODUCTS "<SOURCE_DIR>/build"
   CONFIGURE_COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/cffi-prefix/setup.cfg

--- a/vcpkg-vendor/CMakeLists.txt
+++ b/vcpkg-vendor/CMakeLists.txt
@@ -241,6 +241,8 @@ list(APPEND WHEEL_LIST ${INSTALL_DIR}/psycopg2-${PYSCOPG2_WHEEL_VER}-${Python3_W
 # pygit2 wheel
 #
 find_package(unofficial-git2 CONFIG REQUIRED)
+createvirtualenvironment(pygitWheelBuildEnv REQUIREMENTS wheel ${CFFI_WHEEL})
+add_dependencies(pygitWheelBuildEnv cffi)
 
 file(
   GENERATE
@@ -258,14 +260,14 @@ ExternalProject_Add(
   GIT_TAG kart-v0.14.1
   GIT_SHALLOW ON
   BUILD_IN_SOURCE ON
-  DEPENDS wheelBuildEnv unofficial::git2::libgit2package
+  DEPENDS pygitWheelBuildEnv unofficial::git2::libgit2package
   EXCLUDE_FROM_ALL ON
   BUILD_BYPRODUCTS "<SOURCE_DIR>/build"
   CONFIGURE_COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/pygit2-prefix/setup.cfg
                     <SOURCE_DIR>
   BUILD_COMMAND ${CMAKE_COMMAND} -E rm -rf <INSTALL_DIR>/*.whl <TMP_DIR>/dist <SOURCE_DIR>/.eggs
-  COMMAND ${CMAKE_COMMAND} -E env LIBGIT2=${CURRENT_PACKAGES_DIR} -- ${wheelBuildEnv_PYTHON} -m
-          build --wheel --outdir <TMP_DIR>/dist
+  COMMAND ${CMAKE_COMMAND} -E env LIBGIT2=${CURRENT_PACKAGES_DIR} -- ${pygitWheelBuildEnv_PYTHON} -m
+          build --wheel --no-isolation --outdir <TMP_DIR>/dist
   INSTALL_COMMAND ${CMAKE_COMMAND} -E copy
                   <TMP_DIR>/dist/pygit2-${PYGIT2_WHEEL_VER}-${Python3_WHEEL_ID}.whl <INSTALL_DIR>)
 ExternalProject_Get_Property(pygit2 INSTALL_DIR)
@@ -382,6 +384,9 @@ list(APPEND WHEEL_LIST
 # reflink wheel
 #
 
+createvirtualenvironment(reflinkWheelBuildEnv REQUIREMENTS wheel ${CFFI_WHEEL} pytest-runner)
+add_dependencies(reflinkWheelBuildEnv cffi)
+
 set(REFLINK_WHEEL_VER 0.2.2)
 ExternalProject_Add(
   reflink
@@ -389,12 +394,12 @@ ExternalProject_Add(
   URL_HASH SHA256=882375ee7319275ae5f6a6a1287406365dac1e9643b91ad10e5187d3f84253bd
   DOWNLOAD_NO_PROGRESS ON
   BUILD_IN_SOURCE ON
-  DEPENDS wheelBuildEnv
+  DEPENDS reflinkWheelBuildEnv
   EXCLUDE_FROM_ALL ON
   BUILD_BYPRODUCTS "<SOURCE_DIR>/build"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ${CMAKE_COMMAND} -E rm -rf <INSTALL_DIR>/*.whl
-  COMMAND ${wheelBuildEnv_PYTHON} -m build --wheel --outdir <TMP_DIR>/dist
+  COMMAND ${reflinkWheelBuildEnv_PYTHON} -m build --wheel --no-isolation --outdir <TMP_DIR>/dist
   INSTALL_COMMAND ${CMAKE_COMMAND} -E copy
                   <TMP_DIR>/dist/reflink-${REFLINK_WHEEL_VER}-${Python3_WHEEL_ID}.whl <INSTALL_DIR>)
 ExternalProject_Get_Property(reflink INSTALL_DIR)


### PR DESCRIPTION
## Description

Follow-up to #1027.

Fix Python packages (reflink, pygit2) depending on cffi, but not using the one we're building.

Previously:
```
[ 18%] No configure step for 'reflink'
[ 19%] Performing build step for 'reflink'
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - setuptools >= 40.8.0
* Getting build dependencies for wheel...
* Installing packages in isolated environment:
  - cffi
  - pytest-runner
* Building wheel...
...snip...
[ 37%] Performing configure step for 'pygit2'
[ 39%] Performing build step for 'pygit2'
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - setuptools
  - wheel
* Getting build dependencies for wheel...
* Installing packages in isolated environment:
  - cffi>=1.9.1
* Building wheel...
```

Now:
```
[ 11%] reflinkWheelBuildEnv: creating virtualenv at /Users/rcoup/code/kart/build/vcpkg-vendor/reflinkWheelBuildEnv...
[ 12%] reflinkWheelBuildEnv: installing requirements...
...snip...
Processing ./cffi-prefix/cffi-1.16.0-cp312-cp312-macosx_14_0_arm64.whl
...snip...
Successfully installed cffi-1.16.0 pycparser-2.22 pytest-runner-6.0.1 wheel-0.45.1
[ 13%] VirtualEnv: reflinkWheelBuildEnv
[ 13%] Built target reflinkWheelBuildEnv
[ 14%] Creating directories for 'reflink'
[ 15%] Performing download step (download, verify and extract) for 'reflink'
...snip...
[ 17%] No update step for 'reflink'
[ 17%] No patch step for 'reflink'
[ 18%] No configure step for 'reflink'
[ 18%] Performing build step for 'reflink'
* Getting build dependencies for wheel...
* Building wheel...

...snip...

[ 37%] pygitWheelBuildEnv: creating virtualenv at /Users/rcoup/code/kart/build/vcpkg-vendor/pygitWheelBuildEnv...
[ 38%] pygitWheelBuildEnv: installing requirements...
...snip...
Processing ./cffi-prefix/cffi-1.16.0-cp312-cp312-macosx_14_0_arm64.whl
...snip...
Successfully installed cffi-1.16.0 pycparser-2.22 wheel-0.45.1
[ 38%] VirtualEnv: pygitWheelBuildEnv
[ 38%] Built target pygitWheelBuildEnv
[ 39%] Creating directories for 'pygit2'
[ 39%] Performing download step (git clone) for 'pygit2'
Cloning into 'pygit2'...
HEAD is now at b4f7317 Add Index.add_entry_with_custom_stat
[ 40%] Performing update step for 'pygit2'
[ 42%] No patch step for 'pygit2'
[ 43%] Performing configure step for 'pygit2'
[ 44%] Performing build step for 'pygit2'
* Getting build dependencies for wheel...
* Building wheel...
```

## Related links:

#1027 

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
