### PR TITLE
diff: Fix error diffing WC against commit with a since-deleted dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Please note that compatibility for 0.x releases (software or repositories) isn't
 _When adding new entries to the changelog, please include issue/PR numbers wherever possible._
 
 
+## Unreleased
+
+- diff: Fix an error when diffing a commit against the working copy, where a dataset has been deleted since the commit. [#1033](https://github.com/koordinates/kart/issues/1033)
+
 ## 0.16.0
 
 - Much faster access to tabular/vector datasets (about 75% more features processed per second) by switching to [msgspec](https://jcristharif.com/msgspec/) - [#1025](https://github.com/koordinates/kart/pull/1025)

--- a/kart/diff_util.py
+++ b/kart/diff_util.py
@@ -137,10 +137,10 @@ def get_dataset_diff(
 
     if include_wc_diff:
         # diff += target_ds<>working_copy
-        if workdir_diff_cache is None:
-            workdir_diff_cache = target_ds.repo.working_copy.workdir_diff_cache()
-
+        # note: target_ds may be None if the dataset as deleted between the base & target commits
         if target_ds is not None:
+            if workdir_diff_cache is None:
+                workdir_diff_cache = target_ds.repo.working_copy.workdir_diff_cache()
             target_wc_diff = target_ds.diff_to_working_copy(
                 workdir_diff_cache,
                 ds_filter=ds_filter,

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1267,6 +1267,22 @@ def test_diff_rev_wc(data_working_copy, cli_runner):
         }
 
 
+def test_diff_rev_wc_with_deleted_dataset(data_working_copy, cli_runner):
+    """
+    Diff the working copy against a commit, where a dataset has been deleted since the commit
+    """
+
+    with data_working_copy("points") as (repo_path, wc):
+        r = cli_runner.invoke(
+            ["data", "rm", "nz_pa_points_topo_150k", "--message=destroy"]
+        )
+        assert r.exit_code == 0, r.stderr
+
+        r = cli_runner.invoke(["diff", "HEAD^"])
+        assert r.exit_code == 0, r.stderr
+        assert "--- nz_pa_points_topo_150k:meta:schema.json" in r.stdout
+
+
 @pytest.mark.parametrize("output_format", ["text", "json"])
 def test_3d_diff_wc(data_archive, cli_runner, tmp_path, output_format):
     with data_archive("gpkg-3d-points") as src:


### PR DESCRIPTION

## Description

If you delete a dataset, and then attempt to do a diff between a workingcopy and a commit with that dataset in, `diff` throws an exception:

```
AttributeError: 'NoneType' object has no attribute 'repo'
```

This change fixes the exception and adds a regression test

## Related links:

<!-- If you have links to [issues](https://github.com/koordinates/kart/issues) etc, link them here. -->

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
