### PR TITLE
Fix an error with reprojected diffs in non-text output

### DIFF
--- a/kart/diff_structs.py
+++ b/kart/diff_structs.py
@@ -522,13 +522,13 @@ class DeltaDiff(Diff):
             for k, v in self._lazy_initial_contents:
                 yield (k, v)
 
-        # Invalidate this DeltaDiff; it's not safe to consume it again after this.
-        # `data` is the underlying contents of UserDict, which we inherit from.
-        # So overriding it to a non-dict will cause all dict methods to raise exceptions.
-        #    > TypeError: argument of type 'InvalidatedDeltaDiff' is not iterable
-        self.data = InvalidatedDeltaDiff(
-            "DeltaDiff can't be used after iter_items() has been called"
-        )
+            # Invalidate this DeltaDiff; it's not safe to consume it again after this.
+            # `data` is the underlying contents of UserDict, which we inherit from.
+            # So overriding it to a non-dict will cause all dict methods to raise exceptions.
+            #    > TypeError: argument of type 'InvalidatedDeltaDiff' is not iterable
+            self.data = InvalidatedDeltaDiff(
+                "DeltaDiff can't be used after iter_items() has been called"
+            )
 
     def keys(self):
         """

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -419,6 +419,31 @@ def test_diff_reprojection(output_format, data_working_copy, cli_runner):
             _check_geojson(odata["nz_pa_points_topo_150k"])
 
 
+def test_diff_nontext_reprojection_no_sort_keys(data_archive, cli_runner):
+    """
+    Regression test.
+    Non-text diff writers need to lookup CRS when doing reprojection, and they do so by
+    checking whether the CRS has changed in the diff.
+
+    When --no-sort-keys is given, it's possible for the meta deltas to be lazy, and if so then
+    the diff writer will fail to find the CRS in the diff.
+    This was fixed by making the meta deltas non-lazy. This test checks that it doesn't regress.
+    """
+    with data_archive("points") as repo_path:
+        r = cli_runner.invoke(
+            [
+                "diff",
+                f"--output-format=json-lines",
+                "--output=-",
+                f"--crs=epsg:2193",
+                "--no-sort-keys",
+                "[EMPTY]...",
+            ]
+        )
+
+        assert r.exit_code == 0, r.stderr
+
+
 def test_show_crs_with_aspatial_dataset(data_archive, cli_runner):
     """
     --crs should be ignored when used with aspatial data


### PR DESCRIPTION
## Description
Non-text diff writers need to lookup CRS when doing reprojection, and they do so by checking whether the CRS has changed in the diff.

When --no-sort-keys is given, the meta deltas DeltaDiff is treated as lazy. Then the diff writer will fail to find the CRS in the diff.

This change fixes the issue by making the DeltaDiff.iter_items() method only invalidate the diff if the diff was actually lazily populated, and adds a regression test

no changelog needed since this is a new bug introduced in #1032 

## Related links:


## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
