### PR TITLE
mssql: Support custom CRSs by maintaining OGR convention tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 - diff: Much faster and much lower memory usage when using `--no-sort-keys` [#1032](https://github.com/koordinates/kart/pull/1032)
 - diff: Fix an error when diffing a commit against the working copy, where a dataset has been deleted since the commit. [#1033](https://github.com/koordinates/kart/issues/1033)
+- Custom CRS support in MSSQL server - OGR conventions are used to store custom CRSs in a `spatial_ref_sys` table. [#1036](https://github.com/koordinates/kart/pull/1036)
 
 ## 0.16.0
 

--- a/kart/crs_util.py
+++ b/kart/crs_util.py
@@ -1,3 +1,4 @@
+import re
 from osgeo import osr
 
 from .cli_util import StringFromFile
@@ -197,7 +198,15 @@ def get_identifier_int_from_dataset(dataset, crs_name=None):
         return None
 
     definition = dataset.get_crs_definition(crs_name)
-    return get_identifier_int(definition)
+    if definition:
+        return get_identifier_int(definition)
+
+    # No CRS is actually attached to the dataset - all we have is the CRS name/number, we don't know where to find it.
+    match = re.fullmatch(r"[^:]+:(\d+)", crs_name)
+    if match:
+        return int(match.group(1))
+
+    return None
 
 
 def wkt_equal(wkt1, wkt2):

--- a/kart/sqlalchemy/__init__.py
+++ b/kart/sqlalchemy/__init__.py
@@ -161,6 +161,15 @@ def separate_last_path_part(uri):
     return (modified_url, last_part)
 
 
+def get_path_part(uri, index):
+    """
+    Returns a specified part of the path for a URI by integer index
+    - ie, 0 for the first part, or -1 for the last part.
+    """
+    url = urlsplit(uri)
+    return PurePosixPath(url.path).relative_to("/").parts[index]
+
+
 def text_with_inlined_params(text, params):
     """
     Uses sqlalchemy feature bindparam(literal_execute=True)

--- a/kart/sqlalchemy/adapter/sqlserver.py
+++ b/kart/sqlalchemy/adapter/sqlserver.py
@@ -296,7 +296,7 @@ class KartAdapter_SqlServer(BaseKartAdapter, Db_SqlServer):
                     break
             else:
                 # Couldn't find any info on the CRS - we don't even know exactly what it's called, but we know the srid.
-                yield column_name, f"NONE:{column_srid}", ""
+                yield column_name, f"CUSTOM:{column_srid}", ""
                 continue
 
             wkt = crs_util.normalise_wkt(

--- a/kart/tabular/working_copy/base.py
+++ b/kart/tabular/working_copy/base.py
@@ -609,14 +609,15 @@ class TableWorkingCopy(WorkingCopyPart):
         for key in ds_meta_items.keys() & wc_meta_items.keys():
             if not key.startswith("crs/"):
                 continue
-            old_is_standard = self._is_builtin_crs(ds_meta_items[key])
-            new_is_standard = self._is_builtin_crs(wc_meta_items[key])
+            crs_name = key[4:]
+            old_is_standard = self._is_builtin_crs(crs_name, ds_meta_items[key])
+            new_is_standard = self._is_builtin_crs(crs_name, wc_meta_items[key])
             if old_is_standard and new_is_standard:
                 del ds_meta_items[key]
                 del wc_meta_items[key]
             # If either definition is custom, we keep the diff, since it could be important.
 
-    def _is_builtin_crs(self, crs):
+    def _is_builtin_crs(self, crs_name, crs):
         """
         Returns True if this WC implementation has (some definition of) the given CRS stored as a built-in.
         For instance, GPKG would return True if given a definition EPSG:4326, which is built into every GPKG.

--- a/kart/tabular/working_copy/gpkg.py
+++ b/kart/tabular/working_copy/gpkg.py
@@ -397,7 +397,7 @@ class WorkingCopy_GPKG(TableWorkingCopy):
             wc_schema[index]["primaryKeyIndex"] = 0
             return Schema(wc_schema)
 
-    def _is_builtin_crs(self, crs):
+    def _is_builtin_crs(self, crs_name, crs):
         auth_name, auth_code = crs_util.parse_authority(crs)
         return auth_name == "EPSG" and auth_code == "4326"
 

--- a/kart/tabular/working_copy/mysql.py
+++ b/kart/tabular/working_copy/mysql.py
@@ -241,7 +241,7 @@ class WorkingCopy_MySql(DatabaseServer_WorkingCopy):
                 del ds_meta_items[key]
                 del wc_meta_items[key]
 
-    def _is_builtin_crs(self, crs):
+    def _is_builtin_crs(self, crs_name, crs):
         auth_name, auth_code = crs_util.parse_authority(crs)
         return auth_name == "EPSG"
 

--- a/kart/tabular/working_copy/postgis.py
+++ b/kart/tabular/working_copy/postgis.py
@@ -276,7 +276,7 @@ class WorkingCopy_Postgis(DatabaseServer_WorkingCopy):
 
         return new_type == old_type
 
-    def _is_builtin_crs(self, crs):
+    def _is_builtin_crs(self, crs_name, crs):
         auth_name, auth_code = crs_util.parse_authority(crs)
         return auth_name in ("EPSG", "ESRI") or auth_code == "900913"  # GOOGLE
 

--- a/kart/tabular/working_copy/sqlserver.py
+++ b/kart/tabular/working_copy/sqlserver.py
@@ -283,7 +283,10 @@ class WorkingCopy_SqlServer(DatabaseServer_WorkingCopy):
                 [ds_key] = matching_ds_keys
                 del ds_meta_items[ds_key]
 
-    def _is_builtin_crs(self, crs):
+    def _is_builtin_crs(self, crs_name, crs):
+        if crs_name.startswith("CUSTOM") and not crs:
+            # We don't know where this CRS is found, it is definitely not a built-in.
+            return False
         auth_name, auth_code = crs_util.parse_authority(crs)
         return auth_name == "EPSG"
 

--- a/kart/tabular/working_copy/sqlserver.py
+++ b/kart/tabular/working_copy/sqlserver.py
@@ -5,12 +5,14 @@ import time
 from kart import crs_util
 from kart.sqlalchemy import separate_last_path_part, text_with_inlined_params
 from kart.sqlalchemy.adapter.sqlserver import KartAdapter_SqlServer
+from kart.sqlalchemy.upsert import Upsert as upsert
 from kart.schema import Schema
+import sqlalchemy as sa
 from sqlalchemy.dialects.mssql.base import MSIdentifierPreparer  # type: ignore[attr-defined]
 from sqlalchemy.orm import sessionmaker
 
 from .db_server import DatabaseServer_WorkingCopy
-from .table_defs import SqlServerKartTables
+from .table_defs import SqlServerKartTables, SqlServerOgrTables
 
 
 class WorkingCopy_SqlServer(DatabaseServer_WorkingCopy):
@@ -47,6 +49,9 @@ class WorkingCopy_SqlServer(DatabaseServer_WorkingCopy):
         self.preparer = MSIdentifierPreparer(self.engine.dialect)
 
         self.kart_tables = SqlServerKartTables(self.db_schema, repo.is_kart_branded)
+        self.ogr_tables = SqlServerOgrTables(self.db_schema)
+
+        self._is_builtin_srid_cache = {}
 
     def _create_table_for_dataset(self, sess, dataset):
         table_spec = self.adapter.v2_schema_to_sql_spec(dataset.schema, dataset)
@@ -63,8 +68,41 @@ class WorkingCopy_SqlServer(DatabaseServer_WorkingCopy):
         )
 
     def _write_meta(self, sess, dataset):
-        # There is no metadata stored anywhere except the table itself, so nothing to write.
-        pass
+        # If there are any CRSs that the dataset references that are not built into sys.spatial_reference_systems,
+        # we use the OGR conventions and write them to {self.db_schema}.spatial_ref_sys
+
+        ogr_tables = dict(
+            KartAdapter_SqlServer.generate_ogr_tables(
+                dataset, "", self.db_schema, dataset.table_name
+            )
+        )
+        geometry_columns = ogr_tables["geometry_columns"]
+        spatial_ref_sys = ogr_tables["spatial_ref_sys"]
+        if not geometry_columns and not spatial_ref_sys:
+            return
+
+        # Don't write any CRS definitions in the OGR tables if it's already defined as a builtin.
+        srids = set(row["srid"] for row in geometry_columns) | set(
+            row["srid"] for row in spatial_ref_sys
+        )
+        custom_srids = srids - set(self._keep_builtin_srids(srids))
+        if not custom_srids:
+            return
+
+        # We only create these tables if we have a plan to write to them:
+        self.ogr_tables.create_all(sess)
+
+        geometry_columns = [
+            row for row in geometry_columns if row["srid"] in custom_srids
+        ]
+        spatial_ref_sys = [
+            row for row in spatial_ref_sys if row["srid"] in custom_srids
+        ]
+
+        if geometry_columns:
+            sess.execute(upsert(self.ogr_tables.geometry_columns), geometry_columns)
+        if spatial_ref_sys:
+            sess.execute(upsert(self.ogr_tables.spatial_ref_sys), spatial_ref_sys)
 
     def _delete_meta(self, sess, dataset):
         # There is no metadata stored anywhere except the table itself, so nothing to delete.
@@ -251,44 +289,47 @@ class WorkingCopy_SqlServer(DatabaseServer_WorkingCopy):
         # Geometry type loses various extra type info when roundtripped through SQL Server.
         if old_type == new_type == "geometry":
             new_col_dict["geometryType"] = old_col_dict.get("geometryType")
-            new_geometry_crs = new_col_dict.get("geometryCRS", "")
-            # Custom CRS can't be stored in SQL Server - even the CRS authority can't be roundtripped:
-            if new_geometry_crs.startswith("CUSTOM:"):
-                suffix = new_geometry_crs[new_geometry_crs.index(":") :]
-                if old_col_dict.get("geometryCRS", "").endswith(suffix):
-                    new_col_dict["geometryCRS"] = old_col_dict["geometryCRS"]
 
         if old_type == new_type == "numeric":
             cls._remove_hidden_numeric_diffs(old_col_dict, new_col_dict, 18)
 
         return new_type == old_type
 
-    def _remove_hidden_meta_diffs(self, dataset, ds_meta_items, wc_meta_items):
-        super()._remove_hidden_meta_diffs(dataset, ds_meta_items, wc_meta_items)
-
-        # Nowhere to put custom CRS in SQL Server, so remove custom CRS diffs.
-        # The working copy doesn't know the true authority name, so refers to them all as CUSTOM.
-        # Their original authority name could be anything.
-        for wc_key in list(wc_meta_items.keys()):
-            if not wc_key.startswith("crs/CUSTOM:"):
-                continue
-            del wc_meta_items[wc_key]
-            suffix = wc_key[wc_key.index(":") :]
-            matching_ds_keys = [
-                d
-                for d in ds_meta_items.keys()
-                if d.startswith("crs/") and d.endswith(suffix)
-            ]
-            if len(matching_ds_keys) == 1:
-                [ds_key] = matching_ds_keys
-                del ds_meta_items[ds_key]
-
     def _is_builtin_crs(self, crs_name, crs):
-        if crs_name.startswith("CUSTOM") and not crs:
-            # We don't know where this CRS is found, it is definitely not a built-in.
-            return False
         auth_name, auth_code = crs_util.parse_authority(crs)
-        return auth_name == "EPSG"
+        return auth_name in ("EPSG", "Microsoft") and self._is_builtin_srid(auth_code)
+
+    def _is_builtin_srid(self, srid):
+        if srid in self._is_builtin_srid_cache:
+            return self._is_builtin_srid_cache[srid]
+        return bool(self._keep_builtin_srids([srid]))
+
+    def _keep_builtin_srids(self, srids):
+        """Given a collection of SRIDs, returns those SRIDs from the list that are builtins, defined in sys.spatial_reference_systems"""
+        if not srids:
+            return srids
+        unknown_srids = set(srids) - self._is_builtin_srid_cache.keys()
+        if unknown_srids:
+            print(f"unknown_srid={unknown_srids}")
+            with self.session() as sess:
+                sql = """
+                    SELECT spatial_reference_id
+                    FROM sys.spatial_reference_systems
+                    WHERE spatial_reference_id IN :unknown_srids;
+                """
+                stmt = sa.text(sql).bindparams(
+                    sa.bindparam("unknown_srids", expanding=True)
+                )
+                builtin_srids = [
+                    row[0]
+                    for row in sess.execute(
+                        stmt, {"unknown_srids": list(unknown_srids)}
+                    )
+                ]
+            for srid in unknown_srids:
+                self._is_builtin_srid_cache[srid] = srid in builtin_srids
+
+        return [srid for srid in srids if self._is_builtin_srid_cache[srid]]
 
     def _is_schema_update_supported(self, schema_delta):
         if not schema_delta.old_value or not schema_delta.new_value:


### PR DESCRIPTION
## Description

For custom CRSs in mssql, follow the OGR convention of storing them in a table called `spatial_ref_sys` (which we create if necessary) using the same table definition that OGR uses.
Also stores info about the columns which reference these CRSs in `geometry_columns`.

Reads CRSs from the same tables when diffing, committing and importing from mssql server.

## Related links:

OGR code for creating these tables:
https://github.com/OSGeo/gdal/blob/196f8550298a9e05b4c9739a6022f81349473d13/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp#L1349-L1352

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
