### PR TITLE
Add `--no-sort-keys` to `show` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please note that compatibility for 0.x releases (software or repositories) isn't
 
 _When adding new entries to the changelog, please include issue/PR numbers wherever possible._
 
+## Unreleased
+
+- show: Added `--no-sort-keys` option to disable sorting of features by name/PK. Previously added to `diff` only
+
 ## 0.16.1
 
 - diff: Much faster and much lower memory usage when using `--no-sort-keys` [#1032](https://github.com/koordinates/kart/pull/1032)

--- a/kart/show.py
+++ b/kart/show.py
@@ -95,6 +95,12 @@ from kart.repo import KartRepoState
     "size of the diff if some types of values are not required. "
     "As a final example, --delta-filter=all is equivalent to --delta-filter=--,-,+,++",
 )
+@click.option(
+    "--sort-keys/--no-sort-keys",
+    is_flag=True,
+    default=True,
+    help="Sort keys in the output. This is the default behaviour, but it can be disabled for a slight speed improvement.",
+)
 def show(
     ctx,
     *,
@@ -107,6 +113,7 @@ def show(
     args,
     diff_format=DiffFormat.FULL,
     delta_filter,
+    sort_keys,
 ):
     """
     Shows the given REVISION, or HEAD if none is specified.
@@ -153,6 +160,7 @@ def show(
         json_style=fmt,
         delta_filter=delta_filter,
         target_crs=crs,
+        sort_keys=sort_keys,
     )
     diff_writer.full_file_diffs(diff_files)
     diff_writer.include_target_commit_as_header()


### PR DESCRIPTION

## Description

For parity with `diff`

I haven't added tests because the functionality of the option is already covered by diff tests; any test I'd write would just test the minimal CLI change really. I've run it manually and confirmed it works

## Related links:

- #1031 

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
