### PR TITLE
show: Added `--add-feature-count-estimate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## Unreleased
 
+- diff/show: Faster output for some large repositories (varies wildly) [#1038](https://github.com/koordinates/kart/issues/1038)
 - show: Added `--no-sort-keys` option to disable sorting of features by name/PK. Previously added to `diff` only
+- show: Added `--add-feature-count-estimate` option to add a feature count estimate to `json-lines` output. Previously added to `diff` only
 
 ## 0.16.1
 

--- a/kart/show.py
+++ b/kart/show.py
@@ -66,6 +66,16 @@ from kart.repo import KartRepoState
     ),
 )
 @click.option(
+    "--add-feature-count-estimate",
+    default=None,
+    type=click.Choice(diff_estimation.ACCURACY_CHOICES),
+    help=(
+        "Adds a feature count estimate to this diff (used with `--output-format json-lines` only.) "
+        "The estimate will be calculated while the diff is being generated, and will be added to "
+        "the stream when it is ready. If the estimate is not ready before the process exits, it will not be added."
+    ),
+)
+@click.option(
     "--diff-files",
     is_flag=True,
     help="Show changes to file contents (instead of just showing the object IDs of changed files)",
@@ -109,6 +119,7 @@ def show(
     output_path,
     exit_code,
     only_feature_count,
+    add_feature_count_estimate,
     diff_files,
     args,
     diff_format=DiffFormat.FULL,
@@ -161,6 +172,7 @@ def show(
         delta_filter=delta_filter,
         target_crs=crs,
         sort_keys=sort_keys,
+        diff_estimate_accuracy=add_feature_count_estimate,
     )
     diff_writer.full_file_diffs(diff_files)
     diff_writer.include_target_commit_as_header()


### PR DESCRIPTION
## Description

Added the `--add-feature-count-estimate` option to `show` for parity with `diff`

Haven't added tests since this is already covered by `test_diff_json_lines_with_feature_count_estimate` and the separate CLI tweaks for show aren't worth a separate test. I've tested manually

## Related links:

Was added to `diff` in #543 

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
