### PR TITLE
Fix garbled JSON-lines output sometimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## Unreleased
 
+- diff: Fixed garbled json-lines output sometimes when using `--add-feature-count-estimate` [#1040](https://github.com/koordinates/kart/issues/1040)
 - diff/show: Faster output for some large repositories (varies wildly) [#1038](https://github.com/koordinates/kart/issues/1038)
 - show: Added `--no-sort-keys` option to disable sorting of features by name/PK. Previously added to `diff` only
 - show: Added `--add-feature-count-estimate` option to add a feature count estimate to `json-lines` output. Previously added to `diff` only

--- a/kart/json_diff_writers.py
+++ b/kart/json_diff_writers.py
@@ -247,10 +247,10 @@ class JsonLinesDiffWriter(BaseDiffWriter):
         self._output_buffer = bytearray()
 
     def dump(self, obj):
-        # https://jcristharif.com/msgspec/perf-tips.html#line-delimited-json
-        msgspec_json_encoder.encode_into(obj, self._output_buffer)
-        self._output_buffer.extend(b"\n")
         with self._output_lock:
+            # https://jcristharif.com/msgspec/perf-tips.html#line-delimited-json
+            msgspec_json_encoder.encode_into(obj, self._output_buffer)
+            self._output_buffer.extend(b"\n")
             self.fp.buffer.write(self._output_buffer)
 
     def write_header(self):


### PR DESCRIPTION


## Description
In `kart diff -o json-lines --add-feature-count-estimate={value}`, two threads would write to the output. This correctly used a lock to prevent races, but there is an intermediate bytearray which is written just beforehand (introduced with #1025) and this also needed to use a lock to prevent races.

This change moves that intermediate bytearray under the same lock as writing the output buffer, thus avoiding the race condition

## Related links:

<!-- If you have links to [issues](https://github.com/koordinates/kart/issues) etc, link them here. -->

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
