### PR TITLE
show: Add 'Merge: {parentIDs}' line to text output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 - diff: Fixed garbled json-lines output sometimes when using `--add-feature-count-estimate` [#1040](https://github.com/koordinates/kart/issues/1040)
 - diff/show: Faster output for some large repositories (varies wildly) [#1038](https://github.com/koordinates/kart/issues/1038)
+- show: Text output now displays a 'Merge: {parentIDs}' line when showing a merge commit (consistent with `git show`) [#1043](https://github.com/koordinates/kart/issues/1043)
 - show: Added `--no-sort-keys` option to disable sorting of features by name/PK. Previously added to `diff` only
 - show: Added `--add-feature-count-estimate` option to add a feature count estimate to `json-lines` output. Previously added to `diff` only
 

--- a/kart/text_diff_writer.py
+++ b/kart/text_diff_writer.py
@@ -49,6 +49,10 @@ class TextDiffWriter(BaseDiffWriter):
         author_time_in_author_timezone = author_time_utc.astimezone(author_timezone)
 
         click.secho(f"commit {self.commit.hex}", fg="yellow", **self.pecho)
+        if len(self.commit.parent_ids) > 1:
+            parents = self.commit.parents
+            parent_ids_s = " ".join(str(x.short_id) for x in parents)
+            click.secho(f"Merge: {parent_ids_s}", **self.pecho)
         click.secho(f"Author: {author.name} <{author.email}>", **self.pecho)
         click.secho(
             f'Date:   {author_time_in_author_timezone.strftime("%c %z")}',

--- a/tests/point_cloud/test_conflicts.py
+++ b/tests/point_cloud/test_conflicts.py
@@ -168,7 +168,7 @@ def test_resolve_conflict_with_workingcopy(cli_runner, data_archive, requires_pd
 
         r = cli_runner.invoke(["show", "HEAD", "auckland:tile:auckland_0_0"])
         assert r.exit_code == 0, r.stderr
-        assert r.stdout.splitlines()[4:] == [
+        assert r.stdout.splitlines()[5:] == [
             '    Merge with "theirs_branch"',
             "",
             "--- auckland:tile:auckland_0_0",
@@ -226,7 +226,7 @@ def test_resolve_conflict_with_file(cli_runner, data_archive, requires_pdal, tmp
 
         r = cli_runner.invoke(["show", "HEAD", "auckland:tile:auckland_0_0"])
         assert r.exit_code == 0, r.stderr
-        assert r.stdout.splitlines()[4:] == [
+        assert r.stdout.splitlines()[5:] == [
             '    Merge with "theirs_branch"',
             "",
             "--- auckland:tile:auckland_0_0",

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -379,7 +379,7 @@ def test_resolve_schema_conflict(data_working_copy, cli_runner):
             ["show", "HEAD", "--", "nz_waca_adjustments:feature:9999999"]
         )
         assert r.exit_code == 0, r.stderr
-        assert r.stdout.splitlines()[4:] == [
+        assert r.stdout.splitlines()[5:] == [
             "    Merge with 'theirs_branch'",
             "",
             "--- nz_waca_adjustments:feature:9999999",


### PR DESCRIPTION

## Description


For consistency with `git show`. Useful for identifying a commit as a merge commit; it's hard to notice otherwise


## Related links:

<!-- If you have links to [issues](https://github.com/koordinates/kart/issues) etc, link them here. -->

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
