### PR TITLE
merge: --dry-run merges should return 'dryRun: true' even when merge is a noop

### DIFF
--- a/kart/merge.py
+++ b/kart/merge.py
@@ -99,12 +99,6 @@ def do_merge(
         "conflicts": None,
     }
 
-    # We're up-to-date if we're trying to merge our own common ancestor.
-    if ancestor_id == theirs.id:
-        merge_jdict["noOp"] = True
-        merge_jdict["message"] = None
-        return merge_jdict
-
     # "dryRun": True means we didn't actually do this
     # "dryRun": False means we *did* actually do this
     merge_jdict["dryRun"] = dry_run
@@ -116,6 +110,14 @@ def do_merge(
         raise InvalidOperation(
             "Can't resolve as a fast-forward merge and --ff-only specified"
         )
+
+    # We're up-to-date if we're trying to merge our own common ancestor.
+    if ancestor_id == theirs.id:
+        merge_jdict["noOp"] = True
+        merge_jdict["message"] = None
+        # all noops are fast-forwards
+        merge_jdict["fastForward"] = True
+        return merge_jdict
 
     if can_ff and ff:
         # do fast-forward merge


### PR DESCRIPTION

## Description

also: noops are also fastforwards


## Related links:

Fixes #1048


## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
