### PR TITLE
merge: When `-m` is given, don't imply `--no-ff`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## Unreleased
 
+- merge: `--message`/`-m` option no longer implies `--no-ff`. The message will now be used if the command can't do a fast-forward. [#1051](https://github.com/koordinates/kart/issues/1051)
 - diff: Fixed garbled json-lines output sometimes when using `--add-feature-count-estimate` [#1040](https://github.com/koordinates/kart/issues/1040)
 - diff/show: Faster output for some large repositories (varies wildly) [#1038](https://github.com/koordinates/kart/issues/1038)
 - show: Text output now displays a 'Merge: {parentIDs}' line when showing a merge commit (consistent with `git show`) [#1043](https://github.com/koordinates/kart/issues/1043)

--- a/kart/merge.py
+++ b/kart/merge.py
@@ -69,12 +69,10 @@ def do_merge(
         raise click.BadParameter(
             "Conflicting parameters: --no-ff & --ff-only", param_hint="--ff-only"
         )
-    if message:
-        if ff_only:
-            raise click.BadParameter(
-                "Conflicting parameters: --message & --ff-only", param_hint="--ff-only"
-            )
-        ff = False
+    if message and ff_only:
+        raise click.BadParameter(
+            "Conflicting parameters: --message & --ff-only", param_hint="--ff-only"
+        )
 
     # accept ref-ish things (refspec, branch, commit)
     theirs = CommitWithReference.resolve(repo, commit)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -86,7 +86,8 @@ def test_merge_fastforward(data, data_working_copy, cli_runner, insert, request)
         assert r.exit_code == 0, r
         assert repo.head.target.hex != commit_id
 
-        r = cli_runner.invoke(["merge", "--ff-only", "changes"])
+        # message option is allowed but happens to get ignored since a fastforward is possible
+        r = cli_runner.invoke(["merge", "-m", "custom message", "changes"])
         assert r.exit_code == 0, r
 
         H.git_graph(request, "post-merge")
@@ -106,9 +107,7 @@ def test_merge_fastforward(data, data_working_copy, cli_runner, insert, request)
         pytest.param(H.TABLE, id="table"),
     ],
 )
-@pytest.mark.parametrize("no_ff_method", ["--no-ff", "--message=custom message"])
 def test_merge_fastforward_noff(
-    no_ff_method,
     data,
     data_working_copy,
     cli_runner,
@@ -139,7 +138,7 @@ def test_merge_fastforward_noff(
         assert repo.head.target.hex != commit_id
 
         # force creation of a merge commit
-        r = cli_runner.invoke(["merge", "changes", no_ff_method, "-o", "json"])
+        r = cli_runner.invoke(["merge", "changes", "--no-ff", "-o", "json"])
         assert r.exit_code == 0, r
 
         H.git_graph(request, "post-merge")
@@ -152,10 +151,7 @@ def test_merge_fastforward_noff(
         assert len(c.parents) == 2
         assert c.parents[0].hex == h
         assert c.parents[1].hex == commit_id
-        if no_ff_method == "--no-ff":
-            assert c.message == 'Merge branch "changes" into main'
-        else:
-            assert c.message == "custom message"
+        assert c.message == 'Merge branch "changes" into main'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION

## Description
Previously, there was no way to specify a message while using the default `--ff` behaviour (fastforward if possible otherwise create a merge commit).

The message is useful in the case that the command can't do a fastforward and has to fallback to a merge commit.
This change makes it so that, if kart does decide to use a merge commit, it will use the commit message given.

## Related links:

<!-- If you have links to [issues](https://github.com/koordinates/kart/issues) etc, link them here. -->

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
