### PR TITLE
Get CI passing again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -573,6 +573,8 @@ jobs:
 
             rpm)
               yum install -y sqlite tar
+              # fedora needs this package; other yumlikes don't even have this package :/
+              yum install -y awk || true
               ;;
 
             *)


### PR DESCRIPTION
## Description

1. disable MacOS build, because it's broken. We can fix it later (before next release obviously)
2. Prevent cmake v4.x and cmake v3.x fighting in the manylinux container for Linux builds. At some point almalinux repo must have gotten cmake v4, and this seems to be picked up in preference to the cmake v3 installed by the `get-cmake` action. cmake v4 can't build `qhull`, something we apparently depend upon. So `rm /usr/local/bin/cmake` seems to have fixed their fighting.
3. Pinned ninja build system to a previous release. I think [0.13.0 (released last week)](https://github.com/ninja-build/ninja/releases/v1.13.0) is not compatible with manylinux_2_28's GCC, although I can't find any docs or supporting evidence. But pinning it to 1.12.1 has fixed a build fail in arm64 environments.

## Related links:

<!-- If you have links to [issues](https://github.com/koordinates/kart/issues) etc, link them here. -->

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
