### PR TITLE
CI: windows-2019 has been retired; upgrade to 2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1036,7 +1036,7 @@ jobs:
   Windows:
     strategy:
       matrix:
-        os: [{id: windows-2019, label: "2019/x64"}]
+        os: [{id: windows-2022, label: "2022/x64"}]
     runs-on: ${{ matrix.os.id }}
     name: Windows ${{ matrix.os.label }}
 
@@ -1066,7 +1066,7 @@ jobs:
       - name: "Harden vcvarsall.bat"
         shell: pwsh
         run: |
-          cd 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build'
+          cd 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build'
           mv vcvarsall.bat orig_vcvarsall.bat
           echo @'
           @if not "%VSCMD_DEBUG%" GEQ "3" echo off


### PR DESCRIPTION
## Description

Windows build is failing in CI because Github has turned off the windows-2019 runner.

## Related links:

https://github.com/actions/runner-images/issues/12045

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
