### PR TITLE
A few fixes to the built-in visual HTML diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - show: Text output now displays a 'Merge: {parentIDs}' line when showing a merge commit (consistent with `git show`) [#1043](https://github.com/koordinates/kart/issues/1043)
 - show: Added `--no-sort-keys` option to disable sorting of features by name/PK. Previously added to `diff` only
 - show: Added `--add-feature-count-estimate` option to add a feature count estimate to `json-lines` output. Previously added to `diff` only
+- diff/show: Fixed some issues with the built-in visual HTML diff ie `kart show -ohtml`
 
 ## 0.16.1
 

--- a/kart/html_diff_writer.py
+++ b/kart/html_diff_writer.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import click
 
 import kart
+from kart.crs_util import make_crs
 from kart.diff_format import DiffFormat
 from .base_diff_writer import BaseDiffWriter
 from .json_diff_writers import GeojsonDiffWriter
@@ -20,6 +21,11 @@ class HtmlDiffWriter(BaseDiffWriter):
     Writes a file usually called DIFF.html (the default name), which contains both a GeoJSON viewer, and the diff itself
     in GeoJSON. Automatically opens the created file using webbrowser if the created file is not stdout.
     """
+
+    def __init__(self, *args, target_crs=None, **kwargs):
+        if target_crs is None:
+            target_crs = make_crs("EPSG:4326")
+        super().__init__(*args, target_crs=target_crs, **kwargs)
 
     @classmethod
     def _check_output_path(cls, repo, output_path):
@@ -56,6 +62,7 @@ class HtmlDiffWriter(BaseDiffWriter):
                 "features": self.filtered_dataset_deltas_as_geojson(ds_path, ds_diff),
             }
             for ds_path, ds_diff in repo_diff.items()
+            if ds_path != "<files>"
         }
 
         fo = resolve_output_path(self.output_path)

--- a/kart/structure.py
+++ b/kart/structure.py
@@ -200,6 +200,8 @@ class RepoStructure:
 
     @property
     def short_id(self):
+        if self.ref == "[EMPTY]":
+            return self.ref
         obj = self.commit or self.tree
         return obj.short_id if obj is not None else None
 


### PR DESCRIPTION
- default the output to EPSG:4326 (this is what the HTML template we use expects)
- don't try to show differing <files> in the HTML diff
- fix a bug where short_id doesn't work for the [EMPTY] "commit"

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
