### PR TITLE
Fix `kart export` erroring with absolute path on windows

### DIFF
--- a/kart/tabular/export.py
+++ b/kart/tabular/export.py
@@ -65,7 +65,7 @@ def get_driver(destination_spec):
     Given a destination like target.gpkg, GPKG:target.gpkg, postgresql://x/y/z,
     returns the driver to use and the target that the driver should write to.
     """
-    match = re.match(r"([^:]+)://", destination_spec)
+    match = re.match(r"([^:]{2,})://", destination_spec)
     if match:
         return get_driver_by_shortname(match.group(1)), destination_spec
     if ":" in destination_spec:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,8 +1,9 @@
 import os
-import pytest
 import re
 import subprocess
+from pathlib import Path
 
+import pytest
 from sqlalchemy.orm import sessionmaker
 
 from kart import prefix, is_frozen, is_windows
@@ -62,6 +63,26 @@ def test_export_datasets(archive, layer, geometry, data_archive, cli_runner):
                 continue
 
             assert field_name[0:10] in output
+
+
+@pytest.mark.parametrize("use_absolute_path", [True, False])
+@pytest.mark.parametrize("use_format_specifier", [True, False])
+def test_export_path_styles(
+    use_absolute_path, use_format_specifier, data_archive, cli_runner
+):
+    with data_archive("points") as repo_dir:
+        if use_absolute_path:
+            path = (Path(".") / "output.gpkg").resolve()
+        else:
+            path = "output.gpkg"
+        if use_format_specifier:
+            format_specifier = "GPKG:"
+        else:
+            format_specifier = ""
+
+        r = cli_runner.invoke(["export", H.POINTS.LAYER, f"{format_specifier}{path}"])
+        assert r.exit_code == 0, r.stderr
+        assert (repo_dir / "output.gpkg").exists()
 
 
 @pytest.mark.parametrize("epsg", [4326, 27200])


### PR DESCRIPTION
## Description

[here](https://github.com/koordinates/kart/actions/runs/19316902585/job/55250073388#step:16:2153) I noticed that `kart export ... C:\...\output.gpkg` causes the "C" to be interpreted as a format specifier ("GPKG") and fails

This fixes it by ensuring the format specifier in the path argument has at least two chars.

## Related links:

<!-- If you have links to [issues](https://github.com/koordinates/kart/issues) etc, link them here. -->

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
