### PR TITLE
Output pager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 ## UNRELEASED
 
 - Adds `libkart`, a native shared library exposing a C API for reading Kart repositories in-process (without invoking the `kart` CLI). It is shipped in the bundle alongside the `kart` executable; see the libkart C API reference in the developer docs. [#1110](https://github.com/koordinates/kart/pull/1110)
+- Add pager support to `diff` and `show` commands. [#1080](https://github.com/koordinates/kart/pull/1080)
 
 ## 0.17.1
 

--- a/kart/base_diff_writer.py
+++ b/kart/base_diff_writer.py
@@ -137,6 +137,12 @@ class BaseDiffWriter:
         self.do_full_file_diffs = False
         self.sort_keys = sort_keys
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
     def include_target_commit_as_header(self):
         """
         For show / create-patch commands, which show the diff C^...C but also include a header

--- a/kart/completion.py
+++ b/kart/completion.py
@@ -229,9 +229,11 @@ class PowerShellComplete(click.shell_completion.ShellComplete):
         }
 
     def get_completion_args(self) -> Tuple[List[str], str]:
+        from click.shell_completion import split_arg_string
+
         completion_args = os.getenv("_KART_COMPLETE_ARGS", "")
         incomplete = os.getenv("_KART_COMPLETE_WORD_TO_COMPLETE", "")
-        cwords = click.parser.split_arg_string(completion_args)
+        cwords = split_arg_string(completion_args)
         args = cwords[1:]
         return args, incomplete
 

--- a/kart/conflicts.py
+++ b/kart/conflicts.py
@@ -77,7 +77,7 @@ def conflicts(
     output_type, fmt = output_format
 
     conflicts_writer_class = BaseConflictsWriter.get_conflicts_writer_class(output_type)
-    conflicts_writer = conflicts_writer_class(
+    with conflicts_writer_class(
         repo,
         filters,
         output_path,
@@ -85,8 +85,8 @@ def conflicts(
         flat,
         json_style=fmt,
         target_crs=crs,
-    )
-    conflicts_writer.write_conflicts()
+    ) as conflicts_writer:
+        conflicts_writer.write_conflicts()
 
-    if exit_code or output_type == "quiet":
-        conflicts_writer.exit_with_code()
+        if exit_code or output_type == "quiet":
+            conflicts_writer.exit_with_code()

--- a/kart/conflicts_writer.py
+++ b/kart/conflicts_writer.py
@@ -23,7 +23,7 @@ from .merge_util import (
     rich_conflicts,
     ensure_conflicts_ready,
 )
-from .output_util import dump_json_output, resolve_output_path
+from .output_util import can_output_colour, dump_json_output, resolve_output_path
 from .repo import KartRepo
 from . import diff_util
 
@@ -72,6 +72,12 @@ class BaseConflictsWriter:
         if merge_context is None:
             merge_context = MergeContext.read_from_repo(repo)
         self.merge_context = merge_context
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
 
     @classmethod
     def _normalize_output_path(cls, output_path: str | Path) -> str | Path:
@@ -233,8 +239,19 @@ class TextConflictsWriter(BaseConflictsWriter):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fp = resolve_output_path(self.output_path)
-        self.pecho = {"file": self.fp, "color": self.fp.isatty()}
+        self._fp_context = None
+        self.fp = None
+        self.pecho = None
+
+    def __enter__(self):
+        self._fp_context = resolve_output_path(self.output_path)
+        self.fp = self._fp_context.__enter__()
+        self.pecho = {"file": self.fp, "color": can_output_colour(self.fp)}
+        return self
+
+    def __exit__(self, *args):
+        if self._fp_context:
+            return self._fp_context.__exit__(*args)
 
     @classmethod
     def _check_output_path(

--- a/kart/diff.py
+++ b/kart/diff.py
@@ -232,7 +232,7 @@ def diff(
     from .base_diff_writer import BaseDiffWriter
 
     diff_writer_class = BaseDiffWriter.get_diff_writer_class(output_type)
-    diff_writer = diff_writer_class(
+    with diff_writer_class(
         repo,
         commit_spec,
         filters,
@@ -243,11 +243,11 @@ def diff(
         diff_estimate_accuracy=add_feature_count_estimate,
         html_template=html_template,
         sort_keys=sort_keys,
-    )
-    diff_writer.convert_to_dataset_format(convert_to_dataset_format)
-    diff_writer.full_file_diffs(diff_files)
-    diff_writer.write_diff(diff_format=diff_format)
-    diff_writer.flush()
+    ) as diff_writer:
+        diff_writer.convert_to_dataset_format(convert_to_dataset_format)
+        diff_writer.full_file_diffs(diff_files)
+        diff_writer.write_diff(diff_format=diff_format)
+        diff_writer.flush()
 
-    if exit_code or output_type == "quiet":
-        diff_writer.exit_with_code()
+        if exit_code or output_type == "quiet":
+            diff_writer.exit_with_code()

--- a/kart/diff.py
+++ b/kart/diff.py
@@ -6,7 +6,7 @@ from kart import diff_estimation
 from kart.cli_util import OutputFormatType, DeltaFilterType
 from kart.completion_shared import ref_or_repo_path_completer
 from kart.crs_util import CoordinateReferenceString
-from kart.diff_format import DiffFormat
+from kart.diff_format import DiffFormat, DiffFormatChoice
 from kart.output_util import dump_json_output
 from kart.parse_args import PreserveDoubleDash, parse_revisions_and_filters
 from kart.repo import KartRepoState
@@ -132,7 +132,7 @@ def feature_count_diff(
 )
 @click.option(
     "--diff-format",
-    type=click.Choice(list(DiffFormat)),
+    type=DiffFormatChoice(list(DiffFormat)),
     default=DiffFormat.FULL,
     help="Choose the diff format: \n'full' for full diff or 'no-data-changes' for metadata and a bool indicating the feature/tile tree changes.",
 )

--- a/kart/diff_format.py
+++ b/kart/diff_format.py
@@ -7,3 +7,17 @@ class DiffFormat(str, Enum):
     FULL = "full"
     NO_DATA_CHANGES = "no-data-changes"
     NONE = "none"
+
+
+class DiffFormatChoice(click.Choice):
+    """
+    A click.Choice for the DiffFormat enum that matches on the enum *value*
+    (eg 'none') rather than the member *name* (eg 'NONE'). Click 8.2+ normalizes
+    enum choices by name by default, which would break the documented
+    lower-case --diff-format values.
+    """
+
+    def normalize_choice(self, choice, ctx):
+        if isinstance(choice, Enum):
+            choice = choice.value
+        return super().normalize_choice(choice, ctx)

--- a/kart/html_diff_writer.py
+++ b/kart/html_diff_writer.py
@@ -72,11 +72,12 @@ class HtmlDiffWriter(BaseDiffWriter):
             if ds_path != "<files>"
         }
 
-        fo = resolve_output_path(self.output_path)
-        fo.write(self.substitute_into_template(template, title, all_datasets_geojson))
+        with resolve_output_path(self.output_path) as fo:
+            fo.write(
+                self.substitute_into_template(template, title, all_datasets_geojson)
+            )
 
         if fo != sys.stdout:
-            fo.close()
             webbrowser.open_new(f"file://{self.output_path.resolve()}")
 
         self.write_warnings_footer()

--- a/kart/html_diff_writer.py
+++ b/kart/html_diff_writer.py
@@ -72,7 +72,9 @@ class HtmlDiffWriter(BaseDiffWriter):
             if ds_path != "<files>"
         }
 
-        with resolve_output_path(self.output_path) as fo:
+        # HTML output is never paged - it's either written to a file (and
+        # opened in a browser) or to stdout for redirection.
+        with resolve_output_path(self.output_path, allow_pager=False) as fo:
             fo.write(
                 self.substitute_into_template(template, title, all_datasets_geojson)
             )

--- a/kart/json_diff_writers.py
+++ b/kart/json_diff_writers.py
@@ -285,13 +285,23 @@ class JsonLinesDiffWriter(BaseDiffWriter):
 
     def __init__(self, *args, diff_estimate_accuracy=None, delta_filter=None, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fp = resolve_output_path(self.output_path)
+        self._fp_context = None
+        self.fp = None
 
         self._diff_estimate_accuracy = diff_estimate_accuracy
         self.delta_filter = delta_filter
         self._output_lock = threading.RLock()
         # https://jcristharif.com/msgspec/perf-tips.html#reusing-an-output-buffer
         self._output_buffer = bytearray()
+
+    def __enter__(self):
+        self._fp_context = resolve_output_path(self.output_path)
+        self.fp = self._fp_context.__enter__()
+        return self
+
+    def __exit__(self, *args):
+        if self._fp_context:
+            return self._fp_context.__exit__(*args)
 
     def dump(self, obj):
         with self._output_lock:

--- a/kart/log.py
+++ b/kart/log.py
@@ -10,7 +10,7 @@ from kart.completion_shared import ref_or_repo_path_completer
 from kart.exceptions import NotYetImplemented, SubprocessError
 from kart import subprocess_util as subprocess
 from kart.key_filters import RepoKeyFilter
-from kart.output_util import dump_json_output
+from kart.output_util import dump_json_output, resolve_output_path
 from kart.parse_args import PreserveDoubleDash, parse_revisions_and_filters
 from kart.repo import KartRepoState
 from kart.timestamps import datetime_to_iso8601_utc, timedelta_to_iso8601_tz
@@ -137,6 +137,12 @@ def convert_user_patterns_to_raw_paths(paths, repo, commits):
     hidden=True,
 )
 @click.option(
+    "--output",
+    "output_path",
+    help="Output to a specific file/directory instead of stdout.",
+    type=click.Path(writable=True, allow_dash=True),
+)
+@click.option(
     "--with-feature-count",
     default=None,
     type=click.Choice(diff_estimation.ACCURACY_CHOICES),
@@ -240,6 +246,7 @@ def convert_user_patterns_to_raw_paths(paths, repo, commits):
 def log(
     ctx,
     output_format,
+    output_path,
     dataset_changes,
     with_feature_count,
     args,
@@ -260,61 +267,80 @@ def log(
     paths = convert_user_patterns_to_raw_paths(filters, repo, commits)
     output_type, fmt = output_format
 
-    # TODO: should we check paths exist here? git doesn't!
-    if output_type == "text":
-        if fmt:
-            options.append(f"--format={fmt}")
-        cmd = ["git", "-C", repo.path, "log", *options, *commits, "--", *paths]
-        subprocess.run_then_exit(cmd)
+    log_cmd = [
+        "git",
+        "-C",
+        repo.path,
+        "--no-pager",
+        "log",
+    ]
 
-    elif output_type in ("json", "json-lines"):
-        if kwargs.get("graph"):
-            raise click.UsageError("JSON output and --graph and not compatible")
+    with resolve_output_path(output_path) as output_fp:
+        if output_fp.color:
+            options.append("--color=always")
 
-        try:
-            cmd = [
-                "git",
-                "-C",
-                repo.path,
-                "log",
-                "--format=%H,%D",
-                *options,
-                *commits,
-                "--",
-                *paths,
-            ]
-            r = subprocess.run(
-                cmd,
-                encoding="utf8",
-                check=True,
-                capture_output=True,
+        # TODO: should we check paths exist here? git doesn't!
+        if output_type == "text":
+            if fmt:
+                options.append(f"--format={fmt}")
+
+            p = subprocess.run(
+                [
+                    *log_cmd,
+                    *options,
+                    *commits,
+                    "--",
+                    *paths,
+                ],
+                encoding="utf-8",
+                stdout=output_fp,
             )
-        except subprocess.CalledProcessError as e:
-            raise SubprocessError(
-                f"There was a problem with git log: {e}", called_process_error=e
+            sys.exit(p.returncode)
+
+        elif output_type in ("json", "json-lines"):
+            if kwargs.get("graph"):
+                raise click.UsageError("JSON output and --graph and not compatible")
+
+            try:
+                r = subprocess.run(
+                    [
+                        *log_cmd,
+                        "--format=%H,%D",
+                        *options,
+                        *commits,
+                        "--",
+                        *paths,
+                    ],
+                    encoding="utf8",
+                    check=True,
+                    capture_output=True,
+                )
+            except subprocess.CalledProcessError as e:
+                raise SubprocessError(
+                    f"There was a problem with git log: {e}", called_process_error=e
+                )
+
+            commit_ids_and_refs_log = _parse_git_log_output(r.stdout.splitlines())
+            dataset_change_cache = {}
+
+            commit_log = (
+                commit_obj_to_json(
+                    repo[commit_id],
+                    repo,
+                    refs,
+                    dataset_changes,
+                    dataset_change_cache,
+                    with_feature_count,
+                )
+                for (commit_id, refs) in commit_ids_and_refs_log
             )
+            if output_type == "json-lines":
+                for item in commit_log:
+                    # hardcoded style here; each item must be on one line.
+                    dump_json_output(item, output_fp, "compact")
 
-        commit_ids_and_refs_log = _parse_git_log_output(r.stdout.splitlines())
-        dataset_change_cache = {}
-
-        commit_log = (
-            commit_obj_to_json(
-                repo[commit_id],
-                repo,
-                refs,
-                dataset_changes,
-                dataset_change_cache,
-                with_feature_count,
-            )
-            for (commit_id, refs) in commit_ids_and_refs_log
-        )
-        if output_type == "json-lines":
-            for item in commit_log:
-                # hardcoded style here; each item must be on one line.
-                dump_json_output(item, sys.stdout, "compact")
-
-        else:
-            dump_json_output(commit_log, sys.stdout, fmt)
+            else:
+                dump_json_output(commit_log, output_fp, fmt)
 
 
 def _parse_git_log_output(lines):

--- a/kart/log.py
+++ b/kart/log.py
@@ -1,3 +1,4 @@
+import io
 import sys
 import logging
 from datetime import datetime, timedelta, timezone
@@ -10,7 +11,11 @@ from kart.completion_shared import ref_or_repo_path_completer
 from kart.exceptions import NotYetImplemented, SubprocessError
 from kart import subprocess_util as subprocess
 from kart.key_filters import RepoKeyFilter
-from kart.output_util import dump_json_output, resolve_output_path
+from kart.output_util import (
+    can_output_colour,
+    dump_json_output,
+    resolve_output_path,
+)
 from kart.parse_args import PreserveDoubleDash, parse_revisions_and_filters
 from kart.repo import KartRepoState
 from kart.timestamps import datetime_to_iso8601_utc, timedelta_to_iso8601_tz
@@ -276,7 +281,7 @@ def log(
     ]
 
     with resolve_output_path(output_path) as output_fp:
-        if output_fp.color:
+        if can_output_colour(output_fp):
             options.append("--color=always")
 
         # TODO: should we check paths exist here? git doesn't!
@@ -284,18 +289,8 @@ def log(
             if fmt:
                 options.append(f"--format={fmt}")
 
-            p = subprocess.run(
-                [
-                    *log_cmd,
-                    *options,
-                    *commits,
-                    "--",
-                    *paths,
-                ],
-                encoding="utf-8",
-                stdout=output_fp,
-            )
-            sys.exit(p.returncode)
+            cmd = [*log_cmd, *options, *commits, "--", *paths]
+            sys.exit(_run_git_log_to_output(cmd, output_fp))
 
         elif output_type in ("json", "json-lines"):
             if kwargs.get("graph"):
@@ -341,6 +336,27 @@ def log(
 
             else:
                 dump_json_output(commit_log, output_fp, fmt)
+
+
+def _run_git_log_to_output(cmd, output_fp):
+    """
+    Runs `git log`, sending its stdout to output_fp, and returns the exit code.
+
+    When output_fp has a real file descriptor (normal operation, including
+    writing to a pager or a file) git streams directly into it. Under the Click
+    test harness the output stream has no fileno, so we capture git's output and
+    write it through output_fp.write() instead.
+    """
+    try:
+        output_fp.fileno()
+    except (AttributeError, io.UnsupportedOperation):
+        p = subprocess.run(cmd, encoding="utf-8", capture_output=True)
+        output_fp.write(p.stdout)
+        output_fp.flush()
+        return p.returncode
+
+    p = subprocess.run(cmd, encoding="utf-8", stdout=output_fp)
+    return p.returncode
 
 
 def _parse_git_log_output(lines):

--- a/kart/meta.py
+++ b/kart/meta.py
@@ -74,8 +74,6 @@ def meta_get(ctx, output_format, ref, with_dataset_types, dataset, keys):
     else:
         datasets = repo.datasets(ref)
 
-    fp = resolve_output_path("-")
-
     all_items = {}
     for ds in datasets:
         if keys:
@@ -91,24 +89,25 @@ def meta_get(ctx, output_format, ref, with_dataset_types, dataset, keys):
 
     output_type, fmt = output_format
 
-    if output_type == "text":
-        for ds_path, items in all_items.items():
-            click.secho(ds_path, bold=True)
-            for key, value in items.items():
-                click.secho(f"    {key}", bold=True)
-                value_indent = "        "
-                if key.endswith(".json") or not isinstance(value, str):
-                    value = format_json_for_output(
-                        value, fp, json_style=fmt or "pretty"
-                    )
-                    write_with_indent(fp, value, indent=value_indent)
-                elif key.endswith(".wkt"):
-                    value = format_wkt_for_output(value, fp)
-                    write_with_indent(fp, value, indent=value_indent)
-                else:
-                    fp.write(wrap_text_to_terminal(value, indent=value_indent))
-    else:
-        dump_json_output(all_items, fp, json_style=fmt)
+    with resolve_output_path("-") as fp:
+        if output_type == "text":
+            for ds_path, items in all_items.items():
+                click.secho(ds_path, bold=True)
+                for key, value in items.items():
+                    click.secho(f"    {key}", bold=True)
+                    value_indent = "        "
+                    if key.endswith(".json") or not isinstance(value, str):
+                        value = format_json_for_output(
+                            value, fp, json_style=fmt or "pretty"
+                        )
+                        write_with_indent(fp, value, indent=value_indent)
+                    elif key.endswith(".wkt"):
+                        value = format_wkt_for_output(value, fp)
+                        write_with_indent(fp, value, indent=value_indent)
+                    else:
+                        fp.write(wrap_text_to_terminal(value, indent=value_indent))
+        else:
+            dump_json_output(all_items, fp, json_style=fmt)
 
 
 def get_meta_items(ds, keys):

--- a/kart/output_util.py
+++ b/kart/output_util.py
@@ -1,13 +1,16 @@
 import datetime
 import itertools
 import json
+import os
 import re
 import shutil
 import sys
 import textwrap
 import types
+from contextlib import closing, contextmanager
 from pathlib import Path
 
+import click
 import msgspec.json
 import pygments
 from pygments.lexers import JsonLexer
@@ -122,6 +125,9 @@ def format_json_for_output(output, fp, json_style="pretty"):
 
 
 def can_output_colour(fp):
+    # Check if this is a pager file that supports color
+    if hasattr(fp, "_kart_supports_color"):
+        return fp._kart_supports_color
     return fp in (sys.stdout, sys.stderr) and fp.isatty()
 
 
@@ -210,9 +216,7 @@ def dump_json_output(
     """
     output = _maybe_legacy_style_output(output)
 
-    fp = resolve_output_path(output_path)
-
-    try:
+    with resolve_output_path(output_path) as fp:
         highlit = can_output_colour(fp)
         json_encoder = encoder_class(**JSON_PARAMS[json_style], **encoder_kwargs)
         if highlit:
@@ -230,8 +234,6 @@ def dump_json_output(
             for chunk in json_encoder.iterencode(output):
                 fp.write(chunk)
         fp.write("\n")
-        fp.flush()
-    finally:
         maybe_flush(fp)
 
 
@@ -251,30 +253,46 @@ def _maybe_legacy_style_output(output):
     return output
 
 
-def resolve_output_path(output_path):
+@contextmanager
+def resolve_output_path(output_path, allow_pager=True):
     """
-    Takes a path-ish thing, and returns the appropriate writable file-like object.
+    Context manager that yields the appropriate writable file-like object.
     The path-ish thing could be:
       * a pathlib.Path object
       * a file-like object
       * the string '-' or None (both will return sys.stdout)
+
+    If the file is not stdout, it will be closed when exiting the context manager.
+
+    If allow_pager=True (the default) and the file is stdout, this will attempt to use a
+    pager to display long output.
     """
-    if (not output_path) or output_path == "-":
-        return sys.stdout
-
-    if isinstance(output_path, str):
-        output_path = Path(output_path)
-    if isinstance(output_path, Path):
-        output_path = output_path.expanduser()
-
     if hasattr(output_path, "write"):
-        # filelike object. *usually* this is a io.TextIOWrapper,
-        # but in some circumstances it can be something else.
-        # e.g. click on windows may wrap it with a colorama.ansitowin32.StreamWrapper.
-        return output_path
+        # Make this contextmanager re-entrant - if it's already a file-like object, just yield it
+        yield output_path
+    elif (not output_path) or output_path == "-":
+        if allow_pager and get_input_mode() == InputMode.INTERACTIVE:
+            pager_cmd = (
+                os.environ.get("KART_PAGER")
+                or os.environ.get("PAGER")
+                or _DEFAULT_PAGER
+            )
 
+            with _push_environment("PAGER", pager_cmd):
+                with click.get_pager_file() as pager:
+                    # Mark the pager file as supporting color output
+                    # (the pager command includes -R flag for color support)
+                    pager._kart_supports_color = True
+                    yield pager
+        else:
+            yield sys.stdout
     else:
-        return output_path.open("w", encoding="utf-8")
+        if isinstance(output_path, str):
+            output_path = Path(output_path)
+        if isinstance(output_path, Path):
+            output_path = output_path.expanduser()
+        with closing(output_path.open("w", encoding="utf-8")) as f:
+            yield f
 
 
 class InputMode:
@@ -306,3 +324,25 @@ def is_empty_stream(stream):
             return True
         stream.seek(pos)
     return False
+
+
+def _setenv(k, v):
+    if v is None:
+        os.environ.pop(k, None)
+    else:
+        os.environ[k] = v
+
+
+@contextmanager
+def _push_environment(k, v):
+    orig = os.environ.get(k)
+    _setenv(k, v)
+    try:
+        yield
+    finally:
+        _setenv(k, orig)
+
+
+_DEFAULT_PAGER = shutil.which("less")
+if _DEFAULT_PAGER:
+    _DEFAULT_PAGER += " --quit-if-one-screen --no-init -R"

--- a/kart/output_util.py
+++ b/kart/output_util.py
@@ -126,8 +126,8 @@ def format_json_for_output(output, fp, json_style="pretty"):
 
 def can_output_colour(fp):
     # Check if this is a pager file that supports color
-    if hasattr(fp, "_kart_supports_color"):
-        return fp._kart_supports_color
+    if hasattr(fp, "color"):
+        return fp.color
     return fp in (sys.stdout, sys.stderr) and fp.isatty()
 
 
@@ -282,7 +282,6 @@ def resolve_output_path(output_path, allow_pager=True):
                 with click.get_pager_file() as pager:
                     # Mark the pager file as supporting color output
                     # (the pager command includes -R flag for color support)
-                    pager._kart_supports_color = True
                     yield pager
         else:
             yield sys.stdout

--- a/kart/output_util.py
+++ b/kart/output_util.py
@@ -279,9 +279,14 @@ def resolve_output_path(output_path, allow_pager=True):
             )
 
             with _push_environment("PAGER", pager_cmd):
-                with click.get_pager_file() as pager:
-                    # Mark the pager file as supporting color output
-                    # (the pager command includes -R flag for color support)
+                with click.get_pager_file(color=True) as pager:
+                    # Mark the pager file as supporting color output so
+                    # can_output_colour() returns True for it (the pager
+                    # command includes the -R flag for color support).
+                    try:
+                        pager.color = True
+                    except AttributeError:
+                        pass
                     yield pager
         else:
             yield sys.stdout

--- a/kart/show.py
+++ b/kart/show.py
@@ -163,7 +163,7 @@ def show(
     from .base_diff_writer import BaseDiffWriter
 
     diff_writer_class = BaseDiffWriter.get_diff_writer_class(output_type)
-    diff_writer = diff_writer_class(
+    with diff_writer_class(
         repo,
         commit_spec,
         filters,
@@ -173,14 +173,14 @@ def show(
         target_crs=crs,
         sort_keys=sort_keys,
         diff_estimate_accuracy=add_feature_count_estimate,
-    )
-    diff_writer.full_file_diffs(diff_files)
-    diff_writer.include_target_commit_as_header()
-    diff_writer.write_diff(diff_format=diff_format)
-    diff_writer.flush()
+    ) as diff_writer:
+        diff_writer.full_file_diffs(diff_files)
+        diff_writer.include_target_commit_as_header()
+        diff_writer.write_diff(diff_format=diff_format)
+        diff_writer.flush()
 
-    if exit_code or output_type == "quiet":
-        diff_writer.exit_with_code()
+        if exit_code or output_type == "quiet":
+            diff_writer.exit_with_code()
 
 
 @click.command(cls=KartCommand, name="create-patch")
@@ -243,7 +243,7 @@ def create_patch(
     target_crs = make_crs(crs_str) if crs_str else None
 
     repo = ctx.obj.get_repo(allowed_states=KartRepoState.ALL_STATES)
-    diff_writer = PatchWriter(
+    with PatchWriter(
         repo,
         commit_spec,
         [],
@@ -251,8 +251,8 @@ def create_patch(
         json_style=json_style,
         target_crs=target_crs,
         target_crs_str=crs_str,
-    )
-    diff_writer.full_file_diffs(True)
-    diff_writer.include_target_commit_as_header()
-    diff_writer.write_diff(diff_format=diff_format)
-    diff_writer.flush()
+    ) as diff_writer:
+        diff_writer.full_file_diffs(True)
+        diff_writer.include_target_commit_as_header()
+        diff_writer.write_diff(diff_format=diff_format)
+        diff_writer.flush()

--- a/kart/show.py
+++ b/kart/show.py
@@ -6,7 +6,7 @@ from kart import diff_estimation
 from kart.cli_util import KartCommand, OutputFormatType, DeltaFilterType
 from kart.completion_shared import ref_or_repo_path_completer
 from kart.crs_util import CoordinateReferenceString
-from kart.diff_format import DiffFormat
+from kart.diff_format import DiffFormat, DiffFormatChoice
 from kart.parse_args import PreserveDoubleDash, parse_revisions_and_filters
 from kart.repo import KartRepoState
 
@@ -89,7 +89,7 @@ from kart.repo import KartRepoState
 )
 @click.option(
     "--diff-format",
-    type=click.Choice(list(DiffFormat)),
+    type=DiffFormatChoice(list(DiffFormat)),
     default=DiffFormat.FULL,
     help="Choose the diff format: \n'full' for full diff, 'none' for viewing commit metadata only, or 'no-data-changes' for metadata and a bool indicating the feature/tile tree changes.",
 )

--- a/kart/text_diff_writer.py
+++ b/kart/text_diff_writer.py
@@ -10,7 +10,11 @@ from kart.base_diff_writer import BaseDiffWriter
 from kart.diff_format import DiffFormat
 from kart.diff_structs import BINARY_FILE
 from kart.list_of_conflicts import ListOfConflicts
-from kart.output_util import format_wkt_for_output, resolve_output_path
+from kart.output_util import (
+    can_output_colour,
+    format_wkt_for_output,
+    resolve_output_path,
+)
 from kart.tabular.feature_output import feature_as_text, feature_field_as_text
 from kart.schema import Schema
 
@@ -29,8 +33,38 @@ class TextDiffWriter(BaseDiffWriter):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fp = resolve_output_path(self.output_path)
-        self.pecho = {"file": self.fp, "color": self.fp.isatty()}
+        self._fp_context = None
+        self.fp = None
+        self.pecho = None
+
+    def __enter__(self):
+        self._fp_context = resolve_output_path(self.output_path)
+        self.fp = self._fp_context.__enter__()
+        self.pecho = {"file": self.fp, "color": can_output_colour(self.fp)}
+        return self
+
+    def __exit__(self, *args):
+        if self._fp_context:
+            return self._fp_context.__exit__(*args)
+
+    def _write_colored(self, text, fg=None, bg=None, bold=False):
+        """
+        Write colored text to output, handling multi-line strings correctly.
+
+        Pagers process output line-by-line, so we need to color each line individually
+        (like git does), not the entire block at once.
+        """
+        if self.pecho.get("color"):
+            # Color each line individually for proper pager display
+            lines = text.rstrip("\n").split("\n")
+            for line in lines:
+                styled_line = click.style(line, fg=fg, bg=bg, bold=bold)
+                self.fp.write(styled_line)
+                self.fp.write("\n")
+        else:
+            self.fp.write(text)
+            if not text.endswith("\n"):
+                self.fp.write("\n")
 
     @classmethod
     def _check_output_path(cls, repo, output_path):
@@ -89,10 +123,10 @@ class TextDiffWriter(BaseDiffWriter):
 
         if delta.old:
             output = self._prefix_item(delta.old_value, delta.old_key, "- ")
-            click.secho(output, fg="red", **self.pecho)
+            self._write_colored(output, fg="red")
         if delta.new:
             output = self._prefix_item(delta.new_value, delta.new_key, "+ ")
-            click.secho(output, fg="green", **self.pecho)
+            self._write_colored(output, fg="green")
 
     def write_meta_delta(self, ds_path, key, delta):
         if (
@@ -111,6 +145,14 @@ class TextDiffWriter(BaseDiffWriter):
             click.echo(output, **self.pecho)
         else:
             self.write_full_delta(ds_path, "meta", key, delta)
+
+    def _write_schema_diff_item(self, text, fg=None):
+        """Write a schema diff item with color."""
+        if self.pecho.get("color") and fg:
+            styled_text = click.style(text, fg=fg)
+            self.fp.write(styled_text)
+        else:
+            self.fp.write(text)
 
     @classmethod
     def _prefix_item(cls, item, item_name, prefix):
@@ -145,14 +187,13 @@ class TextDiffWriter(BaseDiffWriter):
         if delta.type == "insert":
             click.secho(f"+++ {ds_path}:{item_type}:{new_key}", bold=True, **self.pecho)
             output = feature_as_text(new_value, prefix="+ ")
-
-            click.secho(output, fg="green", **self.pecho)
+            self._write_colored(output, fg="green")
             return
 
         if delta.type == "delete":
             click.secho(f"--- {ds_path}:{item_type}:{old_key}", bold=True, **self.pecho)
             output = feature_as_text(old_value, prefix="- ")
-            click.secho(output, fg="red", **self.pecho)
+            self._write_colored(output, fg="red")
             return
 
         # More work to do when delta.type == "update"
@@ -169,10 +210,10 @@ class TextDiffWriter(BaseDiffWriter):
                 continue
             if k in old_value:
                 output = feature_field_as_text(old_value, k, prefix="- ")
-                click.secho(output, fg="red", **self.pecho)
+                self._write_colored(output, fg="red")
             if k in new_value:
                 output = feature_field_as_text(new_value, k, prefix="+ ")
-                click.secho(output, fg="green", **self.pecho)
+                self._write_colored(output, fg="green")
 
     # The rest of the class is all just so we can get nice schema diffs. Still, that's important.
     @classmethod
@@ -332,10 +373,10 @@ class TextDiffWriter(BaseDiffWriter):
             if not (delta.flags & BINARY_FILE):
                 if delta.old:
                     output = self._prefix_item(delta.old_value, delta.old_key, "- ")
-                    click.secho(output, fg="red", **self.pecho)
+                    self._write_colored(output, fg="red")
                 if delta.new:
                     output = self._prefix_item(delta.new_value, delta.new_key, "+ ")
-                    click.secho(output, fg="green", **self.pecho)
+                    self._write_colored(output, fg="green")
                 return
 
         file_type = "binary file" if delta.flags & BINARY_FILE else "file"

--- a/kart/text_diff_writer.py
+++ b/kart/text_diff_writer.py
@@ -51,20 +51,24 @@ class TextDiffWriter(BaseDiffWriter):
         """
         Write colored text to output, handling multi-line strings correctly.
 
-        Pagers process output line-by-line, so we need to color each line individually
-        (like git does), not the entire block at once.
+        Equivalent to click.secho(text, ...) - the text is written followed by a
+        single trailing newline - except that each line is colored individually
+        (like git does) rather than wrapping the whole block in one escape
+        sequence. Pagers process output line-by-line, so per-line coloring is
+        needed for colors to display correctly.
         """
         if self.pecho.get("color"):
-            # Color each line individually for proper pager display
-            lines = text.rstrip("\n").split("\n")
-            for line in lines:
-                styled_line = click.style(line, fg=fg, bg=bg, bold=bold)
-                self.fp.write(styled_line)
-                self.fp.write("\n")
+            # Color each (non-empty) line individually for proper pager display.
+            text = "\n".join(
+                click.style(line, fg=fg, bg=bg, bold=bold) if line else ""
+                for line in text.split("\n")
+            )
         else:
-            self.fp.write(text)
-            if not text.endswith("\n"):
-                self.fp.write("\n")
+            # Match click.echo(color=False): strip any embedded ANSI codes
+            # (eg the cyan conflict separator added by _format_item).
+            text = click.unstyle(text)
+        self.fp.write(text)
+        self.fp.write("\n")
 
     @classmethod
     def _check_output_path(cls, repo, output_path):
@@ -89,7 +93,7 @@ class TextDiffWriter(BaseDiffWriter):
             click.secho(f"Merge: {parent_ids_s}", **self.pecho)
         click.secho(f"Author: {author.name} <{author.email}>", **self.pecho)
         click.secho(
-            f'Date:   {author_time_in_author_timezone.strftime("%c %z")}',
+            f"Date:   {author_time_in_author_timezone.strftime('%c %z')}",
             **self.pecho,
         )
         click.secho(**self.pecho)

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -18,7 +18,7 @@ certifi==2025.11.12
     #   requests
 charset-normalizer==3.4.4
     # via requests
-click==8.1.7
+click @ git+https://github.com/craigds/click.git@filelike-pager
     # via
     #   -c requirements.txt
     #   uvicorn

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -18,7 +18,7 @@ certifi==2025.11.12
     #   requests
 charset-normalizer==3.4.4
     # via requests
-click @ git+https://github.com/craigds/click.git@filelike-pager
+click==8.4.1
     # via
     #   -c requirements.txt
     #   uvicorn

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,8 +1,10 @@
 boto3>=1.29.1
 certifi
-# 8.2.x breaks --diff-format somehow (?)
-# 8.3.0 fixes that but breaks Context.invoke (https://github.com/pallets/click/pull/3068)
-click==8.1.7
+# TODO: Switch back to official Click once 9.0.0 is released
+# Using filelike-pager branch for click.get_pager_file() support (PR #1572)
+# Once merged into Click 9.0.0, switch back to: click~=9.0
+# See: https://github.com/pallets/click/pull/1572
+click @ git+https://github.com/craigds/click.git@filelike-pager
 docutils<0.18
 msgspec~=0.18.6
 Pygments

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,10 +1,7 @@
 boto3>=1.29.1
 certifi
-# TODO: Switch back to official Click once 9.0.0 is released
-# Using filelike-pager branch for click.get_pager_file() support (PR #1572)
-# Once merged into Click 9.0.0, switch back to: click~=9.0
-# See: https://github.com/pallets/click/pull/1572
-click @ git+https://github.com/craigds/click.git@filelike-pager
+# 8.4 adds click.get_pager_file() (PR #1572), used for diff/show paging.
+click~=8.4
 docutils<0.18
 msgspec~=0.18.6
 Pygments

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -22,7 +22,7 @@ certifi==2025.11.12
     #   cryptography
     #   pygit2
     #   reflink
-click==8.1.7
+click @ git+https://github.com/craigds/click.git@filelike-pager
     # via -r requirements.in
 #cryptography==44.0.1
     # via -r vendor-wheels.txt

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -22,7 +22,7 @@ certifi==2025.11.12
     #   cryptography
     #   pygit2
     #   reflink
-click @ git+https://github.com/craigds/click.git@filelike-pager
+click==8.4.1
     # via -r requirements.in
 #cryptography==44.0.1
     # via -r vendor-wheels.txt

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -415,9 +415,11 @@ def data_imported(cli_runner, data_archive, chdir, request, tmp_path_factory):
 
 
 class KartCliRunner(CliRunner):
-    def __init__(self, *args, in_pdb=False, mix_stderr=False, **kwargs):
+    def __init__(self, *args, in_pdb=False, **kwargs):
         self._in_pdb = in_pdb
-        super().__init__(*args, mix_stderr=mix_stderr, **kwargs)
+        # mix_stderr was removed in Click 8.2+ - we only support Click 9.0+
+        self.mix_stderr = False
+        super().__init__(*args, **kwargs)
 
     def invoke(self, args=None, **kwargs):
         from kart.cli import load_commands_from_args, cli

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -417,7 +417,7 @@ def data_imported(cli_runner, data_archive, chdir, request, tmp_path_factory):
 class KartCliRunner(CliRunner):
     def __init__(self, *args, in_pdb=False, **kwargs):
         self._in_pdb = in_pdb
-        # mix_stderr was removed in Click 8.2+ - we only support Click 9.0+
+        # mix_stderr was removed in Click 8.2+ (we target Click 8.4.x)
         self.mix_stderr = False
         super().__init__(*args, **kwargs)
 

--- a/tests/test_output_util.py
+++ b/tests/test_output_util.py
@@ -1,4 +1,7 @@
-from kart.output_util import format_wkt_for_output
+import os
+import sys
+
+from kart.output_util import InputMode, format_wkt_for_output, resolve_output_path
 
 NZGD_2000 = """
 PROJCS["NZGD2000 / New Zealand Transverse Mercator 2000",
@@ -56,3 +59,40 @@ def test_format_wkt_for_output():
         '    AXIS["Easting", EAST],',
         '    AXIS["Northing", NORTH]]',
     ]
+
+
+def _mock_pager_file(mocker):
+    """Patches click.get_pager_file to yield a sentinel, and returns (mock, sentinel)."""
+    sentinel = object()
+    pager_cm = mocker.MagicMock()
+    pager_cm.__enter__.return_value = sentinel
+    mock = mocker.patch("kart.output_util.click.get_pager_file", return_value=pager_cm)
+    return mock, sentinel
+
+
+def test_resolve_output_path_pages_when_interactive(mocker):
+    mocker.patch.dict(os.environ, {"KART_PAGER": "cat"})
+    mocker.patch("kart.output_util.get_input_mode", return_value=InputMode.INTERACTIVE)
+    get_pager_file, sentinel = _mock_pager_file(mocker)
+
+    with resolve_output_path("-") as fp:
+        assert fp is sentinel
+    get_pager_file.assert_called_once()
+
+
+def test_resolve_output_path_no_pager_when_disabled(mocker):
+    mocker.patch("kart.output_util.get_input_mode", return_value=InputMode.INTERACTIVE)
+    get_pager_file, _ = _mock_pager_file(mocker)
+
+    with resolve_output_path("-", allow_pager=False) as fp:
+        assert fp is sys.stdout
+    get_pager_file.assert_not_called()
+
+
+def test_resolve_output_path_no_pager_when_not_interactive(mocker):
+    mocker.patch("kart.output_util.get_input_mode", return_value=InputMode.NO_INPUT)
+    get_pager_file, _ = _mock_pager_file(mocker)
+
+    with resolve_output_path("-") as fp:
+        assert fp is sys.stdout
+    get_pager_file.assert_not_called()


### PR DESCRIPTION
## Description

Updates to Click 8.4.1, which has `get_pager_file()` - per my Click PR: pallets/click#1572

Adds output pager to `diff`/`show` commands and reworks the accidentally-existing `log` pager to use the same mechanism

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
