### PR TITLE
Fix invalid JSON escape sequences in HTML output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 # Unreleased
 
 - Helper mode: Fixed crashes when environment variables contain invalid UTF-8 sequences. [#1085](https://github.com/koordinates/kart/issues/1085)
+- Fixes the HTML diff viewer (`-o html`) failing to load the page if the data contained `<`, `>`, or `/` characters. [#1081](https://github.com/koordinates/kart/issues/1081)
 
 ## 0.17.0
 

--- a/kart/html_diff_writer.py
+++ b/kart/html_diff_writer.py
@@ -12,8 +12,15 @@ import kart
 from kart.crs_util import make_crs
 from kart.diff_format import DiffFormat
 from .base_diff_writer import BaseDiffWriter
-from .json_diff_writers import GeojsonDiffWriter
 from .output_util import ExtendedJsonEncoder, resolve_output_path
+
+_JSON_STR_ESCAPES = str.maketrans(
+    {
+        "/": r"\u002f",
+        "<": r"\u003c",
+        ">": r"\u003e",
+    }
+)
 
 
 class HtmlDiffWriter(BaseDiffWriter):
@@ -81,9 +88,6 @@ class HtmlDiffWriter(BaseDiffWriter):
                 "title": html.escape(title),
                 "geojson_data": json.dumps(
                     all_datasets_geojson, cls=ExtendedJsonEncoder
-                )
-                .replace("/", r"\x2f")
-                .replace("<", r"\x3c")
-                .replace(">", r"\x3e"),
+                ).translate(_JSON_STR_ESCAPES),
             }
         )

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -2296,13 +2296,58 @@ def test_xss_protection():
 <html>
   <head>
     <title>Kart Diff: &lt;script&gt;alert(1);&lt;/script&gt;</title>
-    <script type="application/json">{"key": "\\x3c\\x2fscript\\x3e\\x3cscript\\x3ealert(1);\\x3c\\x2fscript\\x3e"}</script>
+    <script type="application/json">{"key": "\\u003c\\u002fscript\\u003e\\u003cscript\\u003ealert(1);\\u003c\\u002fscript\\u003e"}</script>
   </head>
   <body>...</body>
 </html>
 """.lstrip()
 
     assert result == EXPECTED_RESULT
+
+
+def test_html_output_with_special_characters():
+    """Test that special characters in data are properly escaped for JSON in HTML output."""
+    TEMPLATE = """<!DOCTYPE html>
+<html>
+  <head>
+    <title>Kart Diff: ${title}</title>
+    <script id="kart-data" type="application/json">${geojson_data}</script>
+  </head>
+  <body>...</body>
+</html>
+"""
+
+    # Test data with special characters that could break JSON or cause XSS
+    test_data = {
+        "dataset1": {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {
+                        "name": "a name </> with special chars",
+                        "path": "some/path/here",
+                        "html": "<div>content</div>",
+                    },
+                }
+            ],
+        }
+    }
+
+    result = HtmlDiffWriter.substitute_into_template(
+        string.Template(TEMPLATE), "Test Title", test_data
+    )
+
+    # Parse the HTML to extract the JSON
+    parser = html5lib.HTMLParser(strict=True, namespaceHTMLElements=False)
+    document = parser.parse(result)
+    el = document.find("./head/script[@id='kart-data']")
+
+    # This should not raise a JSONDecodeError
+    parsed_data = json.loads(el.text)
+
+    # Verify the data is correct
+    assert parsed_data == test_data
 
 
 def test_diff_format_no_data_changes_json(cli_runner, data_archive):


### PR DESCRIPTION


## Description
Replace Python-style \x hex escapes with JSON-compliant \u Unicode escapes when embedding data in HTML. The \x escape sequence is not valid JSON and causes parsing errors in the browser.

## Related links:

Fixes #1081
## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
