### PR TITLE
Support some kart functions when running from a git clone

### DIFF
--- a/kart/repo.py
+++ b/kart/repo.py
@@ -553,6 +553,9 @@ class KartRepo(pygit2.Repository):
 
     def validate_gitdir_name(self):
         if not self.is_bare and self.gitdir_path.stem not in self.KART_DIR_NAMES:
+            if self.gitdir_path.stem == ".git":
+                L.warning("Selected repo does't follow Kart conventions, but proceeding anyway.")
+                return
             raise NotFound(
                 "Selected repo doesn't follow Kart convention of keeping internals in a '.kart' folder. Perhaps a git repo?",
                 exit_code=NO_REPOSITORY,

--- a/kart/repo.py
+++ b/kart/repo.py
@@ -1,6 +1,7 @@
 import contextlib
 import logging
 import re
+import os
 import struct
 import sys
 from enum import Enum
@@ -553,7 +554,7 @@ class KartRepo(pygit2.Repository):
 
     def validate_gitdir_name(self):
         if not self.is_bare and self.gitdir_path.stem not in self.KART_DIR_NAMES:
-            if self.gitdir_path.stem == ".git":
+            if self.gitdir_path.stem == ".git" and os.environ.get("KART_ALLOW_FROM_GIT") == "1":
                 L.warning("Selected repo does't follow Kart conventions, but proceeding anyway.")
                 return
             raise NotFound(

--- a/kart/repo.py
+++ b/kart/repo.py
@@ -559,7 +559,7 @@ class KartRepo(pygit2.Repository):
                 and os.environ.get("KART_ALLOW_FROM_GIT") == "1"
             ):
                 L.warning(
-                    "Selected repo does't follow Kart conventions, but proceeding anyway."
+                    "Selected repo doesn't follow Kart conventions, but proceeding anyway."
                 )
                 return
             raise NotFound(

--- a/kart/repo.py
+++ b/kart/repo.py
@@ -554,8 +554,13 @@ class KartRepo(pygit2.Repository):
 
     def validate_gitdir_name(self):
         if not self.is_bare and self.gitdir_path.stem not in self.KART_DIR_NAMES:
-            if self.gitdir_path.stem == ".git" and os.environ.get("KART_ALLOW_FROM_GIT") == "1":
-                L.warning("Selected repo does't follow Kart conventions, but proceeding anyway.")
+            if (
+                self.gitdir_path.stem == ".git"
+                and os.environ.get("KART_ALLOW_FROM_GIT") == "1"
+            ):
+                L.warning(
+                    "Selected repo does't follow Kart conventions, but proceeding anyway."
+                )
                 return
             raise NotFound(
                 "Selected repo doesn't follow Kart convention of keeping internals in a '.kart' folder. Perhaps a git repo?",

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -89,6 +89,17 @@ def test_export_path_styles(spec, driver, destination, data_archive, cli_runner)
     assert actual_driver.GetName() == driver
     assert actual_destination == destination
 
+def test_export_from_git(data_archive, cli_runner):
+    with data_archive("polygons") as repo_dir:
+        target_folder = repo_dir / "git-clone"
+
+        r = cli_runner.invoke(["git", "clone", str(repo_dir / ".kart/"), str(target_folder), "--no-checkout"])
+        assert r.exit_code == 0, r.stderr
+
+        r = cli_runner.invoke(["-C", str(target_folder), "export", H.POLYGONS.LAYER, "output.shp"])
+
+        assert r.exit_code == 0, r.stderr
+        assert (repo_dir / "output.shp").exists()
 
 @pytest.mark.parametrize("epsg", [4326, 27200])
 def test_export_with_transformed_crs(epsg, data_archive, cli_runner):

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -97,7 +97,9 @@ def test_export_from_git(data_archive, cli_runner):
         assert r.exit_code == 0, r.stderr
 
         r = cli_runner.invoke(["-C", str(target_folder), "export", H.POLYGONS.LAYER, "output.shp"])
+        assert r.exit_code == 41, r.stderr
 
+        r = cli_runner.invoke(["-C", str(target_folder), "export", H.POLYGONS.LAYER, "output.shp"], env={"KART_ALLOW_FROM_GIT": "1"})
         assert r.exit_code == 0, r.stderr
         assert (repo_dir / "output.shp").exists()
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -89,19 +89,34 @@ def test_export_path_styles(spec, driver, destination, data_archive, cli_runner)
     assert actual_driver.GetName() == driver
     assert actual_destination == destination
 
+
 def test_export_from_git(data_archive, cli_runner):
     with data_archive("polygons") as repo_dir:
         target_folder = repo_dir / "git-clone"
 
-        r = cli_runner.invoke(["git", "clone", str(repo_dir / ".kart/"), str(target_folder), "--no-checkout"])
+        r = cli_runner.invoke(
+            [
+                "git",
+                "clone",
+                str(repo_dir / ".kart/"),
+                str(target_folder),
+                "--no-checkout",
+            ]
+        )
         assert r.exit_code == 0, r.stderr
 
-        r = cli_runner.invoke(["-C", str(target_folder), "export", H.POLYGONS.LAYER, "output.shp"])
+        r = cli_runner.invoke(
+            ["-C", str(target_folder), "export", H.POLYGONS.LAYER, "output.shp"]
+        )
         assert r.exit_code == 41, r.stderr
 
-        r = cli_runner.invoke(["-C", str(target_folder), "export", H.POLYGONS.LAYER, "output.shp"], env={"KART_ALLOW_FROM_GIT": "1"})
+        r = cli_runner.invoke(
+            ["-C", str(target_folder), "export", H.POLYGONS.LAYER, "output.shp"],
+            env={"KART_ALLOW_FROM_GIT": "1"},
+        )
         assert r.exit_code == 0, r.stderr
         assert (repo_dir / "output.shp").exists()
+
 
 @pytest.mark.parametrize("epsg", [4326, 27200])
 def test_export_with_transformed_crs(epsg, data_archive, cli_runner):


### PR DESCRIPTION
## Description

It can be useful to run some kart commands from a sparse git checkout, eg `kart export` currently this fails with "Error: Current directory is not an existing Kart repository" 

Kart can partially work with these folders, I have added a warning log to show support may not work.

## Checklist:

- [x] Have you reviewed your own change? - Works locally
- [x] Have you included test(s)?
- [No] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)? - I am Wondering if this should be a "undocumented feature"?


Fixes #1099