### PR TITLE
ESRI Rest Serivce Import support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Helper mode: Fixed crashes when environment variables contain invalid UTF-8 sequences. [#1085](https://github.com/koordinates/kart/issues/1085)
 - import: `--replace-existing` now preserves attachments (files at the dataset root level, such as licenses or READMEs) instead of deleting them along with the dataset data. [#1083](https://github.com/koordinates/kart/pull/1083)
 - Fixes the HTML diff viewer (`-o html`) failing to load the page if the data contained `<`, `>`, or `/` characters. [#1081](https://github.com/koordinates/kart/issues/1081)
+- Adds support for ArcGIS REST services as import sources. [#1102](https://github.com/koordinates/kart/pull/1102)
 
 ## 0.17.0
 

--- a/docs/include/links.rst
+++ b/docs/include/links.rst
@@ -23,6 +23,7 @@
 .. _postgis: https://postgis.net
 .. _mysql: https://www.mysql.com
 .. _shapefiles: https://doc.arcgis.com/en/arcgis-online/reference/shapefiles.htm
+.. _esri_rest: https://developers.arcgis.com/rest/services-reference/enterprise/feature-service/
 .. _postgis: https://postgis.net
 .. _gpkg_spec: http://www.geopackage.org/spec
 .. _gpkg: http://www.geopackage.org

--- a/docs/pages/command_reference.rst
+++ b/docs/pages/command_reference.rst
@@ -43,6 +43,7 @@ Data can be imported from any of the following types of databases:
 - `Microst SQL Server <sql_server_>`_
 - `MySQL <mysql_>`_
 - `Shapefiles <shapefiles_>`_
+- `ESRI ArcGIS REST Services <esri_rest_>`_ (MapServer/FeatureServer)
 
 The following syntax examples show how to import from each type of
 database.
@@ -54,6 +55,8 @@ database.
    kart import mssql://USERNAME:PASSWORD@HOST/DBNAME/DBSCHEMA table_1 table_2 table_3
    kart import mysql://USERNAME:PASSWORD@HOST/DBNAME/DBSCHEMA table_1 table_2 table_3
    kart import PATH-TO-FILE.shp
+   kart import esri:https://HOST/PATH/MapServer
+   kart import esri:https://HOST/PATH/FeatureServer/LAYER_ID
 
 You can also specify ``--all-tables`` to import all tables from a
 particular datasource.

--- a/docs/pages/table_datasets.rst
+++ b/docs/pages/table_datasets.rst
@@ -24,6 +24,7 @@ Data can be imported from any of the following types of databases:
 - `Microsoft SQL Server <sql_server_>`_
 - `MySQL <mysql_>`_
 - `Shapefiles <shapefiles_>`_
+- `ESRI ArcGIS REST Services <esri_rest_>`_ (MapServer/FeatureServer)
 
 For more information, see :ref:`Import vectors / tables into an existing repository`.
 

--- a/kart/exceptions.py
+++ b/kart/exceptions.py
@@ -117,6 +117,10 @@ class DbConnectionError(BaseException):
         super().__init__(f"{message}\nCaused by error:\n{db_error}")
 
 
+class ImportSourceError(BaseException):
+    exit_code = NO_IMPORT_SOURCE
+
+
 class BadStateError(BaseException):
     pass
 

--- a/kart/fast_import.py
+++ b/kart/fast_import.py
@@ -192,7 +192,7 @@ UNSPECIFIED = object()
 
 def fast_import_tables(
     repo,
-    sources,
+    sources: list[TableImportSource],
     *,
     settings=None,
     verbosity=1,
@@ -437,15 +437,17 @@ def _import_single_source(
                 write_blob_to_stream(proc.stdin, feature_path, blob_data)
 
             if i and progress_every and i % progress_every == 0:
-                click.echo(f"  {i:,d} features... @{time.monotonic()-t1:.1f}s")
+                click.echo(f"  {i:,d} features... @{time.monotonic() - t1:.1f}s")
 
             if limit is not None and i == (limit - 1):
                 click.secho(f"  Stopping at {limit:,d} features", fg="yellow")
                 break
         t2 = time.monotonic()
         if verbosity >= 1:
-            click.echo(f"Added {num_rows:,d} Features to index in {t2-t1:.1f}s")
-            click.echo(f"Overall rate: {(num_rows/(t2-t1 or 1E-3)):.0f} features/s)")
+            click.echo(f"Added {num_rows:,d} Features to index in {t2 - t1:.1f}s")
+            click.echo(
+                f"Overall rate: {(num_rows / (t2 - t1 or 1e-3)):.0f} features/s)"
+            )
 
         # Meta items - written second as certain importers generate extra metadata as they import features.
         for x in write_blobs_to_stream(
@@ -455,7 +457,7 @@ def _import_single_source(
 
     t3 = time.monotonic()
     if verbosity >= 1:
-        click.echo(f"Closed in {(t3-t2):.0f}s")
+        click.echo(f"Closed in {(t3 - t2):.0f}s")
 
 
 def write_blob_to_stream(stream, blob_path, blob_data):

--- a/kart/import_.py
+++ b/kart/import_.py
@@ -9,6 +9,7 @@ from kart.cli_util import (
 )
 from kart.completion_shared import file_path_completer
 from kart.import_sources import from_spec, suggest_specs, ImportType
+from kart.exceptions import ImportSourceError
 
 
 def list_import_formats(ctx):
@@ -128,7 +129,7 @@ def import_(ctx, args, **kwargs):
 
     Note that --dataset can be ommitted if a reasonable name can be inferred from the sources.
     """
-
+    import_source_type = None
     args = [a for a in args if not a.startswith("-")]
     if not args:
         click.echo("At least one SOURCE is required for kart import.", err=True)
@@ -140,9 +141,9 @@ def import_(ctx, args, **kwargs):
             break
 
     if import_source_type is None:
-        raise click.UsageError(
+        raise ImportSourceError(
             "Unrecognised import-source specification.\n"
-            f"Try one of the following:\n{suggest_specs()}"
+            f"Try one of the following:\n{suggest_specs()}",
         )
 
     if kwargs.get("do_link") and import_source_type.import_type in (

--- a/kart/import_.py
+++ b/kart/import_.py
@@ -149,6 +149,7 @@ def import_(ctx, args, **kwargs):
     if kwargs.get("do_link") and import_source_type.import_type in (
         ImportType.SQLALCHEMY_TABLE,
         ImportType.OGR_TABLE,
+        ImportType.ESRI_REST_TABLE,
     ):
         raise click.UsageError("--link is not supported for vector or tabular imports")
 

--- a/kart/import_sources.py
+++ b/kart/import_sources.py
@@ -13,12 +13,13 @@ class ImportType(Enum):
 
     SQLALCHEMY_TABLE = auto()
     OGR_TABLE = auto()
+    ESRI_REST_TABLE = auto()
     POINT_CLOUD = auto()
     RASTER = auto()
 
     @property
     def import_cmd(self):
-        if self in (self.SQLALCHEMY_TABLE, self.OGR_TABLE):
+        if self in (self.SQLALCHEMY_TABLE, self.OGR_TABLE, self.ESRI_REST_TABLE):
             from kart.tabular.import_ import table_import
 
             return table_import
@@ -37,6 +38,11 @@ class ImportType(Enum):
             from kart.tabular import SqlAlchemyTableImportSource
 
             return SqlAlchemyTableImportSource
+
+        elif self is self.ESRI_REST_TABLE:
+            from kart.tabular import ESRIRestImportSource
+
+            return ESRIRestImportSource
         elif self is self.OGR_TABLE:
             from kart.tabular import OgrTableImportSource
 
@@ -113,6 +119,12 @@ ALL_IMPORT_SOURCE_TYPES = [
         "PATH.shp",
         ImportType.OGR_TABLE,
         file_ext=(".shp", ".shx", ".dbf"),
+    ),
+    ImportSourceType(
+        "ESRI Rest Service",
+        "esri:https://HOST/PATH/FeatureServer/[LAYER_ID]",
+        ImportType.ESRI_REST_TABLE,
+        uri_scheme="esri",
     ),
     ImportSourceType(
         "OGR", "OGR:...", ImportType.OGR_TABLE, uri_scheme="OGR", hidden=True

--- a/kart/import_sources.py
+++ b/kart/import_sources.py
@@ -1,9 +1,7 @@
 from enum import Enum, auto
 import os
 
-import click
-
-from kart.exceptions import NotYetImplemented
+from kart.exceptions import ImportSourceError, NotYetImplemented
 
 
 class ImportType(Enum):
@@ -59,7 +57,6 @@ class ImportSourceType:
         *,
         uri_scheme=None,
         file_ext=None,
-        optional_prefix=None,
         hidden=False,
     ):
         self.name = name
@@ -73,7 +70,6 @@ class ImportSourceType:
             self.file_ext = (file_ext,)
         elif isinstance(file_ext, tuple):
             self.file_ext = file_ext
-        self.optional_prefix = optional_prefix
         self.hidden = hidden
 
     @property
@@ -92,7 +88,6 @@ ALL_IMPORT_SOURCE_TYPES = [
         "PATH.gpkg",
         ImportType.SQLALCHEMY_TABLE,
         file_ext=".gpkg",
-        optional_prefix="GPKG:",
     ),
     ImportSourceType(
         "PostgreSQL",
@@ -200,7 +195,7 @@ def suggest_specs(suggestions=None, import_types=None, indent="    "):
 
 
 def bad_spec_error(spec, suggestions=None):
-    """If the user provided a bad format specification, returns a UsageError that tries to help them fix it."""
+    """If the user provided a bad format specification, returns a ImportSourceError that tries to help them fix it."""
     if suggestions is None:
         suggestion = from_spec(spec, allow_unrecognised=True)
         suggestions = (
@@ -210,9 +205,9 @@ def bad_spec_error(spec, suggestions=None):
     try_the_following = (
         "Try one of the following" if len(suggestions) >= 2 else "Try the following"
     )
-    return click.UsageError(
+    return ImportSourceError(
         f"Unrecognised import-source specification: {spec}\n"
-        f"{try_the_following}:\n{suggest_specs(suggestions)}"
+        f"{try_the_following}:\n{suggest_specs(suggestions)}",
     )
 
 

--- a/kart/init.py
+++ b/kart/init.py
@@ -52,8 +52,7 @@ from .working_copy import PartType
     "--initial-branch",
     default=None,  # Not specified? We use git's `init.defaultBranch` config
     help=(
-        "Use the specified name for the initial branch "
-        "in the newly created repository."
+        "Use the specified name for the initial branch in the newly created repository."
     ),
 )
 @click.option(

--- a/kart/tabular/__init__.py
+++ b/kart/tabular/__init__.py
@@ -1,0 +1,15 @@
+from .ogr_import_source import OgrTableImportSource
+from .sqlalchemy_import_source import SqlAlchemyTableImportSource
+from .esri_rest_import_source import (
+    ESRIJSONImportSource,
+    ESRIRestServerSource,
+    ESRIRestImportSource,
+)
+
+__all__ = [
+    "OgrTableImportSource",
+    "SqlAlchemyTableImportSource",
+    "ESRIJSONImportSource",
+    "ESRIRestServerSource",
+    "ESRIRestImportSource",
+]

--- a/kart/tabular/esri_rest_import_source.py
+++ b/kart/tabular/esri_rest_import_source.py
@@ -3,7 +3,8 @@ Import source for ESRI Rest services (MapServer/FeatureServer).
 
 ESRI Rest services can be imported using the "ESRIJSON" OGR driver which does the
 heavy lifting of fetching data from the service and converting it to a format we can
-import. This module provides two classes:
+import. This module provides ESRIRestImportSource which routes to either of the following
+depending on supplied source:
 
 ESRIRestServerSource:
     Discovers and lists all available layers from a MapServer/FeatureServer endpoint.
@@ -16,7 +17,7 @@ ESRIRestServerSource:
         tables = source.get_tables()
 
         # Import all layers from a service
-        kart import "https://example.com/.../MapServer"
+        kart import "esri:https://example.com/.../MapServer"
 
 ESRIJSONImportSource:
     Imports a specific layer from a MapServer/FeatureServer by layer ID.
@@ -26,8 +27,6 @@ ESRIJSONImportSource:
         # Import a specific layer
         kart import "esri:https://example.com/.../MapServer/0" --dataset my_layer
 
-        # Or without the esri: prefix
-        kart import "https://example.com/.../MapServer/0"
 """
 
 import functools

--- a/kart/tabular/esri_rest_import_source.py
+++ b/kart/tabular/esri_rest_import_source.py
@@ -1,0 +1,413 @@
+"""
+Import source for ESRI Rest services (MapServer/FeatureServer).
+
+ESRI Rest services can be imported using the "ESRIJSON" OGR driver which does the
+heavy lifting of fetching data from the service and converting it to a format we can
+import. This module provides two classes:
+
+ESRIRestServerSource:
+    Discovers and lists all available layers from a MapServer/FeatureServer endpoint.
+    Use this when you want to import multiple layers from a service or need to see
+    what layers are available.
+
+    Example:
+        # List all layers in a service
+        source = ESRIRestServerSource.open("https://example.com/.../MapServer")
+        tables = source.get_tables()
+
+        # Import all layers from a service
+        kart import "https://example.com/.../MapServer"
+
+ESRIJSONImportSource:
+    Imports a specific layer from a MapServer/FeatureServer by layer ID.
+    Automatically constructs proper query URLs with necessary parameters.
+
+    Example:
+        # Import a specific layer
+        kart import "esri:https://example.com/.../MapServer/0" --dataset my_layer
+
+        # Or without the esri: prefix
+        kart import "https://example.com/.../MapServer/0"
+"""
+
+import functools
+import json
+import re
+import sys
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+from urllib.request import urlopen
+
+from .import_source import TableImportSource
+from .ogr_import_source import OgrTableImportSource
+from kart.exceptions import ImportSourceError
+
+
+class ESRIRestImportSource(TableImportSource):
+    """
+    Router class for ESRI Rest service imports.
+
+    This class examines the URL and routes to either:
+    - ESRIRestServerSource: for server-level URLs (without layer ID)
+    - ESRIJSONImportSource: for layer-specific URLs (with layer ID)
+    """
+
+    @classmethod
+    def open(cls, source, table=None):
+        """
+        Route to the appropriate ESRI import source based on URL structure.
+
+        Server URLs (no layer ID) -> ESRIRestServerSource
+        Layer URLs (with layer ID) -> ESRIJSONImportSource
+        """
+        spec = str(source).lstrip("esri:")
+        parsed = urlparse(spec)
+
+        # Check if this is a server-level URL (MapServer/FeatureServer without layer ID)
+        # or a layer-specific URL (with layer ID)
+        if re.search(r"/(MapServer|FeatureServer)/\d+", parsed.path, re.I):
+            # Layer-specific URL - use ESRIJSONImportSource
+            return ESRIJSONImportSource.open(source, table=table)
+        elif re.search(r"/(MapServer|FeatureServer)/?$", parsed.path, re.I):
+            # Server-level URL - use ESRIRestServerSource
+            return ESRIRestServerSource.open(source, table=table)
+        else:
+            raise ImportSourceError(
+                "Invalid ESRI Rest service URL. Expected format:\n"
+                "  Server: esri:https://HOST/PATH/MapServer\n"
+                "  Layer:  esri:https://HOST/PATH/MapServer/LAYER_ID"
+            )
+
+
+class ESRIRestServerSource(TableImportSource):
+    """
+    Import source for discovering and importing all layers from an ESRI Rest service.
+
+    This class handles MapServer/FeatureServer endpoints and discovers available layers,
+    then delegates the actual import of each layer to ESRIJSONImportSource.
+    """
+
+    @classmethod
+    def open(cls, source, table=None):
+        """Open an ESRI Rest service and optionally select a specific layer."""
+        spec = str(source).lstrip("esri:")
+        parsed = urlparse(spec)
+
+        # Validate the URL points to a MapServer or FeatureServer
+        if service_match := re.search(
+            r"(?P<base>.*/(MapServer|FeatureServer))(?P<remainder>/.*)?$",
+            parsed.path,
+            re.I,
+        ):
+            base_path = service_match.group("base")
+            remainder = service_match.group("remainder")
+
+            # If it already has a layer ID, this should be handled by ESRIJSONImportSource
+            if remainder and re.match(r"^/\d+(/.*)?$", remainder):
+                raise ImportSourceError(
+                    "Use ESRIJSONImportSource for specific layer imports. "
+                    "ESRIRestServerSource is for server-level discovery."
+                )
+        else:
+            raise ImportSourceError(
+                "Invalid ESRI Rest service URL. Expected format: "
+                "esri:https://HOST/PATH/MapServer or esri:https://HOST/PATH/FeatureServer"
+            )
+
+        # Build the base service URL (without layer ID)
+        base_url = urlunparse(
+            (
+                parsed.scheme,
+                parsed.netloc,
+                base_path,
+                parsed.params,
+                "",
+                parsed.fragment,
+            )
+        )
+
+        return cls(base_url, table=table)
+
+    def __init__(self, base_url, table=None):
+        """
+        Initialize the ESRIRestServerSource.
+
+        Args:
+            base_url: Base URL of the MapServer/FeatureServer (without layer ID)
+            table: Optional specific layer name/ID to import
+        """
+        self.base_url = base_url
+        self.table = table
+
+    @functools.lru_cache(maxsize=1)
+    def _get_layer_metadata(self):
+        """
+        Fetch and cache layer metadata from the ESRI Rest service.
+
+        Returns:
+            dict: Service metadata from the ?f=json endpoint
+        """
+        metadata_url = f"{self.base_url}?f=json"
+
+        try:
+            with urlopen(metadata_url) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except Exception as e:
+            raise ImportSourceError(
+                f"Failed to fetch service metadata from {metadata_url}: {e}"
+            )
+
+    @functools.lru_cache(maxsize=1)
+    def get_tables(self):
+        """
+        Discover available layers from the ESRI Rest service.
+
+        Returns:
+            dict: Dictionary mapping layer names to layer info dicts
+        """
+        service_info = self._get_layer_metadata()
+
+        # Extract layers from the service info
+        layers = {}
+        for layer_info in service_info.get("layers", []):
+            layer_id = layer_info.get("id")
+            layer_name = layer_info.get("name")
+
+            if layer_id is not None and layer_name:
+                layers[layer_name] = {
+                    "id": layer_id,
+                    "name": layer_name,
+                    "type": "layer",
+                }
+
+        # Also check for 'tables' in FeatureServer responses
+        for table_info in service_info.get("tables", []):
+            table_id = table_info.get("id")
+            table_name = table_info.get("name")
+
+            if table_id is not None and table_name:
+                layers[table_name] = {
+                    "id": table_id,
+                    "name": table_name,
+                    "type": "table",
+                }
+
+        if not layers:
+            raise ImportSourceError(
+                f"No layers found in ESRI Rest service: {self.base_url}"
+            )
+
+        # If a specific table was requested, filter to just that one
+        if self.table is not None:
+            if self.table in layers:
+                return {self.table: layers[self.table]}
+            else:
+                # Try to match by ID as well
+                try:
+                    layer_id = int(self.table)
+                    # Create a pseudo-entry for this layer ID
+                    return {
+                        self.table: {
+                            "id": layer_id,
+                            "name": self.table,
+                            "type": "layer",
+                        }
+                    }
+                except ValueError:
+                    raise ImportSourceError(
+                        f"Layer '{self.table}' not found in service. "
+                        f"Available layers: {', '.join(layers.keys())}"
+                    )
+
+        return layers
+
+    def print_table_list(self, *, do_json=False):
+        """Print a list of available layers in the ESRI Rest service."""
+        from kart.output_util import dump_json_output
+
+        tables = self.get_tables()
+
+        if do_json:
+            dump_json_output({"kart.tables/v1": list(tables.keys())}, sys.stdout)
+        else:
+            for name in tables:
+                print(name)
+
+    def default_dest_path(self):
+        """Default destination path based on the service name."""
+        # Extract service name from URL
+        match = re.search(r"/([^/]+)/(MapServer|FeatureServer)", self.base_url, re.I)
+        if match:
+            service_name = match.group(1)
+            if self.table:
+                return self._normalise_dataset_path(f"{service_name}/{self.table}")
+            return self._normalise_dataset_path(service_name)
+        return self._normalise_dataset_path("esri_service")
+
+    def clone_for_table(
+        self, table, *, dest_path=None, primary_key=None, meta_overrides=None
+    ):
+        """
+        Create an import source for a specific table/layer.
+
+        Returns an ESRIJSONImportSource configured for the specified layer.
+        """
+        tables = self.get_tables()
+
+        if table not in tables:
+            raise ImportSourceError(
+                f"Layer '{table}' not found in service. "
+                f"Available layers: {', '.join(tables.keys())}"
+            )
+
+        # Get the layer metadata
+        layer_info = tables[table]
+        layer_id = layer_info["id"]
+        layer_name = layer_info["name"]
+
+        # Construct the URL for this layer
+        layer_url = f"{self.base_url}/{layer_id}"
+
+        # Create and open an ESRIJSONImportSource for this layer
+        layer_source = ESRIJSONImportSource.open(layer_url, table=layer_name)
+
+        # If dest_path or other overrides are provided, clone with those settings
+        if dest_path or primary_key or meta_overrides:
+            if hasattr(layer_source, "clone_for_table"):
+                return layer_source.clone_for_table(
+                    layer_source.table,
+                    dest_path=dest_path,
+                    primary_key=primary_key,
+                    meta_overrides=meta_overrides or {},
+                )
+            else:
+                # If it doesn't have clone_for_table, just set dest_path
+                if dest_path:
+                    layer_source.dest_path = dest_path
+                return layer_source
+
+        return layer_source
+
+    def __str__(self):
+        if self.table:
+            return f"ESRIRestServerSource({self.base_url}, table={self.table})"
+        return f"ESRIRestServerSource({self.base_url})"
+
+    def aggregate_import_source_desc(self, import_sources):
+        """Return a description of all layers being imported from this service."""
+        if len(import_sources) == 1:
+            source = next(iter(import_sources))
+            return source.import_source_desc()
+
+        desc = f"Import {len(import_sources)} layers from {self.base_url}:"
+        for source in import_sources:
+            desc += f"\n * {source.dest_path}/"
+        return desc
+
+
+class ESRIJSONImportSource(OgrTableImportSource):
+    """
+    Import source for ESRI Rest services (MapServer/FeatureServer).
+
+    Handles:
+    - Automatic construction of query URLs with necessary parameters
+    - Layer-specific imports from MapServer/FeatureServer endpoints
+    """
+
+    def __init__(
+        self,
+        ogr_ds,
+        table=None,
+        *,
+        source,
+        ogr_source,
+        dest_path=None,
+        primary_key=None,
+        meta_overrides=None,
+    ):
+        # For ESRI JSON sources, the datasource typically has only one layer
+        # If no table is specified or the specified table doesn't exist,
+        # use the first (and usually only) layer in the datasource
+        if table is None or ogr_ds.GetLayerByName(table) is None:
+            if ogr_ds.GetLayerCount() > 0:
+                actual_layer = ogr_ds.GetLayerByIndex(0)
+                actual_table_name = actual_layer.GetName()
+                # If a table name was requested but doesn't match, still use it for dest_path
+                # but use the actual layer name for accessing the data
+                if table and table != actual_table_name:
+                    # Store the requested name for dest_path purposes
+                    if not dest_path:
+                        dest_path = table
+                    table = actual_table_name
+                elif not table:
+                    table = actual_table_name
+            elif table is None:
+                raise ImportSourceError(
+                    f"No layers found in ESRI JSON datasource: {source}"
+                )
+
+        super().__init__(
+            ogr_ds,
+            table,
+            source=source,
+            ogr_source=ogr_source,
+            dest_path=dest_path,
+            primary_key=primary_key,
+            meta_overrides=meta_overrides,
+        )
+
+    @classmethod
+    def adapt_source_for_ogr(cls, source):
+        source = str(source).lstrip("esri:")
+
+        parsed = urlparse(source)
+
+        # Validate the URL and ensure the /query endpoint for the service is used:
+        if layer_match := re.search(
+            r"(?P<base>.*/(MapServer|FeatureServer)/)(?P<layer_id>\d+)(?P<remainder>/[^?]*)?$",
+            parsed.path,
+            re.I,
+        ):
+            # Raise errors on unexpected path suffixes
+            if layer_match.group("remainder") not in [None, "/", "/query"]:
+                raise ImportSourceError(
+                    "Invalid ESRI Rest service URL. Expected format: "
+                    "esri:https://HOST/PATH/MapServer/LAYER_ID or esri:https://HOST/PATH/FeatureServer/LAYER_ID"
+                )
+            adapted_path = (
+                f"{layer_match.group('base')}{layer_match.group('layer_id')}/query"
+            )
+        else:
+            raise ImportSourceError(
+                "Invalid ESRI Rest service URL. Expected format: "
+                "esri:https://HOST/PATH/MapServer/LAYER_ID or esri:https://HOST/PATH/FeatureServer/LAYER_ID"
+            )
+
+        parsed = urlparse(source)
+        query_params = parse_qs(parsed.query, keep_blank_values=True)
+        # always override format:
+        query_params["f"] = ["json"]
+
+        # Create a lowercase key lookup for case-insensitive checking
+        query_params_lower = {k.lower(): k for k in query_params.keys()}
+
+        # Add default parameters if not already present (case-insensitive)
+        if "where" not in query_params_lower:
+            query_params["where"] = ["1=1"]
+        if "outfields" not in query_params_lower:
+            query_params["outFields"] = ["*"]
+        if "returngeometry" not in query_params_lower:
+            query_params["returnGeometry"] = ["true"]
+
+        # Rebuild query string
+        new_query = urlencode(query_params, doseq=True)
+        adapted_url = urlunparse(
+            (
+                parsed.scheme,
+                parsed.netloc,
+                adapted_path,
+                parsed.params,
+                new_query,
+                parsed.fragment,
+            )
+        )
+        return adapted_url, ["ESRIJSON"]

--- a/kart/tabular/import_.py
+++ b/kart/tabular/import_.py
@@ -28,7 +28,13 @@ def list_import_formats(ctx):
     from kart.import_sources import ImportType
 
     click.echo(
-        suggest_specs(import_types=(ImportType.SQLALCHEMY_TABLE, ImportType.OGR_TABLE))
+        suggest_specs(
+            import_types=(
+                ImportType.SQLALCHEMY_TABLE,
+                ImportType.OGR_TABLE,
+                ImportType.ESRI_REST_TABLE,
+            )
+        )
     )
 
 

--- a/kart/tabular/import_source.py
+++ b/kart/tabular/import_source.py
@@ -4,6 +4,7 @@ from kart.exceptions import NO_TABLE, NotFound
 from kart import list_of_conflicts
 from kart.schema import Schema
 from kart.output_util import InputMode, get_input_mode
+from kart.import_sources import from_spec
 
 
 class TableImportSource:
@@ -24,20 +25,17 @@ class TableImportSource:
         return spec
 
     @classmethod
-    def open(cls, full_spec, table=None):
-        from kart.sqlalchemy import DbType
+    def open(cls, source, table=None):
+        spec = cls._remove_unnecessary_prefix(str(source))
 
-        spec = cls._remove_unnecessary_prefix(str(full_spec))
+        source_type = from_spec(spec)
 
-        db_type = DbType.from_spec(spec)
-        if db_type is not None:
-            from .sqlalchemy_import_source import SqlAlchemyTableImportSource
-
-            return SqlAlchemyTableImportSource.open(spec, table=table)
+        if source_type is not None:
+            return source_type.import_source_class.open(spec, table=table)
         else:
             from .ogr_import_source import OgrTableImportSource
 
-            return OgrTableImportSource.open(full_spec, table=table)
+            return OgrTableImportSource.open(source, table=table)
 
     @classmethod
     def check_valid(cls, import_sources, param_hint=None):

--- a/kart/tabular/import_source.py
+++ b/kart/tabular/import_source.py
@@ -13,7 +13,7 @@ class TableImportSource:
     A read-only interface.
     """
 
-    UNNECESSARY_PREFIXES = ("OGR:", "GPKG:", "PG:")
+    UNNECESSARY_PREFIXES = ("GPKG:", "PG:")
 
     @classmethod
     def _remove_unnecessary_prefix(cls, spec):
@@ -35,7 +35,7 @@ class TableImportSource:
         else:
             from .ogr_import_source import OgrTableImportSource
 
-            return OgrTableImportSource.open(source, table=table)
+            return OgrTableImportSource.open(spec, table=table)
 
     @classmethod
     def check_valid(cls, import_sources, param_hint=None):

--- a/kart/tabular/ogr_import_source.py
+++ b/kart/tabular/ogr_import_source.py
@@ -10,8 +10,8 @@ from osgeo import gdal, ogr
 
 from kart import crs_util, ogr_util
 from kart.exceptions import (
-    NO_IMPORT_SOURCE,
     NO_TABLE,
+    ImportSourceError,
     InvalidOperation,
     NotFound,
 )
@@ -60,11 +60,13 @@ class OgrTableImportSource(TableImportSource):
         # Optionally, accept driver-prefixed paths like 'GPKG:'
         allowed_formats = sorted(FORMAT_TO_OGR_MAP.keys())
         m = re.match(
-            rf'^(OGR|{"|".join(FORMAT_TO_OGR_MAP.keys())}):(.+)$', ogr_source, re.I
+            rf"^(OGR|{'|'.join(FORMAT_TO_OGR_MAP.keys())}):(.+)$", ogr_source, re.I
         )
         prefix = None
+
         if m:
             prefix, ogr_source = m.groups()
+            ogr_source = str(ogr_source)
             prefix = prefix.upper()
             if prefix == "OGR":
                 # Don't specify a driver; let OGR just do whatever it can do.
@@ -83,17 +85,7 @@ class OgrTableImportSource(TableImportSource):
                     ogr_source = f"{prefix}:{ogr_source}"
             if prefix in LOCAL_PATH_FORMATS:
                 if not os.path.exists(ogr_source):
-                    raise NotFound(
-                        f"Couldn't find {ogr_source!r}", exit_code=NO_IMPORT_SOURCE
-                    )
-        else:
-            # see if any subclasses have a handler for this.
-            for subclass in cls._all_subclasses():
-                if "handle_source_string" in subclass.__dict__:
-                    retval = subclass.handle_source_string(ogr_source)
-                    if retval is not None:
-                        ogr_source, allowed_formats = retval
-                        break
+                    raise ImportSourceError(f"Couldn't find {ogr_source!r}")
 
         return ogr_source, allowed_formats
 
@@ -123,14 +115,12 @@ class OgrTableImportSource(TableImportSource):
                 base_filename = os.path.splitext(os.path.basename(source))[0]
                 shx_file = base_filename + ".shx"
                 if not os.path.exists(shx_file):
-                    raise NotFound(
+                    raise ImportSourceError(
                         f"Import source was missing some required files: {shx_file}",
-                        exit_code=NO_IMPORT_SOURCE,
                     ) from e
-            raise NotFound(
+            raise ImportSourceError(
                 f"{ogr_source!r} doesn't appear to be valid "
                 f"(tried formats: {','.join(allowed_formats) if allowed_formats else '(all)'})\n{e}",
-                exit_code=NO_IMPORT_SOURCE,
             ) from e
 
         try:

--- a/kart/tabular/ogr_import_source.py
+++ b/kart/tabular/ogr_import_source.py
@@ -31,13 +31,14 @@ from .import_source import TableImportSource
 FORMAT_TO_OGR_MAP = {
     "GPKG": "GPKG",
     "SHP": "ESRI Shapefile",
+    "ESRIJSON": "ESRIJSON",
     # https://github.com/koordinates/kart/issues/86
     # 'TAB': 'MapInfo File',
     "PG": "PostgreSQL",
 }
 # The set of format prefixes where a local path is expected
 # (as opposed to a URL / something else)
-LOCAL_PATH_FORMATS = set(FORMAT_TO_OGR_MAP.keys()) - {"PG"}
+LOCAL_PATH_FORMATS = set(FORMAT_TO_OGR_MAP.keys()) - {"PG", "ESRIJSON"}
 
 
 class OgrTableImportSource(TableImportSource):

--- a/kart/tabular/pk_generation.py
+++ b/kart/tabular/pk_generation.py
@@ -71,7 +71,7 @@ class PkGeneratingTableImportSource(TableImportSource):
     }
 
     @classmethod
-    def wrap_source_if_needed(cls, source, repo, **kwargs):
+    def wrap_source_if_needed(cls, source: TableImportSource, repo, **kwargs):
         """Wraps an TableImportSource in a PkGeneratingTableImportSource if the original data lacks a primary key."""
         return (
             source
@@ -80,7 +80,7 @@ class PkGeneratingTableImportSource(TableImportSource):
         )
 
     @classmethod
-    def wrap_sources_if_needed(cls, sources, repo, **kwargs):
+    def wrap_sources_if_needed(cls, sources: list[TableImportSource], repo, **kwargs):
         """Wraps any of the given TableImportSources that lack a primary key, returns the result as a new list."""
         return [cls.wrap_source_if_needed(source, repo, **kwargs) for source in sources]
 

--- a/tests/data/test-point.esrijson
+++ b/tests/data/test-point.esrijson
@@ -1,0 +1,70 @@
+{
+  "displayFieldName": "FEATURE_TYPE",
+  "fieldAliases": {
+    "FEATURE_TYPE": "FEATURE_TYPE",
+    "ID": "ID",
+    "SOURCE": "SOURCE",
+    "DATE_SUPPLIED": "DATE_SUPPLIED",
+    "FEATURE_ACCURACY": "FEATURE_ACCURACY",
+    "OBJECTID": "OBJECTID"
+  },
+  "geometryType": "esriGeometryPoint",
+  "spatialReference": {
+    "wkid": 2193,
+    "latestWkid": 2193
+  },
+  "fields": [
+    {
+      "name": "FEATURE_TYPE",
+      "type": "esriFieldTypeString",
+      "alias": "FEATURE_TYPE",
+      "length": 8
+    },
+    {
+      "name": "ID",
+      "type": "esriFieldTypeString",
+      "alias": "ID",
+      "length": 50
+    },
+    {
+      "name": "SOURCE",
+      "type": "esriFieldTypeString",
+      "alias": "SOURCE",
+      "length": 58
+    },
+    {
+      "name": "DATE_SUPPLIED",
+      "type": "esriFieldTypeDate",
+      "alias": "DATE_SUPPLIED",
+      "length": 8
+    },
+    {
+      "name": "FEATURE_ACCURACY",
+      "type": "esriFieldTypeString",
+      "alias": "FEATURE_ACCURACY",
+      "length": 25
+    },
+    {
+      "name": "OBJECTID",
+      "type": "esriFieldTypeOID",
+      "alias": "OBJECTID"
+    }
+  ],
+  "features": [
+    {
+      "attributes": {
+        "FEATURE_TYPE": "Test Feature",
+        "LINK": null,
+        "ID": "Test ID",
+        "SOURCE": "Test Source",
+        "DATE_SUPPLIED": 1401062400000,
+        "FEATURE_ACCURACY": "+/- 10m (1:10,000)",
+        "OBJECTID": 1349962
+      },
+      "geometry": {
+        "x": 1426256.0450000763,
+        "y": 5114622.024600029
+      }
+    }
+  ]
+}

--- a/tests/test_esri_rest_import_source.py
+++ b/tests/test_esri_rest_import_source.py
@@ -430,14 +430,16 @@ class TestESRIRestImportSourceRouter:
     def test_routes_to_layer_source(self):
         """Test that layer URLs route to ESRIJSONImportSource."""
         # Note: This will fail at OGR open time, but we can verify the routing
-        try:
+        with pytest.raises(ImportSourceError) as exc_info:
             source = ESRIRestImportSource.open(
                 "esri:https://example.com/arcgis/rest/services/MyService/MapServer/0"
             )
-            assert isinstance(source, ESRIJSONImportSource)
-        except Exception:
-            # Expected - OGR can't actually open this URL
-            pass
+        # Implied here: the layer URL was routed to ESRIJSONImportSource, which then failed to open it (since it's not a real service),
+        # and the error message should include the adapted URL:
+        assert (
+            "https://example.com/arcgis/rest/services/MyService/MapServer/0/query?f=json&where=1%3D1&outFields=%2A&returnGeometry=true"
+            in str(exc_info.value)
+        )
 
     def test_invalid_url_raises_error(self):
         """Test that invalid URLs raise an error."""

--- a/tests/test_esri_rest_import_source.py
+++ b/tests/test_esri_rest_import_source.py
@@ -1,0 +1,446 @@
+import pytest
+from pathlib import Path
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from threading import Thread
+import json
+
+from kart.exceptions import ImportSourceError
+from kart.repo import KartRepo
+from kart.tabular.esri_rest_import_source import (
+    ESRIJSONImportSource,
+    ESRIRestServerSource,
+    ESRIRestImportSource,
+)
+
+
+class TestESRIJSONImportSourceURLAdaptation:
+    """Tests for ESRIJSONImportSource.adapt_source_for_ogr() URL handling."""
+
+    @pytest.mark.parametrize(
+        "source,expected_adapted_url",
+        [
+            (
+                "https://example.com/arcgis/rest/services/MyService/MapServer/0",
+                "https://example.com/arcgis/rest/services/MyService/MapServer/0/query",
+            ),
+            (
+                "esri:https://example.com/arcgis/rest/services/MyService/MapServer/0/",
+                "https://example.com/arcgis/rest/services/MyService/MapServer/0/query",
+            ),
+            (
+                "https://example.com/arcgis/rest/services/MyService/FEATURESERVER/0",
+                "https://example.com/arcgis/rest/services/MyService/FEATURESERVER/0/query",
+            ),
+            (
+                "esri:https://example.com/arcgis/rest/services/MyService/MapServer/0/query",
+                "https://example.com/arcgis/rest/services/MyService/MapServer/0/query",
+            ),
+            (
+                "https://example.com/arcgis/rest/services/MyService/MapServer/5",
+                "https://example.com/arcgis/rest/services/MyService/MapServer/5/query",
+            ),
+            (
+                "esri:https://example.com/arcgis/rest/services/MyService/MapServer/0",
+                "https://example.com/arcgis/rest/services/MyService/MapServer/0/query",
+            ),
+            (
+                "https://gis.example.com/server/rest/services/Folder1/Folder2/MyService/MapServer/12",
+                "https://gis.example.com/server/rest/services/Folder1/Folder2/MyService/MapServer/12/query",
+            ),
+            (
+                "esri:https://example.com:6443/arcgis/rest/services/MyService/MapServer/0",
+                "https://example.com:6443/arcgis/rest/services/MyService/MapServer/0/query",
+            ),
+        ],
+    )
+    def test_mapserver_url_basic(self, source, expected_adapted_url):
+        """Test rest URL adaptation."""
+        adapted_url, drivers = ESRIJSONImportSource.adapt_source_for_ogr(source)
+
+        assert drivers == ["ESRIJSON"]
+        assert expected_adapted_url in adapted_url
+        assert "where=1%3D1" in adapted_url  # where=1=1
+        assert "f=json" in adapted_url
+        assert "outFields=%2A" in adapted_url  # outFields=*
+        assert "returnGeometry=true" in adapted_url
+
+
+class TestESRIJSONImportSourceQueryParameters:
+    """Tests for query parameter handling."""
+
+    def test_default_parameters_added(self):
+        """Test that default parameters are added when not present."""
+        source = "https://example.com/arcgis/rest/services/MyService/MapServer/0"
+        adapted_url, _ = ESRIJSONImportSource.adapt_source_for_ogr(source)
+
+        assert "where=1%3D1" in adapted_url
+        assert "f=json" in adapted_url
+        assert "outFields=%2A" in adapted_url
+        assert "returnGeometry=true" in adapted_url
+
+    def test_existing_where_preserved(self):
+        """Test that existing where parameter is preserved."""
+        source = "https://example.com/arcgis/rest/services/MyService/MapServer/0?where=STATE='CA'"
+        adapted_url, _ = ESRIJSONImportSource.adapt_source_for_ogr(source)
+
+        assert (
+            "where=STATE%3D%27CA%27" in adapted_url or "where=STATE='CA'" in adapted_url
+        )
+        # Should not have the default where=1=1
+        assert adapted_url.count("where=") == 1
+
+    def test_existing_format_overridden(self):
+        """Test that existing f parameter is overridden."""
+        source = (
+            "https://example.com/arcgis/rest/services/MyService/MapServer/0?f=geojson"
+        )
+        adapted_url, _ = ESRIJSONImportSource.adapt_source_for_ogr(source)
+
+        assert "f=json" in adapted_url
+        assert adapted_url.count("f=") == 1
+
+    def test_existing_outfields_preserved(self):
+        """Test that existing outFields parameter is preserved."""
+        source = "https://example.com/arcgis/rest/services/MyService/MapServer/0?outFields=NAME,POPULATION"
+        adapted_url, _ = ESRIJSONImportSource.adapt_source_for_ogr(source)
+
+        assert "outFields=NAME" in adapted_url
+        assert "POPULATION" in adapted_url
+
+    def test_existing_returngeometry_preserved(self):
+        """Test that existing returnGeometry parameter is preserved."""
+        source = "https://example.com/arcgis/rest/services/MyService/MapServer/0?returnGeometry=false"
+        adapted_url, _ = ESRIJSONImportSource.adapt_source_for_ogr(source)
+
+        assert "returnGeometry=false" in adapted_url
+
+    def test_case_insensitive_parameter_check(self):
+        """Test that parameter checking is case-insensitive."""
+        # Using uppercase parameter names
+        source = "https://example.com/arcgis/rest/services/MyService/MapServer/0?WHERE=1=1&F=geojson&OUTFIELDS=*&RETURNGEOMETRY=true"
+        adapted_url, _ = ESRIJSONImportSource.adapt_source_for_ogr(source)
+
+        # Should preserve the existing parameters and not add duplicates
+        # The exact casing may vary but should not have duplicates
+        param_count = adapted_url.lower().count("where=")
+        assert param_count == 1
+
+    def test_mixed_existing_and_default_parameters(self):
+        """Test mixing existing and default parameters."""
+        source = "https://example.com/arcgis/rest/services/MyService/MapServer/0?where=ID>100"
+        adapted_url, _ = ESRIJSONImportSource.adapt_source_for_ogr(source)
+
+        # Should have the user's where clause
+        assert "where=" in adapted_url
+        # Should add missing defaults
+        assert "f=json" in adapted_url
+        assert "outFields=%2A" in adapted_url or "outFields=*" in adapted_url
+        assert "returnGeometry=true" in adapted_url
+
+    def test_additional_parameters_preserved(self):
+        """Test that additional user parameters are preserved."""
+        source = "https://example.com/arcgis/rest/services/MyService/MapServer/0?resultRecordCount=1000&orderByFields=NAME"
+        adapted_url, _ = ESRIJSONImportSource.adapt_source_for_ogr(source)
+
+        assert "resultRecordCount=1000" in adapted_url
+        assert "orderByFields=NAME" in adapted_url
+        # Should still add defaults
+        assert "where=1%3D1" in adapted_url
+
+
+class TestESRIJSONImportSourceErrors:
+    """Tests for error handling."""
+
+    def test_missing_layer_id(self):
+        """Test error when layer ID is missing."""
+        source = "https://example.com/arcgis/rest/services/MyService/MapServer"
+        with pytest.raises(ImportSourceError) as exc_info:
+            ESRIJSONImportSource.adapt_source_for_ogr(source)
+
+        assert "Invalid ESRI Rest service URL" in str(exc_info.value)
+        assert "MapServer/LAYER_ID" in str(exc_info.value)
+
+    def test_missing_service_type(self):
+        """Test error when neither MapServer nor FeatureServer is present."""
+        source = "https://example.com/arcgis/rest/services/MyService/0"
+        with pytest.raises(ImportSourceError) as exc_info:
+            ESRIJSONImportSource.adapt_source_for_ogr(source)
+
+        assert "Invalid ESRI Rest service URL" in str(exc_info.value)
+
+    def test_invalid_path_suffix(self):
+        """Test error when URL has invalid path suffix."""
+        source = "https://example.com/arcgis/rest/services/MyService/MapServer/0/invalidendpoint"
+        with pytest.raises(ImportSourceError) as exc_info:
+            ESRIJSONImportSource.adapt_source_for_ogr(source)
+
+        assert "Invalid ESRI Rest service URL" in str(exc_info.value)
+
+    def test_non_numeric_layer_id(self):
+        """Test error when layer ID is not numeric."""
+        source = (
+            "https://example.com/arcgis/rest/services/MyService/MapServer/notanumber"
+        )
+        with pytest.raises(ImportSourceError) as exc_info:
+            ESRIJSONImportSource.adapt_source_for_ogr(source)
+
+        assert "Invalid ESRI Rest service URL" in str(exc_info.value)
+
+
+@pytest.fixture
+def mock_esri_server(tmp_path):
+    """
+    Fixture that creates a simple HTTP server serving ESRI JSON test data.
+    Returns the server URL.
+    """
+    # Create a directory to serve from
+    serve_dir = tmp_path / "esri_data"
+    serve_dir.mkdir()
+
+    # Copy test data to serve directory
+    test_data_path = Path(__file__).parent / "data" / "test-point.esrijson"
+    if test_data_path.exists():
+        # Create the service structure
+        service_path = (
+            serve_dir
+            / "arcgis"
+            / "rest"
+            / "services"
+            / "TestService"
+            / "MapServer"
+            / "0"
+        )
+        service_path.mkdir(parents=True)
+
+        # Copy the test data as the query endpoint
+        import shutil
+
+        query_file = service_path / "query"
+        shutil.copy(test_data_path, query_file)
+
+        # Create a simple HTTP server
+        class Handler(SimpleHTTPRequestHandler):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, directory=str(serve_dir), **kwargs)
+
+            def log_message(self, format, *args):
+                pass  # Suppress logging
+
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        port = server.server_address[1]
+        url = f"http://127.0.0.1:{port}"
+
+        # Start server in background thread
+        thread = Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+
+        yield url
+
+        # Cleanup
+        server.shutdown()
+    else:
+        # If test data doesn't exist, skip the fixture
+        pytest.skip("Test data file not found")
+
+
+class TestESRIJSONImportSourceIntegration:
+    """Integration tests that import actual ESRI JSON data."""
+
+    @pytest.mark.slow
+    def test_import_from_mock_esri_server(self, mock_esri_server, tmp_path, cli_runner):
+        """Test importing from a mocked ESRI REST service."""
+        # Initialize a new repo
+        repo_path = tmp_path / "repo"
+        r = cli_runner.invoke(["init", str(repo_path)])
+        assert r.exit_code == 0, r.stderr
+
+        # Import from the mock ESRI server
+        esri_url = (
+            f"esri:{mock_esri_server}/arcgis/rest/services/TestService/MapServer/0"
+        )
+        r = cli_runner.invoke(
+            ["-C", str(repo_path), "import", esri_url, "--dataset", "test_points"]
+        )
+        assert r.exit_code == 0, r.stderr
+
+        # Verify the import
+        repo = KartRepo(repo_path)
+        dataset = repo.datasets()["test_points"]
+
+        # Verify expected fields from the test-point.esrijson
+        field_names = {col["name"] for col in dataset.schema}
+        assert "FEATURE_TYPE" in field_names
+        assert "ID" in field_names
+        assert "SOURCE" in field_names
+
+        # Verify feature count
+        feature_count = sum(1 for _ in dataset.features())
+        assert feature_count == 1
+
+        # Verify the feature data
+        feature = next(dataset.features())
+        assert feature["FEATURE_TYPE"] == "Test Feature"
+        assert feature["ID"] == "Test ID"
+
+
+class TestESRIRestServerSource:
+    """Tests for ESRIRestServerSource layer discovery."""
+
+    def test_server_url_validation(self):
+        """Test that ESRIRestServerSource validates server URLs correctly."""
+        # Valid server URLs
+        source = ESRIRestServerSource.open(
+            "esri:https://example.com/arcgis/rest/services/MyService/MapServer"
+        )
+        assert (
+            source.base_url
+            == "https://example.com/arcgis/rest/services/MyService/MapServer"
+        )
+
+        source = ESRIRestServerSource.open(
+            "https://example.com/arcgis/rest/services/MyService/FeatureServer"
+        )
+        assert (
+            source.base_url
+            == "https://example.com/arcgis/rest/services/MyService/FeatureServer"
+        )
+
+    def test_server_url_with_layer_id_rejected(self):
+        """Test that URLs with layer IDs are rejected (should use ESRIJSONImportSource)."""
+        with pytest.raises(ImportSourceError) as exc_info:
+            ESRIRestServerSource.open(
+                "https://example.com/arcgis/rest/services/MyService/MapServer/0"
+            )
+        assert "ESRIJSONImportSource" in str(exc_info.value)
+
+    def test_invalid_server_url(self):
+        """Test that invalid server URLs are rejected."""
+        with pytest.raises(ImportSourceError):
+            ESRIRestServerSource.open("https://example.com/not-a-service")
+
+    def test_get_tables_with_mock_service(self):
+        """Test layer discovery from a mocked ESRI Rest service."""
+        # Create a mock service metadata JSON
+        service_info = {
+            "currentVersion": 10.91,
+            "serviceDescription": "Test Service",
+            "layers": [
+                {"id": 0, "name": "Layer0", "type": "Feature Layer"},
+                {"id": 1, "name": "Layer1", "type": "Feature Layer"},
+                {"id": 2, "name": "Layer2", "type": "Feature Layer"},
+            ],
+            "tables": [
+                {"id": 3, "name": "Table3", "type": "Table"},
+            ],
+        }
+
+        import unittest.mock as mock
+
+        with mock.patch("kart.tabular.esri_rest_import_source.urlopen") as mock_urlopen:
+            # Mock the response
+            mock_response = mock.MagicMock()
+            mock_response.read.return_value = json.dumps(service_info).encode("utf-8")
+            mock_response.__enter__.return_value = mock_response
+            mock_response.__exit__.return_value = False
+            mock_urlopen.return_value = mock_response
+
+            # Create the source
+            source = ESRIRestServerSource.open(
+                "https://example.com/arcgis/rest/services/TestService/MapServer"
+            )
+
+            # Get tables - this should return the layer metadata
+            tables = source.get_tables()
+
+            # Verify the layers were discovered correctly
+            assert len(tables) == 4
+            assert "Layer0" in tables
+            assert "Layer1" in tables
+            assert "Layer2" in tables
+            assert "Table3" in tables
+
+            # Verify layer structure
+            assert tables["Layer0"]["id"] == 0
+            assert tables["Layer0"]["name"] == "Layer0"
+            assert tables["Layer0"]["type"] == "layer"
+
+            assert tables["Table3"]["id"] == 3
+            assert tables["Table3"]["name"] == "Table3"
+            assert tables["Table3"]["type"] == "table"
+
+    def test_default_dest_path(self):
+        """Test default destination path generation."""
+        source = ESRIRestServerSource(
+            "https://example.com/arcgis/rest/services/MyService/MapServer"
+        )
+        assert source.default_dest_path() == "MyService"
+
+        source = ESRIRestServerSource(
+            "https://example.com/arcgis/rest/services/MyService/FeatureServer",
+            table="Layer0",
+        )
+        assert source.default_dest_path() == "MyService/Layer0"
+
+    def test_clone_for_table(self):
+        """Test clone_for_table method with invalid layer name."""
+        import unittest.mock as mock
+
+        # Create a mock service metadata
+        service_info = {
+            "layers": [
+                {"id": 0, "name": "Layer0", "type": "Feature Layer"},
+                {"id": 1, "name": "Layer1", "type": "Feature Layer"},
+            ],
+        }
+
+        with mock.patch("kart.tabular.esri_rest_import_source.urlopen") as mock_urlopen:
+            # Mock the response
+            mock_response = mock.MagicMock()
+            mock_response.read.return_value = json.dumps(service_info).encode("utf-8")
+            mock_response.__enter__.return_value = mock_response
+            mock_response.__exit__.return_value = False
+            mock_urlopen.return_value = mock_response
+
+            source = ESRIRestServerSource.open(
+                "https://example.com/arcgis/rest/services/MyService/MapServer"
+            )
+
+            # Test cloning for an invalid table - this should fail before trying to open OGR
+            with pytest.raises(ImportSourceError) as exc_info:
+                source.clone_for_table("NonExistentLayer")
+            assert "Layer 'NonExistentLayer' not found" in str(exc_info.value)
+            assert "Layer0, Layer1" in str(exc_info.value)
+
+
+class TestESRIRestImportSourceRouter:
+    """Tests for ESRIRestImportSource routing logic."""
+
+    def test_routes_to_server_source(self):
+        """Test that server URLs route to ESRIRestServerSource."""
+        source = ESRIRestImportSource.open(
+            "esri:https://example.com/arcgis/rest/services/MyService/MapServer"
+        )
+        assert isinstance(source, ESRIRestServerSource)
+
+        source = ESRIRestImportSource.open(
+            "https://example.com/arcgis/rest/services/MyService/FeatureServer"
+        )
+        assert isinstance(source, ESRIRestServerSource)
+
+    def test_routes_to_layer_source(self):
+        """Test that layer URLs route to ESRIJSONImportSource."""
+        # Note: This will fail at OGR open time, but we can verify the routing
+        try:
+            source = ESRIRestImportSource.open(
+                "esri:https://example.com/arcgis/rest/services/MyService/MapServer/0"
+            )
+            assert isinstance(source, ESRIJSONImportSource)
+        except Exception:
+            # Expected - OGR can't actually open this URL
+            pass
+
+    def test_invalid_url_raises_error(self):
+        """Test that invalid URLs raise an error."""
+        with pytest.raises(ImportSourceError) as exc_info:
+            ESRIRestImportSource.open("https://example.com/not-a-service")
+        assert "Invalid ESRI Rest service URL" in str(exc_info.value)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1116,6 +1116,7 @@ def test_import_list_formats(data_archive_readonly, cli_runner):
             "Microsoft SQL Server",
             "MySQL",
             "ESRI Shapefile",
+            "ESRI Rest Service",
             "LAS (LASer)",
             "GeoTIFF",
         ]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -871,7 +871,7 @@ def test_init_import_errors(data_archive, tmp_path, chdir, cli_runner):
         with chdir(repo_path):
             r = cli_runner.invoke(["init", "--import", f"fred:thingz"])
             assert r.exit_code == NO_IMPORT_SOURCE, r
-            assert "fred:thingz' doesn't appear to be valid" in r.stderr
+            assert "Unrecognised import-source specification: fred:thingz" in r.stderr
 
             r = cli_runner.invoke(["init", "--import", f"gpkg:thingz.gpkg"])
             assert r.exit_code == NO_IMPORT_SOURCE, r
@@ -880,7 +880,7 @@ def test_init_import_errors(data_archive, tmp_path, chdir, cli_runner):
             # not empty
             (repo_path / "a.file").touch()
             r = cli_runner.invoke(
-                ["init", "--import", f"gpkg:{data/gpkg}", str(repo_path)]
+                ["init", "--import", f"gpkg:{data / gpkg}", str(repo_path)]
             )
             assert r.exit_code == INVALID_OPERATION, r
             assert "isn't empty" in r.stderr


### PR DESCRIPTION
## Description

Esri Rest services were already importable with the (slightly secret) OGR:ESRIJSON [driver](https://gdal.org/en/stable/drivers/vector/esrijson.html) but it was painful to get the correct parameters. E.g. you needed to know that the `where`, `outFields` and `returnGeometry` fields should be set, and you couldn't import multiple layers from a single source easily.

This PR adds a dedicated `esri:` handler that accepts an Esri ArcGIS Map/Feature Server URL and simplifies the import process. For example:

```
> kart import esri:https://HOST/PATH/MapServer/ -a
Importing 19 features from https://HOST/PATH/MapServer/0:ESRIJSON) to First Layer/ ...
Added 19 Features to index in 0.0s
Overall rate: 2959 features/s)
Closed in 0s
Importing 3 features from PkGeneratingTableImportSource(https://HOST/PATH/MapServer/1:ESRIJSON) to Second Layer/ ...
Added 3 Features to index in 0.0s
Overall rate: 4675 features/s)
Closed in 0s
Importing 303 features from PkGeneratingTableImportSource(https://HOST/PATH/MapServer/2:ESRIJSON) to Third Layer/ ...
Added 303 Features to index in 0.0s
Overall rate: 10269 features/s)
Closed in 0s
```

Any supplied URL parameters are preserved. E.g. a narrower set of features & fields can be imported from a specific source:

```
# Only import the attributes `field1` and `field2` of features with `status=current`
kart import esri:https://HOST/PATH/MapServer/1?where=status%3Dcurrent&outFields=field1,field2
```

This PR includes other improvement to the importer framework to make it simple to add new handlers. See d823ec752cc07d04d02148eecfb86925687a1ba6 for more detail. The subsequent commit 17b7dc4f6ad414fcb8aef2f0d95576f7e68fa319 has the esri-specific changes.

## Future Improvements

This doesn't recurse into folders, so the multi-layer importer will only work from a single MapServer/FeatureService endpoint. It would be straight-forward to extent this to iterate into folders in future.

## Related links:

N/A

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
