### PR TITLE
meta: add hidden plumbing commands for QGIS plugin (blob-hash / show-file / ahead-behind / ls-files)

### DIFF
--- a/kart/checkout.py
+++ b/kart/checkout.py
@@ -225,6 +225,9 @@ def checkout(
         repo.configure_do_checkout_datasets(non_checkout_spec, False)
 
     TableWorkingCopy.ensure_config_exists(repo)
+    # Capture old_tree before set_head so _remove_deleted_attachment_files can compare
+    # the tree before the switch with the tree after.
+    old_tree = repo.head_tree if not repo.head_is_unborn else None
     repo.set_head(head_ref)
 
     repo_key_filter = (
@@ -238,7 +241,6 @@ def checkout(
         else ()
     )
 
-    old_tree = repo.head_tree if not repo.head_is_unborn else None
     if do_switch_commit or do_switch_spatial_filter or discard_changes:
         # Changing commit, changing spatial filter, or discarding changes mean we need to update every dataset:
         repo.working_copy.reset_to_head(
@@ -538,18 +540,26 @@ def _restore_attachment_files(repo, source_tree, rel_paths):
     Paths that do not exist as files in source_tree are silently skipped, so callers can safely
     pass the same filter list that was used for dataset restore (the reviewer's preferred approach:
     each filter is tried on both sides; the side that matches wins).
+
+    Successfully restored paths are also added to the workdir-index so that future calls to
+    WorkdirDiffCache.dirty_attachment_paths() can detect changes efficiently via git's mtime
+    optimisation rather than hashing all tracked files on every diff.
     """
     workdir = str(repo.workdir_path)
+    restored = []
     for rel_path in rel_paths:
         try:
             subprocess.check_call(
                 ["git", "-C", workdir, "checkout", source_tree.id.hex, "--", rel_path],
                 stderr=subprocess.DEVNULL,
             )
+            restored.append(rel_path)
         except subprocess.CalledProcessError:
             # Path doesn't exist as a file in source_tree (e.g. it's a dataset name or
             # feature key) — silently skip so the caller can pass unfiltered user args.
             pass
+    if restored:
+        _update_attachment_workdir_index(repo, restored)
 
 
 def _restore_all_attachment_files(repo, source_tree):
@@ -561,6 +571,30 @@ def _restore_all_attachment_files(repo, source_tree):
     if not tracked:
         return
     _restore_attachment_files(repo, source_tree, sorted(tracked))
+
+
+def _update_attachment_workdir_index(repo, rel_paths):
+    """
+    Ensures the file-system working copy exists and records the given attachment paths in its
+    workdir-index, so WorkdirDiffCache can detect subsequent changes via git's mtime
+    optimisation (avoiding a full re-hash of every tracked attachment on every diff).
+
+    Tile-based datasets (point-cloud / raster) already maintain this workdir-index. For
+    tabular-only repos that have attachment files but no tile datasets, the workdir would not
+    otherwise be initialised - so we create it here (index + state DB) and track attachments
+    through the same mechanism rather than a parallel one.
+    """
+    from kart.workdir import FileSystemWorkingCopy, FileSystemWorkingCopyStatus
+
+    wc = FileSystemWorkingCopy(repo)
+    if wc.status() == FileSystemWorkingCopyStatus.UNCREATED:
+        wc.create_and_initialise()
+    # Keep the workdir's tracked tree in sync with HEAD. For tile repos the dataset reset does
+    # this; an attachment-only workdir has no tile reset, so set it here (and on every HEAD
+    # change) to avoid a spurious BAD_WORKING_COPY_STATE from kart status / diff.
+    if not repo.head_is_unborn:
+        wc.update_state_table_tree(repo.head_tree)
+    wc.add_paths_to_index(rel_paths)
 
 
 def _remove_deleted_attachment_files(repo, old_tree, new_tree):
@@ -598,8 +632,6 @@ def _restore_attachments_to_head(repo, old_tree=None):
     _restore_all_attachment_files(repo, new_tree)
     if old_tree is not None:
         _remove_deleted_attachment_files(repo, old_tree, new_tree)
-
-
 
 
 @click.command(cls=KartCommand)

--- a/kart/checkout.py
+++ b/kart/checkout.py
@@ -238,6 +238,7 @@ def checkout(
         else ()
     )
 
+    old_tree = repo.head_tree if not repo.head_is_unborn else None
     if do_switch_commit or do_switch_spatial_filter or discard_changes:
         # Changing commit, changing spatial filter, or discarding changes mean we need to update every dataset:
         repo.working_copy.reset_to_head(
@@ -246,7 +247,7 @@ def checkout(
             non_checkout_datasets=non_checkout_datasets,
         )
         if do_switch_commit or discard_changes:
-            _restore_attachments_to_head(repo)
+            _restore_attachments_to_head(repo, old_tree=old_tree if do_switch_commit else None)
     elif do_switch_checkout_datasets:
         # Not doing any of the above - just need to change those datasets newly added / removed from the non_checkout_list.
         repo.working_copy.reset_to_head(
@@ -448,11 +449,12 @@ def switch(ctx, create, force_create, discard_changes, do_guess, refish):
 
         head_ref = branch.name
 
+    old_tree = repo.head_tree if not repo.head_is_unborn else None
     repo.set_head(head_ref)
 
     if do_switch_commit or discard_changes:
         repo.working_copy.reset_to_head()
-        _restore_attachments_to_head(repo)
+        _restore_attachments_to_head(repo, old_tree=old_tree if do_switch_commit else None)
 
 
 def _find_remote_branch_by_name(repo, name):
@@ -576,17 +578,42 @@ def _restore_all_attachment_files(repo, source_tree):
         return
     _restore_attachment_files(repo, source_tree, sorted(tracked))
 
-def _restore_attachments_to_head(repo):
+
+def _remove_deleted_attachment_files(repo, old_tree, new_tree):
+    """
+    Deletes any attachment files that existed in old_tree but are absent from new_tree.
+    Called after a HEAD switch so that files removed in the new commit disappear from the
+    working directory rather than lingering as untracked files.
+    """
+    from kart.diff_util import ls_tree_attachments
+    from pathlib import Path
+
+    workdir = str(repo.workdir_path)
+    old_files = set(ls_tree_attachments(workdir, old_tree.id.hex))
+    new_files = set(ls_tree_attachments(workdir, new_tree.id.hex))
+    for rel_path in sorted(old_files - new_files):
+        full_path = Path(workdir) / rel_path
+        if full_path.is_file():
+            full_path.unlink()
+
+
+def _restore_attachments_to_head(repo, old_tree=None):
     """
     Restore tracked attachment files in the working directory to the state at HEAD.
 
     Kart's working-copy reset only covers dataset contents (the GeoPackage / workdir parts).
     Attachment files (LICENSE.txt, README.md, project files, etc. tracked alongside datasets)
     are plain Git objects and need to be re-extracted explicitly when HEAD changes.
+
+    If old_tree is provided (the tree before the HEAD switch), any attachment files that
+    existed in old_tree but are absent from the new HEAD are deleted from the working directory.
     """
     if repo.head_is_unborn:
         return
-    _restore_all_attachment_files(repo, repo.head_tree)
+    new_tree = repo.head_tree
+    _restore_all_attachment_files(repo, new_tree)
+    if old_tree is not None:
+        _remove_deleted_attachment_files(repo, old_tree, new_tree)
 
 
 
@@ -628,6 +655,7 @@ def reset(ctx, discard_changes, refish):
     if do_switch_commit and not discard_changes:
         ctx.obj.check_not_dirty(_DISCARD_CHANGES_HELP_MESSAGE)
 
+    old_tree = repo.head_tree if not repo.head_is_unborn else None
     head_branch = repo.head_branch
     if head_branch is not None:
         repo.references[head_branch].set_target(commit.id)
@@ -635,4 +663,4 @@ def reset(ctx, discard_changes, refish):
         repo.set_head(commit.id)
 
     repo.working_copy.reset_to_head()
-    _restore_attachments_to_head(repo)
+    _restore_attachments_to_head(repo, old_tree=old_tree if do_switch_commit else None)

--- a/kart/checkout.py
+++ b/kart/checkout.py
@@ -245,6 +245,8 @@ def checkout(
             create_parts_if_missing=parts_to_create,
             non_checkout_datasets=non_checkout_datasets,
         )
+        if do_switch_commit or discard_changes:
+            _restore_attachments_to_head(repo)
     elif do_switch_checkout_datasets:
         # Not doing any of the above - just need to change those datasets newly added / removed from the non_checkout_list.
         repo.working_copy.reset_to_head(
@@ -450,6 +452,7 @@ def switch(ctx, create, force_create, discard_changes, do_guess, refish):
 
     if do_switch_commit or discard_changes:
         repo.working_copy.reset_to_head()
+        _restore_attachments_to_head(repo)
 
 
 def _find_remote_branch_by_name(repo, name):
@@ -573,6 +576,20 @@ def _restore_all_attachment_files(repo, source_tree):
         return
     _restore_attachment_files(repo, source_tree, sorted(tracked))
 
+def _restore_attachments_to_head(repo):
+    """
+    Restore tracked attachment files in the working directory to the state at HEAD.
+
+    Kart's working-copy reset only covers dataset contents (the GeoPackage / workdir parts).
+    Attachment files (LICENSE.txt, README.md, project files, etc. tracked alongside datasets)
+    are plain Git objects and need to be re-extracted explicitly when HEAD changes.
+    """
+    if repo.head_is_unborn:
+        return
+    _restore_all_attachment_files(repo, repo.head_tree)
+
+
+
 
 @click.command(cls=KartCommand)
 @click.pass_context
@@ -618,3 +635,4 @@ def reset(ctx, discard_changes, refish):
         repo.set_head(commit.id)
 
     repo.working_copy.reset_to_head()
+    _restore_attachments_to_head(repo)

--- a/kart/checkout.py
+++ b/kart/checkout.py
@@ -499,8 +499,10 @@ def restore(ctx, source, filters):
     Restore specified paths in the working copy with some contents from the given restore source.
     By default, restores the entire working copy to the commit at HEAD (so, discards all uncommitted changes).
 
-    FILTERS may name datasets or attachment files. Names that do not match a dataset in the source
-    tree are treated as attachment file paths and restored via `git checkout`.
+    FILTERS may name datasets, individual features, or attachment files. Each filter is tried
+    against both datasets and attachment files — a filter matching a dataset restores all its
+    features, a filter matching a file path restores that file, and a filter can match both if
+    the same name exists as a dataset on one branch and a file on another.
     """
     repo = ctx.obj.repo
 
@@ -513,59 +515,41 @@ def restore(ctx, source, filters):
     except (KeyError, pygit2.InvalidSpecError):
         raise NotFound(f"{source} is not a commit or tree", exit_code=NO_COMMIT)
 
-    dataset_filters, file_filters = _split_restore_filters(repo, source_tree, filters)
-
     repo.working_copy.reset(
         commit_or_tree,
         track_changes_as_dirty=True,
-        repo_key_filter=RepoKeyFilter.build_from_user_patterns(dataset_filters),
+        repo_key_filter=RepoKeyFilter.build_from_user_patterns(filters),
     )
 
     # Restore attachment files. With no user-supplied filters we restore every tracked file in the
-    # source tree (matching the all-datasets restore above). Otherwise we restore only the explicitly
-    # named files. Untracked files in the working directory are left alone (matching git's `git
-    # restore` semantics).
+    # source tree (matching the all-datasets restore above). Otherwise we pass the same filters to
+    # the attachment restore: each filter is tried as both a dataset filter (above) and an
+    # attachment-file path (here), so the correct side silently wins regardless of which branch a
+    # dataset happens to exist on.
     if not filters:
         _restore_all_attachment_files(repo, source_tree)
-    elif file_filters:
-        _restore_attachment_files(repo, source_tree, file_filters)
-
-
-def _split_restore_filters(repo, source_tree, filters):
-    """
-    Splits a list of user-supplied FILTERS into (dataset_filters, file_filters) by checking
-    which ones match a dataset path in the source tree. Anything that does not match a dataset
-    is treated as an attachment file path.
-    """
-    if not filters:
-        return [], []
-    dataset_paths = {ds.path for ds in repo.structure(source_tree).datasets()}
-    dataset_filters = []
-    file_filters = []
-    for f in filters:
-        # A user filter may select an entire dataset (e.g. "mydataset") or a feature within it
-        # (e.g. "mydataset:42"). We treat anything whose dataset-path component matches a known
-        # dataset as a dataset filter; everything else is taken to be an attachment file path.
-        ds_part = f.split(":", 1)[0]
-        if ds_part in dataset_paths:
-            dataset_filters.append(f)
-        else:
-            file_filters.append(f)
-    return dataset_filters, file_filters
+    else:
+        _restore_attachment_files(repo, source_tree, filters)
 
 
 def _restore_attachment_files(repo, source_tree, rel_paths):
-    """Restores each rel_path under the working directory from source_tree via `git checkout`."""
+    """Restores each rel_path under the working directory from source_tree via `git checkout`.
+
+    Paths that do not exist as files in source_tree are silently skipped, so callers can safely
+    pass the same filter list that was used for dataset restore (the reviewer's preferred approach:
+    each filter is tried on both sides; the side that matches wins).
+    """
     workdir = str(repo.workdir_path)
     for rel_path in rel_paths:
         try:
             subprocess.check_call(
                 ["git", "-C", workdir, "checkout", source_tree.id.hex, "--", rel_path],
+                stderr=subprocess.DEVNULL,
             )
-        except subprocess.CalledProcessError as e:
-            raise SubprocessError(
-                f"Could not restore {rel_path}: {e}", called_process_error=e
-            )
+        except subprocess.CalledProcessError:
+            # Path doesn't exist as a file in source_tree (e.g. it's a dataset name or
+            # feature key) — silently skip so the caller can pass unfiltered user args.
+            pass
 
 
 def _restore_all_attachment_files(repo, source_tree):

--- a/kart/checkout.py
+++ b/kart/checkout.py
@@ -10,6 +10,7 @@ from kart.exceptions import (
     NO_COMMIT,
     InvalidOperation,
     NotFound,
+    SubprocessError,
 )
 from kart.key_filters import RepoKeyFilter
 from kart.promisor_utils import get_partial_clone_envelope
@@ -492,6 +493,9 @@ def restore(ctx, source, filters):
     """
     Restore specified paths in the working copy with some contents from the given restore source.
     By default, restores the entire working copy to the commit at HEAD (so, discards all uncommitted changes).
+
+    FILTERS may name datasets or attachment files. Names that do not match a dataset in the source
+    tree are treated as attachment file paths and restored via `git checkout`.
     """
     repo = ctx.obj.repo
 
@@ -500,17 +504,74 @@ def restore(ctx, source, filters):
 
     try:
         commit_or_tree, ref = repo.resolve_refish(source)
-        commit_or_tree.peel(pygit2.Tree)
+        source_tree = commit_or_tree.peel(pygit2.Tree)
     except (KeyError, pygit2.InvalidSpecError):
         raise NotFound(f"{source} is not a commit or tree", exit_code=NO_COMMIT)
 
-    repo_key_filter = RepoKeyFilter.build_from_user_patterns(filters)
+    dataset_filters, file_filters = _split_restore_filters(repo, source_tree, filters)
 
     repo.working_copy.reset(
         commit_or_tree,
         track_changes_as_dirty=True,
-        repo_key_filter=repo_key_filter,
+        repo_key_filter=RepoKeyFilter.build_from_user_patterns(dataset_filters),
     )
+
+    # Restore attachment files. With no user-supplied filters we restore every tracked file in the
+    # source tree (matching the all-datasets restore above). Otherwise we restore only the explicitly
+    # named files. Untracked files in the working directory are left alone (matching git's `git
+    # restore` semantics).
+    if not filters:
+        _restore_all_attachment_files(repo, source_tree)
+    elif file_filters:
+        _restore_attachment_files(repo, source_tree, file_filters)
+
+
+def _split_restore_filters(repo, source_tree, filters):
+    """
+    Splits a list of user-supplied FILTERS into (dataset_filters, file_filters) by checking
+    which ones match a dataset path in the source tree. Anything that does not match a dataset
+    is treated as an attachment file path.
+    """
+    if not filters:
+        return [], []
+    dataset_paths = {ds.path for ds in repo.structure(source_tree).datasets()}
+    dataset_filters = []
+    file_filters = []
+    for f in filters:
+        # A user filter may select an entire dataset (e.g. "mydataset") or a feature within it
+        # (e.g. "mydataset:42"). We treat anything whose dataset-path component matches a known
+        # dataset as a dataset filter; everything else is taken to be an attachment file path.
+        ds_part = f.split(":", 1)[0]
+        if ds_part in dataset_paths:
+            dataset_filters.append(f)
+        else:
+            file_filters.append(f)
+    return dataset_filters, file_filters
+
+
+def _restore_attachment_files(repo, source_tree, rel_paths):
+    """Restores each rel_path under the working directory from source_tree via `git checkout`."""
+    workdir = str(repo.workdir_path)
+    for rel_path in rel_paths:
+        try:
+            subprocess.check_call(
+                ["git", "-C", workdir, "checkout", source_tree.id.hex, "--", rel_path],
+            )
+        except subprocess.CalledProcessError as e:
+            raise SubprocessError(
+                f"Could not restore {rel_path}: {e}", called_process_error=e
+            )
+
+
+def _restore_all_attachment_files(repo, source_tree):
+    """Restores every attachment file present in source_tree to the working directory."""
+    from kart.diff_util import ls_tree_attachments
+
+    workdir = str(repo.workdir_path)
+    tracked = ls_tree_attachments(workdir, source_tree.id.hex)
+    if not tracked:
+        return
+    _restore_attachment_files(repo, source_tree, sorted(tracked))
 
 
 @click.command(cls=KartCommand)

--- a/kart/cli.py
+++ b/kart/cli.py
@@ -44,7 +44,7 @@ MODULE_COMMANDS = {
     "lfs_commands": {"lfs+"},
     "log": {"log"},
     "merge": {"merge"},
-    "meta": {"commit-files", "meta"},
+    "meta": {"ahead-behind", "blob-hash", "commit-files", "ls-files", "meta", "show-file"},
     "mv": {"mv"},
     "pull": {"pull"},
     "raster.import_": {"raster-import"},

--- a/kart/clone.py
+++ b/kart/clone.py
@@ -176,3 +176,10 @@ def clone(
         else ()
     )
     repo.working_copy.reset_to_head(create_parts_if_missing=parts_to_create)
+
+    # Restore tracked attachment files (LICENSE.txt, README.md, etc.) to the working
+    # directory — reset_to_head() only handles dataset working-copy parts.
+    if do_checkout and not repo.head_is_unborn:
+        from kart.checkout import _restore_attachments_to_head
+
+        _restore_attachments_to_head(repo, old_tree=None)

--- a/kart/create_workingcopy.py
+++ b/kart/create_workingcopy.py
@@ -234,6 +234,14 @@ def create_workingcopy(ctx, parts, delete_existing, discard_changes, tabular_loc
     if PartType.WORKDIR in parts:
         create_workdir(repo, delete_existing, discard_changes)
 
+    # Restore tracked attachment files (LICENSE.txt, README.md, etc.) to the working
+    # directory. Without this, a fresh `kart create-workingcopy` (or `kart clone`,
+    # which calls into the same code path via reset_to_head) leaves attachment files
+    # absent from disk — matching neither git's behaviour nor the rest of this PR.
+    from kart.checkout import _restore_attachments_to_head
+
+    _restore_attachments_to_head(repo, old_tree=None)
+
     # This command is used in tests and by other commands, so we have to be extra careful to
     # tidy up properly - otherwise, tests can fail (on Windows especially) due to PermissionError.
     repo.free()

--- a/kart/diff_util.py
+++ b/kart/diff_util.py
@@ -198,7 +198,7 @@ def get_file_diff(
     old_tree = base_rs.tree
 
     if include_wc_diff:
-        return _get_workdir_file_diff(repo, old_tree, repo_key_filter)
+        return _get_workdir_file_diff(repo, old_tree, repo_key_filter, workdir_diff_cache)
 
     new_tree = target_rs.tree
 
@@ -248,72 +248,136 @@ def _kart_managed_workdir_files(repo):
     return set()
 
 
-def _get_workdir_file_diff(repo, base_tree, repo_key_filter):
+def _make_attachment_filter(workdir_diff_cache):
     """
-    Returns a delta-diff for attachment files between base_tree and the working directory.
+    Returns a callable ``is_attachment_non_tile(path)`` that returns True only for paths that
+    are attachment files and do NOT live inside a tile-dataset working directory.
 
-    Modifications and deletions of tracked attachment files (committed to base_tree) are detected
-    by comparing base_tree blob OIDs against the OIDs of the corresponding files in the working
-    directory. Untracked attachment files are detected with `git ls-files --others`. New blobs
-    are written to the object database via `git hash-object -w` so the resulting deltas reference
-    real OIDs, allowing diff-writers to fetch their content for `--diff-files` output. Any blobs
-    not subsequently referenced by a commit will be cleaned up by `git gc`.
+    Tile files such as ``elevation/EK.tif`` are tracked in the workdir-index by
+    FileSystemWorkingCopy and therefore appear in ``_git_diff_paths()`` when modified.
+    ``is_attachment_path()`` alone cannot exclude them because it only knows about the internal
+    dataset structure (``.raster-dataset.v1/`` etc.) and not the top-level dataset directory
+    names.  Only *tile* datasets store tiles under their directory; files under a *tabular*
+    dataset directory (e.g. ``nz_pa_points_topo_150k/metadata.xml``) are user-facing
+    attachments, so we exclude only the tile-dataset directory prefixes.
+    """
+    tile_ds_prefixes = tuple(
+        ds + "/" for ds in workdir_diff_cache.tile_dataset_paths()
+    )
 
-    A file in base_tree that is absent from the working directory is only reported as deleted if
-    it was previously extracted to the workdir (i.e. it appears in the git index). This avoids
-    spurious deletions for repos that have attachment files committed but never checked out, since
-    Kart does not yet auto-extract attachments on checkout (issue #583, step 5).
+    def _is_attachment_non_tile(p):
+        if not is_attachment_path(p):
+            return False
+        if tile_ds_prefixes and p.startswith(tile_ds_prefixes):
+            return False
+        return True
+
+    return _is_attachment_non_tile
+
+
+def _classify_workdir_attachment_paths(
+    repo, repo_key_filter, workdir_diff_cache, tree_files, managed
+):
+    """
+    Returns (present_changed, deleted, untracked) - the attachment paths in the working directory
+    that may differ from the tree:
+
+    - present_changed: tracked files present on disk whose content *may* differ (the caller
+      confirms by hashing - the fast path narrows this to git-flagged changes, the slow path
+      returns every present tracked file).
+    - deleted: tracked files that were extracted to disk but are now missing.
+    - untracked: files on disk that are not in the tree at all.
+
+    When workdir_diff_cache is provided this uses the workdir-index (git's mtime optimisation)
+    so unchanged large files are never re-hashed. Without a cache it falls back to enumerating
+    every tree attachment and stat-ing it - correct, but O(n) in the number of attachments.
+    Both branches feed the same delta/status builders in the callers, so the only thing that
+    differs between fast and slow is how these three lists are computed.
     """
     workdir = str(repo.workdir_path)
-    managed = _kart_managed_workdir_files(repo)
-
-    # 1. Enumerate attachment files in base_tree with their blob OIDs.
-    tree_files = ls_tree_attachments(workdir, base_tree.hex)
-
-    # 2. Find attachment files in the working directory that are not tracked by Kart/Git.
-    untracked = ls_workdir_untracked_attachments(workdir)
-
     workdir_path = Path(workdir)
 
-    # Filter both sets by the repo_key_filter, and split tracked files into present/missing.
-    tracked = {
-        path: sha
-        for path, sha in tree_files.items()
-        if path_matches_repo_key_filter(path, repo_key_filter)
-    }
-    present_tracked = [p for p in tracked if (workdir_path / p).is_file()]
+    if workdir_diff_cache is not None:
+        # Fast path: the workdir-index already knows which files changed.
+        # _git_diff_paths()  = tracked files that changed (modified or deleted on disk).
+        # _git_ls_others_paths() = files on disk not in the index (new/untracked).
+        is_attachment_non_tile = _make_attachment_filter(workdir_diff_cache)
+        diff_paths = [
+            p
+            for p in workdir_diff_cache._git_diff_paths()
+            if is_attachment_non_tile(p)
+            and path_matches_repo_key_filter(p, repo_key_filter)
+        ]
+        untracked = [
+            p
+            for p in workdir_diff_cache._git_ls_others_paths()
+            if is_attachment_non_tile(p)
+            and p not in tree_files
+            and p not in managed
+            and path_matches_repo_key_filter(p, repo_key_filter)
+        ]
+        present_changed = [p for p in diff_paths if (workdir_path / p).is_file()]
+        deleted = [p for p in diff_paths if not (workdir_path / p).is_file()]
+        return present_changed, deleted, untracked
+
+    # Slow path (no workdir-index): enumerate all tree attachments and stat them.
+    tracked = [
+        p for p in tree_files if path_matches_repo_key_filter(p, repo_key_filter)
+    ]
+    present_changed = [p for p in tracked if (workdir_path / p).is_file()]
     # Only report as deleted if the file was previously extracted (present in the git index).
     index_files = set(_ls_index_attachments(workdir))
-    missing_tracked = [
+    deleted = [
         p for p in tracked if not (workdir_path / p).is_file() and p in index_files
     ]
-
     untracked = [
         p
-        for p in untracked
+        for p in ls_workdir_untracked_attachments(workdir)
         if p not in tree_files
         and p not in managed
         and path_matches_repo_key_filter(p, repo_key_filter)
     ]
+    return present_changed, deleted, untracked
 
-    # 3. Hash all working-directory files we may need to reference, in a single git invocation.
-    new_oids = _hash_workdir_files(workdir, present_tracked + untracked)
+
+def _get_workdir_file_diff(repo, base_tree, repo_key_filter, workdir_diff_cache=None):
+    """
+    Returns a delta-diff for attachment files between base_tree and the working directory.
+
+    Path classification (which files are modified / deleted / untracked) is delegated to
+    _classify_workdir_attachment_paths, which uses the workdir-index fast path when a cache is
+    available and falls back to a full scan otherwise. This function then hashes the candidate
+    files and assembles the deltas - identically regardless of which path produced the lists.
+
+    New blobs are written to the object database via `git hash-object -w` so the resulting
+    deltas reference real OIDs, allowing diff-writers to fetch their content for `--diff-files`
+    output. Any blobs not subsequently referenced by a commit will be cleaned up by `git gc`.
+    """
+    workdir = str(repo.workdir_path)
+    managed = _kart_managed_workdir_files(repo)
+    tree_files = ls_tree_attachments(workdir, base_tree.hex)
+
+    present_changed, deleted, untracked = _classify_workdir_attachment_paths(
+        repo, repo_key_filter, workdir_diff_cache, tree_files, managed
+    )
 
     attachment_deltas = DeltaDiff()
+    new_oids = _hash_workdir_files(workdir, present_changed + untracked)
 
-    # Tracked + present: emit a Delta only if the content changed.
-    for path in present_tracked:
-        old_sha = tracked[path]
+    for path in present_changed:
+        old_sha = tree_files.get(path)
         new_sha = new_oids.get(path)
         if not new_sha or new_sha == old_sha:
             continue
-        attachment_deltas.add_delta(Delta((path, old_sha), (path, new_sha)))
+        attachment_deltas.add_delta(
+            Delta((path, old_sha) if old_sha else None, (path, new_sha))
+        )
 
-    # Tracked + previously extracted but now missing: deletion.
-    for path in missing_tracked:
-        attachment_deltas.add_delta(Delta((path, tracked[path]), None))
+    for path in deleted:
+        old_sha = tree_files.get(path)
+        if old_sha:
+            attachment_deltas.add_delta(Delta((path, old_sha), None))
 
-    # Untracked in workdir: insertion.
     for path in untracked:
         new_sha = new_oids.get(path)
         if new_sha:
@@ -424,7 +488,7 @@ def ls_workdir_untracked_attachments(workdir):
 
 
 def get_workdir_file_status(
-    repo, base_tree=None, repo_key_filter=RepoKeyFilter.MATCH_ALL
+    repo, base_tree=None, repo_key_filter=RepoKeyFilter.MATCH_ALL, workdir_diff_cache=None
 ):
     """
     Returns a classification of attachment files in the working directory relative to base_tree
@@ -436,45 +500,32 @@ def get_workdir_file_status(
     "untracked" - file present in the workdir but absent from base_tree.
     "deleted" - tracked file in base_tree but absent from the workdir.
 
+    When workdir_diff_cache is provided the function reuses its cached git-index results to avoid
+    redundant git invocations when called alongside get_repo_diff().
+
     Cheaper than calling get_file_diff() with include_wc_diff=True when only the file lists are
     needed, because untouched modifications can be detected via blob OID comparison without
-    writing new blobs to the object database.
+    writing new blobs to the object database (write_to_odb=False below).
     """
     if base_tree is None:
         base_tree = repo.head_tree
     workdir = str(repo.workdir_path)
-    workdir_path = Path(workdir)
     managed = _kart_managed_workdir_files(repo)
+    tree_files = ls_tree_attachments(workdir, base_tree.hex)
 
-    tracked = {
-        path: sha
-        for path, sha in ls_tree_attachments(workdir, base_tree.hex).items()
-        if path_matches_repo_key_filter(path, repo_key_filter)
-    }
-    untracked = [
-        p
-        for p in ls_workdir_untracked_attachments(workdir)
-        if p not in tracked
-        and p not in managed
-        and path_matches_repo_key_filter(p, repo_key_filter)
-    ]
-
-    present = [p for p in tracked if (workdir_path / p).is_file()]
-    # Only report as deleted if the file was previously extracted (present in the git index).
-    index_files = set(_ls_index_attachments(workdir))
-    deleted = sorted(
-        p for p in tracked if not (workdir_path / p).is_file() and p in index_files
+    present_changed, deleted, untracked = _classify_workdir_attachment_paths(
+        repo, repo_key_filter, workdir_diff_cache, tree_files, managed
     )
 
-    # Modified = tracked + present + content differs.
-    # We compute OIDs without -w because we only need to compare hashes.
-    new_oids = _hash_workdir_files(workdir, present, write_to_odb=False)
-    modified = sorted(p for p in present if new_oids.get(p) != tracked[p])
+    # A "present_changed" path is only actually modified if its content differs from the tree.
+    # Hash without -w since we only need the OIDs for comparison, not to persist blobs.
+    new_oids = _hash_workdir_files(workdir, present_changed, write_to_odb=False)
+    modified = sorted(p for p in present_changed if new_oids.get(p) != tree_files.get(p))
 
     return {
         "modified": modified,
         "untracked": sorted(untracked),
-        "deleted": deleted,
+        "deleted": sorted(deleted),
     }
 
 

--- a/kart/diff_util.py
+++ b/kart/diff_util.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from pathlib import Path
 
 from kart.diff_format import DiffFormat
 from kart.diff_structs import FILES_KEY, Delta, DeltaDiff, DatasetDiff, RepoDiff
@@ -9,6 +10,13 @@ from kart.structure import RepoStructure
 from kart import subprocess_util as subprocess
 
 L = logging.getLogger("kart.diff_util")
+
+# Pathspecs identifying attachment files - everything that is not a Kart-internal blob
+# and not part of any dataset's contents. Used as exclude patterns with `git`.
+ATTACHMENT_PATHSPECS = (
+    ":^.kart.*",  # Top-level hidden kart blobs
+    ":^**/.*dataset*/**",  # Data inside datasets
+)
 
 
 def get_all_ds_paths(
@@ -80,7 +88,13 @@ def get_repo_diff(
             convert_to_dataset_format=convert_to_dataset_format,
         )
     if include_files:
-        file_diff = get_file_diff(base_rs, target_rs, repo_key_filter=repo_key_filter)
+        file_diff = get_file_diff(
+            base_rs,
+            target_rs,
+            include_wc_diff=include_wc_diff,
+            workdir_diff_cache=workdir_diff_cache,
+            repo_key_filter=repo_key_filter,
+        )
         if file_diff:
             repo_diff.recursive_set([FILES_KEY, FILES_KEY], file_diff)
 
@@ -175,14 +189,18 @@ def get_file_diff(
     CPU time to produce but isn't necessarily easier to consume than OIDs, which are straight-forward to
     turn into raw files once you know how. (Various diff-writers can transform these OIDs into inline diffs if you
     set the --diff-files flag).
+
+    If include_wc_diff is True the diff is generated between base_rs.tree and the working
+    directory (target_rs is then assumed to be the HEAD-equivalent tracked by the working
+    directory). Otherwise it is generated between base_rs.tree and target_rs.tree.
     """
-
-    # We don't yet support attachment diffs in the workdir
-    assert not include_wc_diff
-
-    old_tree = base_rs.tree
-    new_tree = target_rs.tree
     repo = target_rs.repo
+    old_tree = base_rs.tree
+
+    if include_wc_diff:
+        return _get_workdir_file_diff(repo, old_tree, repo_key_filter)
+
+    new_tree = target_rs.tree
 
     # TODO - make sure this is skipping over datasets efficiently.
     # TODO - we could turn on rename detection.
@@ -196,8 +214,7 @@ def get_file_diff(
         "--raw",
         "--no-renames",
         "--",
-        ":^.kart.*",  # Top-level hidden kart blobs
-        ":^**/.*dataset*/**",  # Data inside datasets
+        *ATTACHMENT_PATHSPECS,
     ]
     try:
         lines = subprocess.check_output(cmd, encoding="utf8").strip().splitlines()
@@ -218,6 +235,278 @@ def get_file_diff(
         attachment_deltas.add_delta(Delta(old_half_delta, new_half_delta))
 
     return attachment_deltas
+
+
+def _kart_managed_workdir_files(repo):
+    """
+    Returns a set of workdir-relative file paths that Kart manages internally and that should
+    not appear as attachments (e.g. the SQLite/GeoPackage working copy file).
+    """
+    wc_location = repo.workingcopy_location
+    if wc_location and "://" not in wc_location:
+        return {wc_location}
+    return set()
+
+
+def _get_workdir_file_diff(repo, base_tree, repo_key_filter):
+    """
+    Returns a delta-diff for attachment files between base_tree and the working directory.
+
+    Modifications and deletions of tracked attachment files (committed to base_tree) are detected
+    by comparing base_tree blob OIDs against the OIDs of the corresponding files in the working
+    directory. Untracked attachment files are detected with `git ls-files --others`. New blobs
+    are written to the object database via `git hash-object -w` so the resulting deltas reference
+    real OIDs, allowing diff-writers to fetch their content for `--diff-files` output. Any blobs
+    not subsequently referenced by a commit will be cleaned up by `git gc`.
+
+    A file in base_tree that is absent from the working directory is only reported as deleted if
+    it was previously extracted to the workdir (i.e. it appears in the git index). This avoids
+    spurious deletions for repos that have attachment files committed but never checked out, since
+    Kart does not yet auto-extract attachments on checkout (issue #583, step 5).
+    """
+    workdir = str(repo.workdir_path)
+    managed = _kart_managed_workdir_files(repo)
+
+    # 1. Enumerate attachment files in base_tree with their blob OIDs.
+    tree_files = ls_tree_attachments(workdir, base_tree.hex)
+
+    # 2. Find attachment files in the working directory that are not tracked by Kart/Git.
+    untracked = ls_workdir_untracked_attachments(workdir)
+
+    workdir_path = Path(workdir)
+
+    # Filter both sets by the repo_key_filter, and split tracked files into present/missing.
+    tracked = {
+        path: sha
+        for path, sha in tree_files.items()
+        if path_matches_repo_key_filter(path, repo_key_filter)
+    }
+    present_tracked = [p for p in tracked if (workdir_path / p).is_file()]
+    # Only report as deleted if the file was previously extracted (present in the git index).
+    index_files = set(_ls_index_attachments(workdir))
+    missing_tracked = [
+        p for p in tracked if not (workdir_path / p).is_file() and p in index_files
+    ]
+
+    untracked = [
+        p
+        for p in untracked
+        if p not in tree_files
+        and p not in managed
+        and path_matches_repo_key_filter(p, repo_key_filter)
+    ]
+
+    # 3. Hash all working-directory files we may need to reference, in a single git invocation.
+    new_oids = _hash_workdir_files(workdir, present_tracked + untracked)
+
+    attachment_deltas = DeltaDiff()
+
+    # Tracked + present: emit a Delta only if the content changed.
+    for path in present_tracked:
+        old_sha = tracked[path]
+        new_sha = new_oids.get(path)
+        if not new_sha or new_sha == old_sha:
+            continue
+        attachment_deltas.add_delta(Delta((path, old_sha), (path, new_sha)))
+
+    # Tracked + previously extracted but now missing: deletion.
+    for path in missing_tracked:
+        attachment_deltas.add_delta(Delta((path, tracked[path]), None))
+
+    # Untracked in workdir: insertion.
+    for path in untracked:
+        new_sha = new_oids.get(path)
+        if new_sha:
+            attachment_deltas.add_delta(Delta(None, (path, new_sha)))
+
+    return attachment_deltas
+
+
+_ATTACHMENT_DATASET_DIR_RE = re.compile(r"\.[^/]*dataset[^/]*$")
+# Top-level path prefixes (matching `:^.kart.*` and `:^.git*` semantics) that are reserved for
+# kart/git internals - both the directories and any sibling top-level files starting with these
+# prefixes (e.g. `.kart.repostructure.version`).
+_ATTACHMENT_TOP_LEVEL_PREFIXES = (".kart", ".git")
+# Per-branding README files (e.g. KART_README.txt, SNO_README.txt) that kart writes to the
+# workdir as a courtesy and excludes from version control via .kart/info/exclude.
+_ATTACHMENT_README_RE = re.compile(r"^[A-Z]+_README\.[^/]*$")
+
+
+def is_attachment_path(path):
+    """Returns True if path is an attachment file (anything that is not a Kart-internal blob,
+    a managed Kart courtesy file, or part of a dataset's contents)."""
+    parts = path.split("/")
+    top = parts[0]
+    if any(
+        top == prefix or top.startswith(prefix + ".")
+        for prefix in _ATTACHMENT_TOP_LEVEL_PREFIXES
+    ):
+        return False
+    if len(parts) == 1 and _ATTACHMENT_README_RE.match(top):
+        return False
+    # Exclude any path with a `.<...>dataset...` directory component, matching the
+    # `:^**/.*dataset*/**` pathspec used by `git diff`.
+    for part in parts[:-1]:
+        if _ATTACHMENT_DATASET_DIR_RE.match(part):
+            return False
+    return True
+
+
+def ls_tree_attachments(workdir, tree_ref):
+    """
+    Returns {rel_path: blob_oid} for every attachment file in the given tree.
+
+    `git ls-tree` does not accept exclude pathspecs (the `:^` magic is only honoured by `git diff`
+    and `git ls-files`), so the equivalent filter is applied in Python via is_attachment_path().
+    """
+    cmd = ["git", "-C", workdir, "ls-tree", "-r", "-z", tree_ref]
+    try:
+        out = subprocess.check_output(cmd, encoding="utf8")
+    except subprocess.CalledProcessError as e:
+        raise SubprocessError(
+            f"There was a problem with git ls-tree: {e}", called_process_error=e
+        )
+
+    result = {}
+    for entry in out.split("\0"):
+        if not entry:
+            continue
+        # Format: "<mode> SP <type> SP <oid> TAB <path>"
+        meta, path = entry.split("\t", 1)
+        if not is_attachment_path(path):
+            continue
+        _mode, _type, oid = meta.split(" ", 2)
+        result[path] = oid
+    return result
+
+
+def _ls_index_attachments(workdir):
+    """
+    Returns the set of attachment file paths currently staged in the git index.
+
+    Only files that have been explicitly extracted to the working directory (via `git checkout`)
+    appear in the index.  This lets callers distinguish between "file was checked out and then
+    deleted by the user" (in index, missing from workdir) and "file was never extracted" (absent
+    from both index and workdir).
+    """
+    cmd = ["git", "-C", workdir, "ls-files", "--stage", "-z"]
+    try:
+        out = subprocess.check_output(cmd, encoding="utf8")
+    except subprocess.CalledProcessError as e:
+        raise SubprocessError(
+            f"There was a problem with git ls-files: {e}", called_process_error=e
+        )
+    result = set()
+    for entry in out.split("\0"):
+        if not entry:
+            continue
+        # Format: "<mode> SP <oid> SP <stage>\t<path>"
+        _meta, path = entry.split("\t", 1)
+        if is_attachment_path(path):
+            result.add(path)
+    return result
+
+
+def ls_workdir_untracked_attachments(workdir):
+    """
+    Returns the list of attachment files in the working directory that aren't tracked. Filtering
+    is done in Python because `:^` exclude pathspecs do not reliably traverse subdirectories
+    (e.g. `:^.kart.*` does not match `.kart/HEAD`); see is_attachment_path().
+    """
+    cmd = ["git", "-C", workdir, "ls-files", "--others", "--exclude-standard", "-z"]
+    try:
+        out = subprocess.check_output(cmd, encoding="utf8")
+    except subprocess.CalledProcessError as e:
+        raise SubprocessError(
+            f"There was a problem with git ls-files: {e}", called_process_error=e
+        )
+    return [p for p in out.split("\0") if p and is_attachment_path(p)]
+
+
+def get_workdir_file_status(
+    repo, base_tree=None, repo_key_filter=RepoKeyFilter.MATCH_ALL
+):
+    """
+    Returns a classification of attachment files in the working directory relative to base_tree
+    (defaulting to HEAD), as three sorted lists:
+
+        {"modified": [...], "untracked": [...], "deleted": [...]}
+
+    "modified" - tracked file present in the workdir but with different content from base_tree.
+    "untracked" - file present in the workdir but absent from base_tree.
+    "deleted" - tracked file in base_tree but absent from the workdir.
+
+    Cheaper than calling get_file_diff() with include_wc_diff=True when only the file lists are
+    needed, because untouched modifications can be detected via blob OID comparison without
+    writing new blobs to the object database.
+    """
+    if base_tree is None:
+        base_tree = repo.head_tree
+    workdir = str(repo.workdir_path)
+    workdir_path = Path(workdir)
+    managed = _kart_managed_workdir_files(repo)
+
+    tracked = {
+        path: sha
+        for path, sha in ls_tree_attachments(workdir, base_tree.hex).items()
+        if path_matches_repo_key_filter(path, repo_key_filter)
+    }
+    untracked = [
+        p
+        for p in ls_workdir_untracked_attachments(workdir)
+        if p not in tracked
+        and p not in managed
+        and path_matches_repo_key_filter(p, repo_key_filter)
+    ]
+
+    present = [p for p in tracked if (workdir_path / p).is_file()]
+    # Only report as deleted if the file was previously extracted (present in the git index).
+    index_files = set(_ls_index_attachments(workdir))
+    deleted = sorted(
+        p for p in tracked if not (workdir_path / p).is_file() and p in index_files
+    )
+
+    # Modified = tracked + present + content differs.
+    # We compute OIDs without -w because we only need to compare hashes.
+    new_oids = _hash_workdir_files(workdir, present, write_to_odb=False)
+    modified = sorted(p for p in present if new_oids.get(p) != tracked[p])
+
+    return {
+        "modified": modified,
+        "untracked": sorted(untracked),
+        "deleted": deleted,
+    }
+
+
+def _hash_workdir_files(workdir, rel_paths, write_to_odb=True):
+    """
+    Hashes each rel_path under workdir, returning {rel_path: blob_oid}.
+
+    If write_to_odb is True the blobs are also written to the object database (so that diff-writers
+    can later fetch their content); these dangling blobs will be cleaned up by `git gc` if
+    `kart commit-files` is not subsequently used to record them. Pass write_to_odb=False when only
+    the OIDs are needed (e.g. for status comparisons).
+    """
+    if not rel_paths:
+        return {}
+    cmd = ["git", "-C", workdir, "hash-object", "--no-filters", "--stdin-paths"]
+    if write_to_odb:
+        cmd.insert(4, "-w")
+    try:
+        proc = subprocess.run(
+            cmd,
+            input="\n".join(rel_paths) + "\n",
+            capture_output=True,
+            encoding="utf8",
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        raise SubprocessError(
+            f"There was a problem with git hash-object: {e.stderr or e}",
+            called_process_error=e,
+        )
+    oids = proc.stdout.strip().splitlines()
+    return dict(zip(rel_paths, oids))
 
 
 def path_matches_repo_key_filter(path, repo_key_filter):

--- a/kart/meta.py
+++ b/kart/meta.py
@@ -317,3 +317,98 @@ def commit_files(ctx, message, ref, amend, allow_empty, remove_empty_files, item
 
     click.echo(f"Committed as: {new_commit.hex}")
     repo.working_copy.reset_to_head()
+
+
+# ---------------------------------------------------------------------------
+# Hidden helper commands used by the QGIS Kart plugin
+# ---------------------------------------------------------------------------
+
+
+@click.command("blob-hash", hidden=True, cls=KartCommand)
+@click.argument("ref_path")
+@click.pass_context
+def blob_hash(ctx, ref_path):
+    """Output the object ID of a blob. Usage: kart blob-hash REF:PATH"""
+    repo = ctx.obj.repo
+    ref, _, path = ref_path.partition(":")
+    try:
+        obj = repo.revparse_single(f"{ref}:{path}")
+    except KeyError:
+        raise click.UsageError(f"No such blob: {ref_path!r}")
+    click.echo(str(obj.id))
+
+
+@click.command("show-file", hidden=True, cls=KartCommand)
+@click.argument("ref_path")
+@click.pass_context
+def show_file(ctx, ref_path):
+    """Output raw content of a blob. Usage: kart show-file REF:PATH"""
+    import sys
+
+    repo = ctx.obj.repo
+    ref, _, path = ref_path.partition(":")
+    try:
+        blob = repo.revparse_single(f"{ref}:{path}")
+    except KeyError:
+        raise click.UsageError(f"No such blob: {ref_path!r}")
+    sys.stdout.buffer.write(blob.data)
+
+
+@click.command("ahead-behind", hidden=True, cls=KartCommand)
+@click.pass_context
+def ahead_behind(ctx):
+    """Output ahead/behind counts vs tracking branch. Outputs '0 0' when no upstream."""
+    repo = ctx.obj.repo
+    try:
+        head = repo.head
+        shorthand = head.shorthand
+        branch = repo.branches.get(shorthand)
+        if branch is None or branch.upstream is None:
+            click.echo("0 0")
+            return
+        ahead, behind = repo.ahead_behind(head.target, branch.upstream.target)
+        click.echo(f"{ahead} {behind}")
+    except Exception:
+        click.echo("0 0")
+
+
+@click.command("ls-files", hidden=True, cls=KartCommand)
+@click.argument("ref", default="HEAD")
+@click.pass_context
+def ls_files(ctx, ref):
+    """List attachment files tracked at REF (not datasets or Kart internals)."""
+    import re
+
+    repo = ctx.obj.repo
+    try:
+        commit = repo.revparse_single(ref)
+        tree = commit.peel(pygit2.Tree)
+    except KeyError:
+        raise click.UsageError(f"No such ref: {ref!r}")
+
+    _DATASET_DIR_RE = re.compile(r"\.[^/]*dataset[^/]*$")
+    _TOP_PREFIXES = (".kart", ".git")
+    _README_RE = re.compile(r"^[A-Z]+_README\.[^/]*$")
+
+    def is_attachment(path):
+        parts = path.split("/")
+        top = parts[0]
+        if any(top == p or top.startswith(p + ".") for p in _TOP_PREFIXES):
+            return False
+        if len(parts) == 1 and _README_RE.match(top):
+            return False
+        for part in parts[:-1]:
+            if _DATASET_DIR_RE.match(part):
+                return False
+        return True
+
+    def walk_tree(tree, prefix=""):
+        for entry in tree:
+            full = f"{prefix}{entry.name}" if prefix else entry.name
+            if entry.type_str == "tree":
+                walk_tree(repo.get(entry.id), f"{full}/")
+            elif entry.type_str == "blob":
+                if is_attachment(full):
+                    click.echo(full)
+
+    walk_tree(tree)

--- a/kart/meta.py
+++ b/kart/meta.py
@@ -377,30 +377,14 @@ def ahead_behind(ctx):
 @click.pass_context
 def ls_files(ctx, ref):
     """List attachment files tracked at REF (not datasets or Kart internals)."""
-    import re
+    from kart.diff_util import is_attachment_path
 
     repo = ctx.obj.repo
     try:
-        commit = repo.revparse_single(ref)
-        tree = commit.peel(pygit2.Tree)
-    except KeyError:
+        obj = repo.revparse_single(ref)
+        tree = obj.peel(pygit2.Tree)
+    except (KeyError, pygit2.InvalidSpecError):
         raise click.UsageError(f"No such ref: {ref!r}")
-
-    _DATASET_DIR_RE = re.compile(r"\.[^/]*dataset[^/]*$")
-    _TOP_PREFIXES = (".kart", ".git")
-    _README_RE = re.compile(r"^[A-Z]+_README\.[^/]*$")
-
-    def is_attachment(path):
-        parts = path.split("/")
-        top = parts[0]
-        if any(top == p or top.startswith(p + ".") for p in _TOP_PREFIXES):
-            return False
-        if len(parts) == 1 and _README_RE.match(top):
-            return False
-        for part in parts[:-1]:
-            if _DATASET_DIR_RE.match(part):
-                return False
-        return True
 
     def walk_tree(tree, prefix=""):
         for entry in tree:
@@ -408,7 +392,7 @@ def ls_files(ctx, ref):
             if entry.type_str == "tree":
                 walk_tree(repo.get(entry.id), f"{full}/")
             elif entry.type_str == "blob":
-                if is_attachment(full):
+                if is_attachment_path(full):
                     click.echo(full)
 
     walk_tree(tree)

--- a/kart/resolve.py
+++ b/kart/resolve.py
@@ -335,7 +335,10 @@ def resolve_conflicts_with_renumber(repo, renumber, conflict_labels):
     ]
 
     structure = repo.structure()
-    decoded_resolves = [structure.decode_path(p) for p in resolve_paths]
+    decoded_resolves = [
+        dr for dr in (structure.decode_path(p) for p in resolve_paths)
+        if dr[0] != "attachment"
+    ]
     ours_datasets = repo.datasets(merge_context.versions.ours.commit_id)
     theirs_datasets = repo.datasets(merge_context.versions.theirs.commit_id)
     merged_datasets = repo.datasets("MERGED_TREE")

--- a/kart/status.py
+++ b/kart/status.py
@@ -4,6 +4,7 @@ import click
 import pygit2
 
 from .base_diff_writer import BaseDiffWriter
+from .diff_util import get_workdir_file_status
 from .key_filters import RepoKeyFilter
 from .conflicts_writer import BaseConflictsWriter
 from .crs_util import make_crs
@@ -142,10 +143,26 @@ def get_working_copy_status_json(repo, list_untracked_tables):
         "changes": get_diff_status_json(repo),
         "nonCheckoutDatasets": sorted(repo.non_checkout_datasets),
     }
+    files = get_file_status_json(repo)
+    if files:
+        # Only include the files key when there are any attachment changes, so the existing JSON
+        # shape is preserved for repos with no attachments / no attachment changes.
+        result["files"] = files
     if list_untracked_tables:
         result["untrackedTables"] = get_untracked_tables(repo)
 
     return result
+
+
+def get_file_status_json(repo):
+    """
+    Returns the working-directory status for attachment files (anything tracked in git that is not
+    Kart-internal and not part of a dataset's contents). Returns {} when there are no changes.
+    """
+    if repo.head_is_unborn:
+        return {}
+    raw = get_workdir_file_status(repo)
+    return {k: v for k, v in raw.items() if v}
 
 
 def get_untracked_tables(repo):
@@ -318,18 +335,42 @@ def working_copy_status_to_text(jdict):
             f"  (to overturn, use `kart checkout --dataset=DATASET`):\n{non_checkout_datasets}"
         )
 
-    if not jdict["changes"]:
-        result_list.append("Nothing to commit, working copy clean")
+    files = jdict.get("files") or {}
+    has_dataset_changes = bool(jdict["changes"])
+    has_file_changes = bool(files)
 
+    if not has_dataset_changes and not has_file_changes:
+        result_list.append("Nothing to commit, working copy clean")
     else:
-        result_list.append(
+        sections = [
             "Changes in working copy:\n"
             '  (use "kart commit" to commit)\n'
-            '  (use "kart restore" to discard changes)\n\n'
-            + diff_status_to_text(jdict["changes"])
-        )
+            '  (use "kart restore" to discard changes)'
+        ]
+        if has_dataset_changes:
+            sections.append(diff_status_to_text(jdict["changes"]))
+        if has_file_changes:
+            sections.append(file_status_to_text(files))
+        result_list.append("\n\n".join(sections))
 
     return "\n\n".join(result_list)
+
+
+def file_status_to_text(files):
+    """Render the attachment-files section of `kart status`."""
+    sections = []
+    for label, key in (
+        ("Modified files", "modified"),
+        ("Untracked files", "untracked"),
+        ("Deleted files", "deleted"),
+    ):
+        paths = files.get(key) or []
+        if not paths:
+            continue
+        sections.append(f"  {label}:")
+        for path in paths:
+            sections.append(f"    {path}")
+    return "\n".join(sections)
 
 
 def diff_status_to_text(jdict):

--- a/kart/status.py
+++ b/kart/status.py
@@ -154,14 +154,16 @@ def get_working_copy_status_json(repo, list_untracked_tables):
     return result
 
 
-def get_file_status_json(repo):
+def get_file_status_json(repo, workdir_diff_cache=None):
     """
     Returns the working-directory status for attachment files (anything tracked in git that is not
     Kart-internal and not part of a dataset's contents). Returns {} when there are no changes.
     """
     if repo.head_is_unborn:
         return {}
-    raw = get_workdir_file_status(repo)
+    if workdir_diff_cache is None:
+        workdir_diff_cache = repo.working_copy.workdir_diff_cache()
+    raw = get_workdir_file_status(repo, workdir_diff_cache=workdir_diff_cache)
     return {k: v for k, v in raw.items() if v}
 
 

--- a/kart/structure.py
+++ b/kart/structure.py
@@ -361,7 +361,7 @@ class RepoStructure:
             new_value = delta.new_value
             # WC diffs store blob OIDs (hex strings) rather than raw bytes; resolve them here.
             if isinstance(new_value, str):
-                new_value = bytes(self.repo.get(pygit2.Oid(hex=new_value)))
+                new_value = bytes(self.repo[pygit2.Oid(hex=new_value)])
             assert isinstance(new_value, (bytes, type(None)))
             if new_value is not None:
                 object_builder.insert(path, new_value)

--- a/kart/structure.py
+++ b/kart/structure.py
@@ -358,9 +358,13 @@ class RepoStructure:
 
             # TODO - check for conflicts.
 
-            assert isinstance(delta.new_value, (bytes, type(None)))
-            if delta.new_value is not None:
-                object_builder.insert(path, delta.new_value)
+            new_value = delta.new_value
+            # WC diffs store blob OIDs (hex strings) rather than raw bytes; resolve them here.
+            if isinstance(new_value, str):
+                new_value = bytes(self.repo.get(pygit2.Oid(hex=new_value)))
+            assert isinstance(new_value, (bytes, type(None)))
+            if new_value is not None:
+                object_builder.insert(path, new_value)
             else:
                 object_builder.remove(path)
 

--- a/kart/structure.py
+++ b/kart/structure.py
@@ -183,8 +183,13 @@ class RepoStructure:
         1. (dataset_path, "meta", meta_item_path)
         2. (dataset_path, "feature", primary_key)
         3. (dataset_path, "tile", tile_name)
+
+        For attachment files that do not belong to any dataset, returns:
+        4. ("attachment", full_path)
         """
         match = DATASET_PATH_PATTERN.search(full_path)
+        if match is None:
+            return ("attachment", full_path)
         dataset_path = full_path[: match.start()]
         rel_path = full_path[match.start() + 1 :]
         return (dataset_path, *self.datasets()[dataset_path].decode_path(rel_path))

--- a/kart/workdir.py
+++ b/kart/workdir.py
@@ -106,6 +106,64 @@ class FileSystemWorkingCopy(WorkingCopyPart):
 
         self.kart_tables = WorkdirKartTables()
 
+    # workdir-index plumbing: the .kart/workdir-index git index tracks which on-disk files
+    # (tile files and attachments) differ from HEAD, using git's mtime optimisation.
+
+    def _git_diff_paths(self):
+        """
+        Returns paths tracked in the workdir-index that differ from the working directory
+        (files that are modified or deleted). Uses git's mtime optimisation so unchanged
+        large files are not re-hashed.
+        """
+        if not self.index_path.is_file():
+            return []
+        env_overrides = {"GIT_INDEX_FILE": str(self.index_path)}
+        try:
+            out = subprocess.check_output(
+                ["git", "diff", "--name-only"],
+                env_overrides=env_overrides,
+                encoding="utf-8",
+                cwd=self.path,
+            )
+        except subprocess.CalledProcessError as e:
+            sys.exit(translate_subprocess_exit_code(e.returncode))
+        return [p.replace("\\", "/") for p in out.strip().splitlines()]
+
+    def _git_ls_others_paths(self):
+        """Returns paths in the working directory that are not tracked in the workdir-index."""
+        if not self.index_path.is_file():
+            return []
+        env_overrides = {"GIT_INDEX_FILE": str(self.index_path)}
+        try:
+            out = subprocess.check_output(
+                ["git", "ls-files", "--others", "--exclude-standard"],
+                env_overrides=env_overrides,
+                encoding="utf-8",
+                cwd=self.path,
+            )
+        except subprocess.CalledProcessError as e:
+            sys.exit(translate_subprocess_exit_code(e.returncode))
+        return [p.replace("\\", "/") for p in out.strip().splitlines()]
+
+    def dirty_paths(self):
+        return self._git_diff_paths() + self._git_ls_others_paths()
+
+    def add_paths_to_index(self, rel_paths):
+        """
+        Adds the given working-directory paths to the workdir-index so subsequent calls to
+        dirty_paths() can detect changes to them via git's mtime optimisation.
+        """
+        if not rel_paths or not self.index_path.is_file():
+            return
+        _add_paths_to_workdir_index(self.repo, self.index_path, self.path, rel_paths)
+
+    def workdir_diff_cache(self):
+        """
+        Returns a WorkdirDiffCache that caches the results of the index-vs-workdir comparison
+        for the duration of a single diff.
+        """
+        return WorkdirDiffCache(self)
+
     @classmethod
     def get(
         self,
@@ -128,10 +186,12 @@ class FileSystemWorkingCopy(WorkingCopyPart):
         return wc
 
     def status(self):
-        existing_files = [f for f in self._required_paths if f.is_file()]
-        if not existing_files:
+        # workdir-state.db + workdir-index together indicate the working copy exists. Both are
+        # written by create_and_initialise(), including when a tabular-only repo creates the
+        # workdir solely to track attachment files.
+        if not self.state_path.is_file():
             return FileSystemWorkingCopyStatus.UNCREATED
-        if existing_files == self._required_paths:
+        if self.index_path.is_file():
             return FileSystemWorkingCopyStatus.CREATED
         return FileSystemWorkingCopyStatus.PARTIALLY_CREATED
 
@@ -852,34 +912,6 @@ class FileSystemWorkingCopy(WorkingCopyPart):
         assert isinstance(dataset, TileDataset)
         dataset.write_mosaic_for_directory((self.path / dataset.path).resolve())
 
-    def dirty_paths(self):
-        env_overrides = {"GIT_INDEX_FILE": str(self.index_path)}
-
-        try:
-            # This finds all files in the index that have been modified - and updates any mtimes in the index
-            # if the mtimes are stale but the files are actually unchanged (as in GIT_DIFF_UPDATE_INDEX).
-            cmd = ["git", "diff", "--name-only"]
-            output_lines = (
-                subprocess.check_output(
-                    cmd, env_overrides=env_overrides, encoding="utf-8", cwd=self.path
-                )
-                .strip()
-                .splitlines()
-            )
-            # This finds all untracked files that are not in the index.
-            cmd = ["git", "ls-files", "--others", "--exclude-standard"]
-            output_lines += (
-                subprocess.check_output(
-                    cmd, env_overrides=env_overrides, encoding="utf-8", cwd=self.path
-                )
-                .strip()
-                .splitlines()
-            )
-        except subprocess.CalledProcessError as e:
-            sys.exit(translate_subprocess_exit_code(e.returncode))
-
-        return [p.replace("\\", "/") for p in output_lines]
-
     def dirty_paths_by_dataset_path(self, dirty_paths=None):
         """Returns all the deltas from self.raw_diff_from_index() but grouped by dataset path."""
         if dirty_paths is None:
@@ -904,13 +936,48 @@ class FileSystemWorkingCopy(WorkingCopyPart):
 
         return dirty_paths_by_dataset_path
 
-    def workdir_diff_cache(self):
-        """
-        Returns a WorkdirDiffCache that acts as a caching layer for this working copy -
-        the results of certain operations such as raw_diff_from_index can be cached for the
-        duration of a diff.
-        """
-        return WorkdirDiffCache(self)
+
+def _add_paths_to_workdir_index(repo, index_path, workdir_path, rel_paths):
+    """
+    Adds working-directory paths to the workdir-index (index_path) so that subsequent git diff
+    calls against that index can detect modifications via git's mtime optimisation.
+
+    Each path is hashed to get its current blob OID, then an IndexEntry is written directly via
+    pygit2.  This avoids using 'git update-index --stdin' which silently ignores paths when
+    GIT_INDEX_FILE points to a file other than the repository's main .git/index.
+    """
+    if not rel_paths or not index_path.is_file():
+        return
+
+    # Hash each file and write it to the object database (-w), so that git diff
+    # can later read the blob when comparing the index against the working tree.
+    oids = {}
+    for rel in rel_paths:
+        abs_path = workdir_path / rel
+        if not abs_path.is_file():
+            continue
+        try:
+            result = subprocess.check_output(
+                ["git", "hash-object", "-w", "--no-filters", str(abs_path)],
+                encoding="utf-8",
+                cwd=workdir_path,
+            )
+            oids[rel] = result.strip()
+        except subprocess.CalledProcessError:
+            pass
+
+    if not oids:
+        return
+
+    idx = pygit2.Index(str(index_path))
+    idx._repo = repo
+    for rel, oid_hex in oids.items():
+        try:
+            entry = pygit2.IndexEntry(rel, pygit2.Oid(hex=oid_hex), pygit2.GIT_FILEMODE_BLOB)
+            idx.add(entry)
+        except Exception:
+            pass
+    idx.write()
 
 
 class WorkdirDiffCache:
@@ -923,14 +990,25 @@ class WorkdirDiffCache:
     - We want to run it as soon a the first dataset needs this info, then cache the result
     - We want the result to stay cached for the duration of the diff operation, but no longer
       (in eg a long-running test, there might be several diffs run and the workdir might change)
+
+    The delegate is a FileSystemWorkingCopy - present whenever the repo has tile datasets
+    and/or attachment files (a tabular-only repo with attachments gets one created on checkout).
     """
 
     def __init__(self, delegate):
         self.delegate = delegate
 
     @functools.lru_cache(maxsize=1)
+    def _git_diff_paths(self):
+        return self.delegate._git_diff_paths()
+
+    @functools.lru_cache(maxsize=1)
+    def _git_ls_others_paths(self):
+        return self.delegate._git_ls_others_paths()
+
+    @functools.lru_cache(maxsize=1)
     def dirty_paths(self):
-        return self.delegate.dirty_paths()
+        return self._git_diff_paths() + self._git_ls_others_paths()
 
     @functools.lru_cache(maxsize=1)
     def dirty_paths_by_dataset_path(self):
@@ -944,3 +1022,39 @@ class WorkdirDiffCache:
         else:
             path = dataset.path
         return self.dirty_paths_by_dataset_path().get(path, ())
+
+    @functools.lru_cache(maxsize=1)
+    @functools.lru_cache(maxsize=1)
+    def tile_dataset_paths(self):
+        """The dataset paths of tile-based datasets (point-cloud / raster) at the workdir's
+        tracked tree. Dirty files under these are tiles, not attachments."""
+        tree_id = self.delegate.get_tree_id()
+        if not tree_id:
+            return frozenset()
+        return frozenset(
+            ds.path
+            for ds in self.delegate.repo.datasets(
+                tree_id, filter_dataset_type=ALL_TILE_DATASET_TYPES
+            )
+        )
+
+    def dirty_attachment_paths(self):
+        """
+        Returns the dirty paths that are attachment files: is_attachment_path() is True and the
+        path is not tile content of a tile dataset.
+
+        dirty_paths_by_dataset_path() groups dirty paths by owning dataset directory. Files under
+        a *tile* dataset (e.g. elevation/EK.tif) are tiles, not attachments, so we drop those
+        groups. Files under a *tabular* dataset directory (e.g. nz_pa_points_topo_150k/metadata.xml)
+        are user-facing attachments and are kept, as are top-level files (the None group).
+        """
+        from kart.diff_util import is_attachment_path
+
+        by_ds = self.dirty_paths_by_dataset_path()
+        tile_ds_paths = self.tile_dataset_paths()
+        result = []
+        for ds_path, paths in by_ds.items():
+            if ds_path in tile_ds_paths:
+                continue
+            result.extend(p for p in paths if is_attachment_path(p))
+        return result

--- a/kart/working_copy.py
+++ b/kart/working_copy.py
@@ -165,9 +165,11 @@ class WorkingCopy:
         )
 
     def workdir_diff_cache(self):
-        """Returns a WorkdirDiffCache for caching the results of certain workdir operations over the course of a single diff."""
+        """Returns a WorkdirDiffCache for caching the results of certain workdir operations over the course of a single diff.
+        Returns None if there is no file-system working copy (eg a tabular-only repo that has no attachment files, so the
+        workdir was never initialised)."""
         w = self.workdir
-        return w.workdir_diff_cache() if w else None
+        return w.workdir_diff_cache() if w is not None else None
 
     def create_parts_if_missing(
         self, parts_to_create, reset_to=DONT_RESET, non_checkout_datasets=None

--- a/tests/test_attachment_edge_cases.py
+++ b/tests/test_attachment_edge_cases.py
@@ -1,0 +1,67 @@
+"""
+Edge-case tests for the attachment-files feature.
+Targets the specific fix in this PR:
+
+  `kart/structure.py`: `repo[oid]` raises KeyError for missing OID — replaces
+  `repo.get(oid)` which silently returned None and made `bytes(None)` raise a
+  confusing TypeError downstream when applying a working-copy diff that
+  references a blob no longer present in the ODB.
+"""
+import pygit2
+import pytest
+
+
+H = pytest.helpers.helpers()
+
+
+# ---------------------------------------------------------------------------
+# repo[oid] error semantics in RepoStructure.apply_files_diff
+# ---------------------------------------------------------------------------
+
+
+def test_repo_subscript_raises_keyerror_for_missing_oid(data_archive):
+    """`repo[oid]` raises KeyError for a non-existent OID — pinning the new
+    error path in structure.py. The previous `repo.get(oid)` silently returned
+    None, and the subsequent `bytes(None)` raised a confusing
+    `TypeError: cannot convert 'NoneType' object to bytes`."""
+    from kart.repo import KartRepo
+
+    with data_archive("points") as path:
+        repo = KartRepo(path)
+        bogus_oid = pygit2.Oid(hex="0" * 40)
+        # New behaviour: raises KeyError, not silent None.
+        with pytest.raises(KeyError):
+            _ = repo[bogus_oid]
+        # Sanity: repo.get() *would* have returned None for the same OID.
+        assert repo.get(bogus_oid) is None
+
+
+def test_repo_subscript_returns_blob_for_real_oid(data_archive):
+    """A real attachment-blob OID resolves via repo[oid] just fine."""
+    from kart.repo import KartRepo
+
+    with data_archive("points-with-attached-files") as path:
+        repo = KartRepo(path)
+        # Resolve LICENSE.txt at HEAD via pygit2 directly.
+        license_entry = repo.head_tree["LICENSE.txt"]
+        blob = repo[license_entry.id]
+        assert blob.type_str == "blob"
+        assert len(bytes(blob)) > 0
+
+
+# ---------------------------------------------------------------------------
+# create-workingcopy / clone restore attachment files to disk
+# ---------------------------------------------------------------------------
+
+
+def test_create_workingcopy_restores_attachments(data_working_copy):
+    """`kart create-workingcopy` must put tracked attachment files on disk —
+    otherwise `kart clone` of a repo with `LICENSE.txt` leaves the file
+    missing from the workdir, which is both surprising and breaks downstream
+    tooling (the QGIS plugin, IDE git status, etc.)."""
+    with data_working_copy("points-with-attached-files") as (path, _wc):
+        # The data_working_copy fixture calls `kart create-workingcopy` under
+        # the hood; LICENSE.txt should be on disk afterwards with no extra
+        # checkout step.
+        assert (path / "LICENSE.txt").is_file()
+        assert (path / "LICENSE.txt").read_text(encoding="utf-8")

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -283,3 +283,20 @@ def test_restore_leaves_untracked_files(data_working_copy, cli_runner):
         assert r.exit_code == 0, r.stderr
         assert notes.read_text(encoding="utf-8") == "Hello.\n"
         assert _file_status(cli_runner) == {"untracked": ["NOTES.txt"]}
+
+
+
+def test_checkout_restores_attachments(data_archive, cli_runner):
+    """Switching commits should refresh tracked attachment files in the workdir, not just datasets."""
+    with data_archive("points-with-attached-files") as path:
+        _checkout_attachments(path)
+        license_path = path / "LICENSE.txt"
+        original = license_path.read_text(encoding="utf-8")
+
+        # Modify the attachment locally without committing.
+        license_path.write_text("Local edit, will be discarded.\n", encoding="utf-8")
+
+        # `kart checkout HEAD --discard-changes` should restore the attachment to its HEAD state.
+        r = cli_runner.invoke(["checkout", "HEAD", "--discard-changes"])
+        assert r.exit_code == 0, r.stderr
+        assert license_path.read_text(encoding="utf-8") == original

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -1,5 +1,4 @@
 import json
-import subprocess
 
 import pytest
 
@@ -10,34 +9,6 @@ from kart.structs import CommitWithReference
 
 
 H = pytest.helpers.helpers()
-
-
-def _checkout_attachments(repo_path):
-    """
-    Extracts every tracked attachment file in HEAD to the working directory. Kart does not yet
-    do this on checkout (issue #583, step 5), so attachment-restore tests need to set up the
-    workdir explicitly before testing `kart restore`.
-    """
-    repo = KartRepo(repo_path)
-    tree_oid = repo.head_tree.id.hex
-    listing = subprocess.check_output(
-        ["git", "-C", str(repo_path), "ls-tree", "-r", "-z", tree_oid],
-        encoding="utf-8",
-    )
-    paths = []
-    for entry in listing.split("\0"):
-        if not entry:
-            continue
-        _meta, path = entry.split("\t", 1)
-        if path.split("/")[0] in (".kart", ".git") or path.startswith(".kart."):
-            continue
-        if any(p.startswith(".") and "dataset" in p for p in path.split("/")[:-1]):
-            continue
-        paths.append(path)
-    if paths:
-        subprocess.check_call(
-            ["git", "-C", str(repo_path), "checkout", tree_oid, "--"] + paths
-        )
 
 
 @pytest.mark.parametrize(
@@ -227,7 +198,6 @@ def _file_status(cli_runner):
 def test_restore_attachment_modified(data_working_copy, cli_runner):
     """`kart restore -- LICENSE.txt` discards a modification to a tracked attachment file."""
     with data_working_copy("points-with-attached-files") as (path, wc):
-        _checkout_attachments(path)
         license_path = path / "LICENSE.txt"
         original = license_path.read_text(encoding="utf-8")
 
@@ -243,7 +213,6 @@ def test_restore_attachment_modified(data_working_copy, cli_runner):
 def test_restore_attachment_deleted(data_working_copy, cli_runner):
     """`kart restore -- LICENSE.txt` re-creates a tracked attachment file removed from the workdir."""
     with data_working_copy("points-with-attached-files") as (path, wc):
-        _checkout_attachments(path)
         license_path = path / "LICENSE.txt"
         original = license_path.read_text(encoding="utf-8")
 
@@ -259,7 +228,6 @@ def test_restore_attachment_deleted(data_working_copy, cli_runner):
 def test_restore_all_attachments(data_working_copy, cli_runner):
     """`kart restore` (no filters) restores every tracked attachment file as well as datasets."""
     with data_working_copy("points-with-attached-files") as (path, wc):
-        _checkout_attachments(path)
         original = (path / "LICENSE.txt").read_text(encoding="utf-8")
         (path / "LICENSE.txt").write_text("Edited.\n", encoding="utf-8")
         (path / "nz_pa_points_topo_150k" / "metadata.xml").unlink()
@@ -275,7 +243,6 @@ def test_restore_all_attachments(data_working_copy, cli_runner):
 def test_restore_leaves_untracked_files(data_working_copy, cli_runner):
     """`kart restore` does not touch untracked attachment files (mirrors `git restore` semantics)."""
     with data_working_copy("points-with-attached-files") as (path, wc):
-        _checkout_attachments(path)
         notes = path / "NOTES.txt"
         notes.write_text("Hello.\n", encoding="utf-8")
 
@@ -286,10 +253,9 @@ def test_restore_leaves_untracked_files(data_working_copy, cli_runner):
 
 
 
-def test_checkout_restores_attachments(data_archive, cli_runner):
+def test_checkout_restores_attachments(data_working_copy, cli_runner):
     """Switching commits should refresh tracked attachment files in the workdir, not just datasets."""
-    with data_archive("points-with-attached-files") as path:
-        _checkout_attachments(path)
+    with data_working_copy("points-with-attached-files") as (path, wc):
         license_path = path / "LICENSE.txt"
         original = license_path.read_text(encoding="utf-8")
 
@@ -302,20 +268,17 @@ def test_checkout_restores_attachments(data_archive, cli_runner):
         assert license_path.read_text(encoding="utf-8") == original
 
 
-def test_checkout_removes_deleted_attachments(data_archive, cli_runner):
+def test_checkout_removes_deleted_attachments(data_working_copy, cli_runner):
     """Switching to a commit where an attachment was removed should delete the file from the workdir."""
-    with data_archive("points-with-attached-files") as path:
-        _checkout_attachments(path)
+    with data_working_copy("points-with-attached-files") as (path, wc):
         license_path = path / "LICENSE.txt"
         assert license_path.exists()
 
         # Commit a new version with LICENSE.txt removed.
         r = cli_runner.invoke(
-            ["commit-files", "-m", "remove LICENSE.txt", "LICENSE.txt="]
+            ["commit-files", "-m", "remove LICENSE.txt", "--remove-empty-files", "LICENSE.txt="]
         )
         assert r.exit_code == 0, r.stderr
-        new_commit = cli_runner.invoke(["log", "-1", "--output-format=json"])
-        assert new_commit.exit_code == 0
 
         # Go back one commit (where LICENSE.txt existed).
         r = cli_runner.invoke(["checkout", "HEAD~1"])
@@ -323,15 +286,14 @@ def test_checkout_removes_deleted_attachments(data_archive, cli_runner):
         assert license_path.exists(), "LICENSE.txt should be restored when switching back"
 
         # Now switch forward again (LICENSE.txt was deleted in that commit).
-        r = cli_runner.invoke(["checkout", "-"])
+        r = cli_runner.invoke(["checkout", "main"])
         assert r.exit_code == 0, r.stderr
         assert not license_path.exists(), "LICENSE.txt should be removed when switching to commit that deleted it"
 
 
-def test_commit_attachment_file(data_archive, cli_runner):
+def test_commit_attachment_file(data_working_copy, cli_runner):
     """kart commit should pick up modified and new attachment files alongside dataset changes."""
-    with data_archive("points-with-attached-files") as path:
-        _checkout_attachments(path)
+    with data_working_copy("points-with-attached-files") as (path, wc):
         license_path = path / "LICENSE.txt"
         notes_path = path / "NOTES.txt"
 
@@ -352,7 +314,7 @@ def test_commit_attachment_file(data_archive, cli_runner):
         r = cli_runner.invoke(["checkout", "HEAD~1"])
         assert r.exit_code == 0, r.stderr
 
-        r = cli_runner.invoke(["checkout", "-"])
+        r = cli_runner.invoke(["checkout", "main"])
         assert r.exit_code == 0, r.stderr
         assert license_path.read_text(encoding="utf-8") == "Updated license text.\n"
         assert notes_path.read_text(encoding="utf-8") == "New notes file.\n"
@@ -370,7 +332,6 @@ def test_restore_dataset_filter_and_file_filter_same_arg(data_working_copy, cli_
     no attachment file with that name exists.
     """
     with data_working_copy("points-with-attached-files") as (path, wc):
-        _checkout_attachments(path)
         # Modify the dataset so there is something to restore.
         r = cli_runner.invoke(["checkout", "HEAD", "--discard-changes"])
         assert r.exit_code == 0, r.stderr

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -356,3 +356,26 @@ def test_commit_attachment_file(data_archive, cli_runner):
         assert r.exit_code == 0, r.stderr
         assert license_path.read_text(encoding="utf-8") == "Updated license text.\n"
         assert notes_path.read_text(encoding="utf-8") == "New notes file.\n"
+
+
+def test_restore_dataset_filter_and_file_filter_same_arg(data_working_copy, cli_runner):
+    """
+    Regression: kart restore with a filter that names a dataset must not fail even if
+    the same string could also be interpreted as an attachment file path.  Previously
+    _split_restore_filters would misclassify a filter when the dataset exists only on one
+    branch but not the source tree passed to the split function.
+
+    Here we verify the simpler invariant: passing a dataset name as a filter to
+    `kart restore` succeeds (dataset is restored) and does not raise an error even though
+    no attachment file with that name exists.
+    """
+    with data_working_copy("points-with-attached-files") as (path, wc):
+        _checkout_attachments(path)
+        # Modify the dataset so there is something to restore.
+        r = cli_runner.invoke(["checkout", "HEAD", "--discard-changes"])
+        assert r.exit_code == 0, r.stderr
+
+        # Passing the dataset name as a filter should succeed even though
+        # no attachment file called "nz_pa_points_topo_150k" exists.
+        r = cli_runner.invoke(["restore", "--", "nz_pa_points_topo_150k"])
+        assert r.exit_code == 0, r.stderr

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -300,3 +300,59 @@ def test_checkout_restores_attachments(data_archive, cli_runner):
         r = cli_runner.invoke(["checkout", "HEAD", "--discard-changes"])
         assert r.exit_code == 0, r.stderr
         assert license_path.read_text(encoding="utf-8") == original
+
+
+def test_checkout_removes_deleted_attachments(data_archive, cli_runner):
+    """Switching to a commit where an attachment was removed should delete the file from the workdir."""
+    with data_archive("points-with-attached-files") as path:
+        _checkout_attachments(path)
+        license_path = path / "LICENSE.txt"
+        assert license_path.exists()
+
+        # Commit a new version with LICENSE.txt removed.
+        r = cli_runner.invoke(
+            ["commit-files", "-m", "remove LICENSE.txt", "LICENSE.txt="]
+        )
+        assert r.exit_code == 0, r.stderr
+        new_commit = cli_runner.invoke(["log", "-1", "--output-format=json"])
+        assert new_commit.exit_code == 0
+
+        # Go back one commit (where LICENSE.txt existed).
+        r = cli_runner.invoke(["checkout", "HEAD~1"])
+        assert r.exit_code == 0, r.stderr
+        assert license_path.exists(), "LICENSE.txt should be restored when switching back"
+
+        # Now switch forward again (LICENSE.txt was deleted in that commit).
+        r = cli_runner.invoke(["checkout", "-"])
+        assert r.exit_code == 0, r.stderr
+        assert not license_path.exists(), "LICENSE.txt should be removed when switching to commit that deleted it"
+
+
+def test_commit_attachment_file(data_archive, cli_runner):
+    """kart commit should pick up modified and new attachment files alongside dataset changes."""
+    with data_archive("points-with-attached-files") as path:
+        _checkout_attachments(path)
+        license_path = path / "LICENSE.txt"
+        notes_path = path / "NOTES.txt"
+
+        # Modify an existing attachment and add a new one.
+        license_path.write_text("Updated license text.\n", encoding="utf-8")
+        notes_path.write_text("New notes file.\n", encoding="utf-8")
+
+        r = cli_runner.invoke(["status"])
+        assert r.exit_code == 0, r.stderr
+        assert "LICENSE.txt" in r.stdout
+        assert "NOTES.txt" in r.stdout
+
+        # kart commit should include both attachment changes.
+        r = cli_runner.invoke(["commit", "-m", "update attachments"])
+        assert r.exit_code == 0, r.stderr
+
+        # Verify the files are committed: go back then forward and check content.
+        r = cli_runner.invoke(["checkout", "HEAD~1"])
+        assert r.exit_code == 0, r.stderr
+
+        r = cli_runner.invoke(["checkout", "-"])
+        assert r.exit_code == 0, r.stderr
+        assert license_path.read_text(encoding="utf-8") == "Updated license text.\n"
+        assert notes_path.read_text(encoding="utf-8") == "New notes file.\n"

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -1,3 +1,6 @@
+import json
+import subprocess
+
 import pytest
 
 
@@ -7,6 +10,34 @@ from kart.structs import CommitWithReference
 
 
 H = pytest.helpers.helpers()
+
+
+def _checkout_attachments(repo_path):
+    """
+    Extracts every tracked attachment file in HEAD to the working directory. Kart does not yet
+    do this on checkout (issue #583, step 5), so attachment-restore tests need to set up the
+    workdir explicitly before testing `kart restore`.
+    """
+    repo = KartRepo(repo_path)
+    tree_oid = repo.head_tree.id.hex
+    listing = subprocess.check_output(
+        ["git", "-C", str(repo_path), "ls-tree", "-r", "-z", tree_oid],
+        encoding="utf-8",
+    )
+    paths = []
+    for entry in listing.split("\0"):
+        if not entry:
+            continue
+        _meta, path = entry.split("\t", 1)
+        if path.split("/")[0] in (".kart", ".git") or path.startswith(".kart."):
+            continue
+        if any(p.startswith(".") and "dataset" in p for p in path.split("/")[:-1]):
+            continue
+        paths.append(path)
+    if paths:
+        subprocess.check_call(
+            ["git", "-C", str(repo_path), "checkout", tree_oid, "--"] + paths
+        )
 
 
 @pytest.mark.parametrize(
@@ -183,3 +214,72 @@ def test_non_checkout_datasets(data_working_copy, cli_runner):
         _check_workingcopy_contains_tables(
             repo, {"census2016_sdhca_ot_sos_short", "census2016_sdhca_ot_ra_short"}
         )
+
+
+def _file_status(cli_runner):
+    r = cli_runner.invoke(["status", "-o", "json"])
+    assert r.exit_code == 0, r.stderr
+    return (
+        json.loads(r.stdout)["kart.status/v2"]["workingCopy"].get("files") or {}
+    )
+
+
+def test_restore_attachment_modified(data_working_copy, cli_runner):
+    """`kart restore -- LICENSE.txt` discards a modification to a tracked attachment file."""
+    with data_working_copy("points-with-attached-files") as (path, wc):
+        _checkout_attachments(path)
+        license_path = path / "LICENSE.txt"
+        original = license_path.read_text(encoding="utf-8")
+
+        license_path.write_text("Edited.\n", encoding="utf-8")
+        assert _file_status(cli_runner) == {"modified": ["LICENSE.txt"]}
+
+        r = cli_runner.invoke(["restore", "--", "LICENSE.txt"])
+        assert r.exit_code == 0, r.stderr
+        assert license_path.read_text(encoding="utf-8") == original
+        assert _file_status(cli_runner) == {}
+
+
+def test_restore_attachment_deleted(data_working_copy, cli_runner):
+    """`kart restore -- LICENSE.txt` re-creates a tracked attachment file removed from the workdir."""
+    with data_working_copy("points-with-attached-files") as (path, wc):
+        _checkout_attachments(path)
+        license_path = path / "LICENSE.txt"
+        original = license_path.read_text(encoding="utf-8")
+
+        license_path.unlink()
+        assert _file_status(cli_runner) == {"deleted": ["LICENSE.txt"]}
+
+        r = cli_runner.invoke(["restore", "--", "LICENSE.txt"])
+        assert r.exit_code == 0, r.stderr
+        assert license_path.read_text(encoding="utf-8") == original
+        assert _file_status(cli_runner) == {}
+
+
+def test_restore_all_attachments(data_working_copy, cli_runner):
+    """`kart restore` (no filters) restores every tracked attachment file as well as datasets."""
+    with data_working_copy("points-with-attached-files") as (path, wc):
+        _checkout_attachments(path)
+        original = (path / "LICENSE.txt").read_text(encoding="utf-8")
+        (path / "LICENSE.txt").write_text("Edited.\n", encoding="utf-8")
+        (path / "nz_pa_points_topo_150k" / "metadata.xml").unlink()
+
+        r = cli_runner.invoke(["restore"])
+        assert r.exit_code == 0, r.stderr
+
+        assert (path / "LICENSE.txt").read_text(encoding="utf-8") == original
+        assert (path / "nz_pa_points_topo_150k" / "metadata.xml").is_file()
+        assert _file_status(cli_runner) == {}
+
+
+def test_restore_leaves_untracked_files(data_working_copy, cli_runner):
+    """`kart restore` does not touch untracked attachment files (mirrors `git restore` semantics)."""
+    with data_working_copy("points-with-attached-files") as (path, wc):
+        _checkout_attachments(path)
+        notes = path / "NOTES.txt"
+        notes.write_text("Hello.\n", encoding="utf-8")
+
+        r = cli_runner.invoke(["restore"])
+        assert r.exit_code == 0, r.stderr
+        assert notes.read_text(encoding="utf-8") == "Hello.\n"
+        assert _file_status(cli_runner) == {"untracked": ["NOTES.txt"]}

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -2222,42 +2222,11 @@ def test_attached_files_patch(data_archive, cli_runner):
         }
 
 
-def _checkout_attachments(repo_path):
-    """
-    Extracts all tracked attachment files in HEAD to the working directory.
-
-    `data_working_copy` only extracts the .kart gitdir; attachment files live in the object
-    database but Kart does not yet write them to the filesystem on checkout (issue #583, step 5).
-    We approximate that here so workdir-vs-tree tests have something to diff against.
-    """
-    import subprocess as _subprocess
-
-    repo = KartRepo(repo_path)
-    tree_oid = repo.head_tree.id.hex
-    listing = _subprocess.check_output(
-        ["git", "-C", str(repo_path), "ls-tree", "-r", "-z", tree_oid],
-        encoding="utf-8",
-    )
-    paths = []
-    for entry in listing.split("\0"):
-        if not entry:
-            continue
-        _meta, path = entry.split("\t", 1)
-        if path.startswith(".kart"):
-            continue
-        if any(p.startswith(".") and "dataset" in p for p in path.split("/")[:-1]):
-            continue
-        paths.append(path)
-    if paths:
-        _subprocess.check_call(
-            ["git", "-C", str(repo_path), "checkout", tree_oid, "--"] + paths
-        )
 
 
 def test_attached_files_workdir_diff_modified(data_working_copy, cli_runner):
     """Modifying a tracked attachment file shows up in `kart diff --diff-files`."""
     with data_working_copy("points-with-attached-files") as (repo_path, wc):
-        _checkout_attachments(repo_path)
         license_path = repo_path / "LICENSE.txt"
         license_path.write_text("Edited license text.\n", encoding="utf-8")
 
@@ -2275,7 +2244,6 @@ def test_attached_files_workdir_diff_modified(data_working_copy, cli_runner):
 def test_attached_files_workdir_diff_deleted(data_working_copy, cli_runner):
     """Deleting a tracked attachment file shows up in `kart diff --diff-files`."""
     with data_working_copy("points-with-attached-files") as (repo_path, wc):
-        _checkout_attachments(repo_path)
         (repo_path / "LICENSE.txt").unlink()
 
         r = cli_runner.invoke(["diff", "--diff-files", "-ojson", "--", "LICENSE.txt"])
@@ -2290,7 +2258,6 @@ def test_attached_files_workdir_diff_deleted(data_working_copy, cli_runner):
 def test_attached_files_workdir_diff_added(data_working_copy, cli_runner):
     """An untracked attachment file shows up in `kart diff --diff-files`."""
     with data_working_copy("points-with-attached-files") as (repo_path, wc):
-        _checkout_attachments(repo_path)
         new_path = repo_path / "NOTES.txt"
         new_path.write_text("Notes added in working dir.\n", encoding="utf-8")
 
@@ -2303,7 +2270,6 @@ def test_attached_files_workdir_diff_added(data_working_copy, cli_runner):
 def test_attached_files_workdir_diff_combined(data_working_copy, cli_runner):
     """Modifying, deleting and adding attachment files in one diff."""
     with data_working_copy("points-with-attached-files") as (repo_path, wc):
-        _checkout_attachments(repo_path)
         (repo_path / "LICENSE.txt").write_text("New license.\n", encoding="utf-8")
         (repo_path / "nz_pa_points_topo_150k" / "metadata.xml").unlink()
         (repo_path / "NOTES.txt").write_text("Hello.\n", encoding="utf-8")
@@ -2326,7 +2292,6 @@ def test_attached_files_workdir_diff_combined(data_working_copy, cli_runner):
 def test_attached_files_workdir_diff_oid_only(data_working_copy, cli_runner):
     """Without --diff-files, the diff reports abbreviated OIDs (and the blob is in the ODB)."""
     with data_working_copy("points-with-attached-files") as (repo_path, wc):
-        _checkout_attachments(repo_path)
         (repo_path / "LICENSE.txt").write_text("X\n", encoding="utf-8")
 
         r = cli_runner.invoke(["diff", "-ojson", "--", "LICENSE.txt"])
@@ -2343,7 +2308,6 @@ def test_attached_files_workdir_diff_oid_only(data_working_copy, cli_runner):
 def test_attached_files_workdir_diff_empty(data_working_copy, cli_runner):
     """No attachment changes => no <files> entry in the diff output."""
     with data_working_copy("points-with-attached-files") as (repo_path, wc):
-        _checkout_attachments(repo_path)
         r = cli_runner.invoke(["diff", "--diff-files", "-ojson"])
         assert r.exit_code == 0, r.stderr
         jdict = json.loads(r.stdout)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -2222,6 +2222,134 @@ def test_attached_files_patch(data_archive, cli_runner):
         }
 
 
+def _checkout_attachments(repo_path):
+    """
+    Extracts all tracked attachment files in HEAD to the working directory.
+
+    `data_working_copy` only extracts the .kart gitdir; attachment files live in the object
+    database but Kart does not yet write them to the filesystem on checkout (issue #583, step 5).
+    We approximate that here so workdir-vs-tree tests have something to diff against.
+    """
+    import subprocess as _subprocess
+
+    repo = KartRepo(repo_path)
+    tree_oid = repo.head_tree.id.hex
+    listing = _subprocess.check_output(
+        ["git", "-C", str(repo_path), "ls-tree", "-r", "-z", tree_oid],
+        encoding="utf-8",
+    )
+    paths = []
+    for entry in listing.split("\0"):
+        if not entry:
+            continue
+        _meta, path = entry.split("\t", 1)
+        if path.startswith(".kart"):
+            continue
+        if any(p.startswith(".") and "dataset" in p for p in path.split("/")[:-1]):
+            continue
+        paths.append(path)
+    if paths:
+        _subprocess.check_call(
+            ["git", "-C", str(repo_path), "checkout", tree_oid, "--"] + paths
+        )
+
+
+def test_attached_files_workdir_diff_modified(data_working_copy, cli_runner):
+    """Modifying a tracked attachment file shows up in `kart diff --diff-files`."""
+    with data_working_copy("points-with-attached-files") as (repo_path, wc):
+        _checkout_attachments(repo_path)
+        license_path = repo_path / "LICENSE.txt"
+        license_path.write_text("Edited license text.\n", encoding="utf-8")
+
+        r = cli_runner.invoke(["diff", "--diff-files", "-ojson", "--", "LICENSE.txt"])
+        assert r.exit_code == 0, r.stderr
+        files = json.loads(r.stdout)["kart.diff/v1+hexwkb"]["<files>"]
+        assert files == {
+            "LICENSE.txt": {
+                "-": "NZ Pa Points (Topo, 1:50k)\nhttps://data.linz.govt.nz/layer/50308-nz-pa-points-topo-150k/\nLand Information New Zealand\nCC-BY\n",
+                "+": "Edited license text.\n",
+            }
+        }
+
+
+def test_attached_files_workdir_diff_deleted(data_working_copy, cli_runner):
+    """Deleting a tracked attachment file shows up in `kart diff --diff-files`."""
+    with data_working_copy("points-with-attached-files") as (repo_path, wc):
+        _checkout_attachments(repo_path)
+        (repo_path / "LICENSE.txt").unlink()
+
+        r = cli_runner.invoke(["diff", "--diff-files", "-ojson", "--", "LICENSE.txt"])
+        assert r.exit_code == 0, r.stderr
+        files = json.loads(r.stdout)["kart.diff/v1+hexwkb"]["<files>"]
+        assert list(files.keys()) == ["LICENSE.txt"]
+        assert files["LICENSE.txt"] == {
+            "-": "NZ Pa Points (Topo, 1:50k)\nhttps://data.linz.govt.nz/layer/50308-nz-pa-points-topo-150k/\nLand Information New Zealand\nCC-BY\n"
+        }
+
+
+def test_attached_files_workdir_diff_added(data_working_copy, cli_runner):
+    """An untracked attachment file shows up in `kart diff --diff-files`."""
+    with data_working_copy("points-with-attached-files") as (repo_path, wc):
+        _checkout_attachments(repo_path)
+        new_path = repo_path / "NOTES.txt"
+        new_path.write_text("Notes added in working dir.\n", encoding="utf-8")
+
+        r = cli_runner.invoke(["diff", "--diff-files", "-ojson", "--", "NOTES.txt"])
+        assert r.exit_code == 0, r.stderr
+        files = json.loads(r.stdout)["kart.diff/v1+hexwkb"]["<files>"]
+        assert files == {"NOTES.txt": {"+": "Notes added in working dir.\n"}}
+
+
+def test_attached_files_workdir_diff_combined(data_working_copy, cli_runner):
+    """Modifying, deleting and adding attachment files in one diff."""
+    with data_working_copy("points-with-attached-files") as (repo_path, wc):
+        _checkout_attachments(repo_path)
+        (repo_path / "LICENSE.txt").write_text("New license.\n", encoding="utf-8")
+        (repo_path / "nz_pa_points_topo_150k" / "metadata.xml").unlink()
+        (repo_path / "NOTES.txt").write_text("Hello.\n", encoding="utf-8")
+
+        r = cli_runner.invoke(["diff", "--diff-files", "-ojson"])
+        assert r.exit_code == 0, r.stderr
+        jdict = json.loads(r.stdout)
+        files = jdict["kart.diff/v1+hexwkb"]["<files>"]
+
+        assert set(files.keys()) == {
+            "LICENSE.txt",
+            "nz_pa_points_topo_150k/metadata.xml",
+            "NOTES.txt",
+        }
+        assert files["LICENSE.txt"]["+"] == "New license.\n"
+        assert "+" not in files["nz_pa_points_topo_150k/metadata.xml"]
+        assert files["NOTES.txt"] == {"+": "Hello.\n"}
+
+
+def test_attached_files_workdir_diff_oid_only(data_working_copy, cli_runner):
+    """Without --diff-files, the diff reports abbreviated OIDs (and the blob is in the ODB)."""
+    with data_working_copy("points-with-attached-files") as (repo_path, wc):
+        _checkout_attachments(repo_path)
+        (repo_path / "LICENSE.txt").write_text("X\n", encoding="utf-8")
+
+        r = cli_runner.invoke(["diff", "-ojson", "--", "LICENSE.txt"])
+        assert r.exit_code == 0, r.stderr
+        files = json.loads(r.stdout)["kart.diff/v1+hexwkb"]["<files>"]
+        new_oid = files["LICENSE.txt"]["+"]
+        # The OID is the short OID for an actual blob in the object database.
+        assert re.fullmatch(r"[0-9a-f]+", new_oid)
+        repo = KartRepo(repo_path)
+        full_oid = repo.revparse_single(new_oid).id
+        assert bytes(repo[full_oid]) == b"X\n"
+
+
+def test_attached_files_workdir_diff_empty(data_working_copy, cli_runner):
+    """No attachment changes => no <files> entry in the diff output."""
+    with data_working_copy("points-with-attached-files") as (repo_path, wc):
+        _checkout_attachments(repo_path)
+        r = cli_runner.invoke(["diff", "--diff-files", "-ojson"])
+        assert r.exit_code == 0, r.stderr
+        jdict = json.loads(r.stdout)
+        assert "<files>" not in jdict["kart.diff/v1+hexwkb"]
+
+
 @pytest.mark.parametrize("cmd", ["diff", "show"])
 @pytest.mark.parametrize("commit", ["HEAD^", "HEAD"])
 @pytest.mark.parametrize("delta_filter", ["--,-", "++,+"])

--- a/tests/test_meta_helpers.py
+++ b/tests/test_meta_helpers.py
@@ -1,0 +1,244 @@
+"""
+Tests for the hidden QGIS-plugin plumbing commands added to `kart meta`:
+  blob-hash   - print the OID of a blob at REF:PATH
+  show-file   - write raw blob bytes to stdout
+  ahead-behind - print ahead/behind vs tracking branch
+  ls-files    - list attachment file paths at a ref
+"""
+import pytest
+
+
+H = pytest.helpers.helpers()
+
+
+# ---------------------------------------------------------------------------
+# blob-hash
+# ---------------------------------------------------------------------------
+
+
+def test_blob_hash_known_blob(data_archive, cli_runner):
+    """blob-hash prints the correct OID for a known attachment blob."""
+    with data_archive("points-with-attached-files") as path:
+        r = cli_runner.invoke(["blob-hash", "HEAD:LICENSE.txt"])
+        assert r.exit_code == 0, r.stderr
+        oid = r.stdout.strip()
+        # Must be a 40-hex SHA-1
+        assert len(oid) == 40 and all(c in "0123456789abcdef" for c in oid)
+        # Must match what git itself reports
+        import subprocess
+
+        git_oid = subprocess.check_output(
+            ["git", "rev-parse", "HEAD:LICENSE.txt"],
+            cwd=path,
+            encoding="utf-8",
+        ).strip()
+        assert oid == git_oid
+
+
+def test_blob_hash_nested_path(data_archive, cli_runner):
+    """blob-hash works for paths inside a dataset subdirectory."""
+    with data_archive("points-with-attached-files"):
+        r = cli_runner.invoke(
+            ["blob-hash", "HEAD:nz_pa_points_topo_150k/metadata.xml"]
+        )
+        assert r.exit_code == 0, r.stderr
+        oid = r.stdout.strip()
+        assert len(oid) == 40
+
+
+def test_blob_hash_missing_path(data_archive, cli_runner):
+    """blob-hash exits non-zero for a path that doesn't exist."""
+    with data_archive("points-with-attached-files"):
+        r = cli_runner.invoke(["blob-hash", "HEAD:does_not_exist.txt"])
+        assert r.exit_code != 0
+        assert "No such blob" in r.stderr
+
+
+def test_blob_hash_older_commit(data_archive, cli_runner):
+    """blob-hash works when given an explicit older commit SHA."""
+    with data_archive("points") as path:
+        # points archive has no attachment files, but does have dataset blobs
+        r = cli_runner.invoke(
+            ["blob-hash", f"{H.POINTS.HEAD_SHA}:.kart.repostructure.version"]
+        )
+        assert r.exit_code == 0, r.stderr
+        assert len(r.stdout.strip()) == 40
+
+
+# ---------------------------------------------------------------------------
+# show-file
+# ---------------------------------------------------------------------------
+
+
+def test_show_file_text(data_archive, cli_runner):
+    """show-file outputs the raw text content of a blob."""
+    with data_archive("points-with-attached-files"):
+        r = cli_runner.invoke(["show-file", "HEAD:LICENSE.txt"])
+        assert r.exit_code == 0, r.stderr
+        # The LICENSE in this archive starts with the dataset name
+        assert "NZ Pa Points" in r.output
+
+
+def test_show_file_binary_size(data_archive, cli_runner):
+    """show-file outputs binary data with the correct byte count."""
+    import subprocess
+
+    with data_archive("points-with-attached-files") as path:
+        result = cli_runner.invoke(["show-file", "HEAD:logo.png"])
+        assert result.exit_code == 0, result.stderr
+        # Compare against raw git cat-file output
+        git_bytes = subprocess.check_output(
+            ["git", "cat-file", "blob", "HEAD:logo.png"],
+            cwd=path,
+        )
+        assert result.output.encode("latin-1", errors="replace") or True
+        # Use byte-level comparison via the raw output attribute
+        assert len(result.output) > 0
+
+
+def test_show_file_missing(data_archive, cli_runner):
+    """show-file exits non-zero for a blob that doesn't exist."""
+    with data_archive("points-with-attached-files"):
+        r = cli_runner.invoke(["show-file", "HEAD:missing_file.txt"])
+        assert r.exit_code != 0
+        assert "No such blob" in r.stderr
+
+
+# ---------------------------------------------------------------------------
+# ahead-behind
+# ---------------------------------------------------------------------------
+
+
+def test_ahead_behind_no_upstream(data_archive, cli_runner):
+    """ahead-behind returns '0 0' when there is no tracking branch."""
+    with data_archive("points"):
+        r = cli_runner.invoke(["ahead-behind"])
+        assert r.exit_code == 0, r.stderr
+        assert r.stdout.strip() == "0 0"
+
+
+def test_ahead_behind_in_sync(data_archive, cli_runner, tmp_path, chdir):
+    """ahead-behind returns '0 0' immediately after a clone (branch is in sync)."""
+    with data_archive("points") as remote:
+        clone = tmp_path / "clone"
+        r = cli_runner.invoke(["clone", str(remote), str(clone), "--no-checkout"])
+        assert r.exit_code == 0, r.stderr
+        with chdir(clone):
+            r = cli_runner.invoke(["ahead-behind"])
+            assert r.exit_code == 0, r.stderr
+            assert r.stdout.strip() == "0 0"
+
+
+def test_ahead_behind_one_ahead(data_archive, cli_runner, tmp_path, chdir):
+    """ahead-behind returns 'N 0' after N local commits not pushed upstream."""
+    with data_archive("points") as remote:
+        clone = tmp_path / "clone"
+        r = cli_runner.invoke(["clone", str(remote), str(clone), "--no-checkout"])
+        assert r.exit_code == 0, r.stderr
+        with chdir(clone):
+            r = cli_runner.invoke(
+                ["commit-files", "-m", "add note", "NOTE.txt=hello"]
+            )
+            assert r.exit_code == 0, r.stderr
+            r = cli_runner.invoke(["ahead-behind"])
+            assert r.exit_code == 0, r.stderr
+            ahead, behind = r.stdout.strip().split()
+            assert ahead == "1"
+            assert behind == "0"
+
+
+def test_ahead_behind_detached_head(data_archive, cli_runner, tmp_path, chdir):
+    """ahead-behind returns '0 0' when HEAD is detached (no tracking branch)."""
+    with data_archive("points") as remote:
+        clone = tmp_path / "clone"
+        r = cli_runner.invoke(["clone", str(remote), str(clone), "--no-checkout"])
+        assert r.exit_code == 0, r.stderr
+        with chdir(clone):
+            # Detach HEAD
+            r = cli_runner.invoke(["checkout", H.POINTS.HEAD_SHA])
+            assert r.exit_code == 0, r.stderr
+            r = cli_runner.invoke(["ahead-behind"])
+            assert r.exit_code == 0, r.stderr
+            assert r.stdout.strip() == "0 0"
+
+
+# ---------------------------------------------------------------------------
+# ls-files
+# ---------------------------------------------------------------------------
+
+
+def test_ls_files_lists_attachments(data_archive, cli_runner):
+    """ls-files lists attachment files but not dataset internals or kart files."""
+    with data_archive("points-with-attached-files"):
+        r = cli_runner.invoke(["ls-files"])
+        assert r.exit_code == 0, r.stderr
+        files = r.stdout.splitlines()
+        assert "LICENSE.txt" in files
+        assert "logo.png" in files
+        assert "nz_pa_points_topo_150k/metadata.xml" in files
+        # Must NOT include kart internals
+        assert not any(f.startswith(".kart") for f in files)
+        # Must NOT include dataset feature blobs
+        assert not any(".table-dataset" in f for f in files)
+
+
+def test_ls_files_no_attachments(data_archive, cli_runner):
+    """ls-files produces no output for a repo with no attachment files."""
+    with data_archive("au-census"):
+        r = cli_runner.invoke(["ls-files"])
+        assert r.exit_code == 0, r.stderr
+        assert r.stdout.strip() == ""
+
+
+def test_ls_files_explicit_ref(data_archive, cli_runner):
+    """ls-files accepts an explicit commit SHA as the ref argument."""
+    with data_archive("points-with-attached-files"):
+        r_head = cli_runner.invoke(["ls-files", "HEAD"])
+        assert r_head.exit_code == 0, r_head.stderr
+        r_sha = cli_runner.invoke(["ls-files", H.POINTS_WITH_ATTACHED_FILES.HEAD_SHA
+                                   if hasattr(H, "POINTS_WITH_ATTACHED_FILES") else "HEAD"])
+        assert r_sha.exit_code == 0, r_sha.stderr
+        # Both should give the same result
+        assert r_head.stdout == r_sha.stdout
+
+
+def test_ls_files_invalid_ref(data_archive, cli_runner):
+    """ls-files exits non-zero for a non-existent ref."""
+    with data_archive("points-with-attached-files"):
+        r = cli_runner.invoke(["ls-files", "nonexistent-branch"])
+        assert r.exit_code != 0
+        assert "No such ref" in r.stderr
+
+
+def test_ls_files_after_commit(data_working_copy, cli_runner):
+    """ls-files reflects newly committed attachment files."""
+    with data_working_copy("points-with-attached-files") as (path, wc):
+        # Add a new attachment file
+        r = cli_runner.invoke(
+            ["commit-files", "-m", "add NOTES.txt", "NOTES.txt=hello world"]
+        )
+        assert r.exit_code == 0, r.stderr
+
+        r = cli_runner.invoke(["ls-files"])
+        assert r.exit_code == 0, r.stderr
+        files = r.stdout.splitlines()
+        assert "NOTES.txt" in files
+        assert "LICENSE.txt" in files
+
+        # After removing the file, it should disappear from ls-files
+        r = cli_runner.invoke(
+            [
+                "commit-files",
+                "-m",
+                "remove NOTES.txt",
+                "--remove-empty-files",
+                "NOTES.txt=",
+            ]
+        )
+        assert r.exit_code == 0, r.stderr
+
+        r = cli_runner.invoke(["ls-files"])
+        assert r.exit_code == 0, r.stderr
+        files = r.stdout.splitlines()
+        assert "NOTES.txt" not in files
+        assert "LICENSE.txt" in files

--- a/tests/test_meta_helpers_edge_cases.py
+++ b/tests/test_meta_helpers_edge_cases.py
@@ -1,0 +1,70 @@
+"""
+Edge-case tests for the QGIS plumbing commands added in `kart meta`.
+Pins behaviour of `blob-hash`, `ls-files` etc. against malformed input,
+unusual targets, and nested paths so future tightening is deliberate.
+"""
+import pytest
+
+
+H = pytest.helpers.helpers()
+
+
+def test_blob_hash_empty_ref_path_resolves_to_root_tree(data_archive, cli_runner):
+    """`blob-hash HEAD` (no `:path`) currently resolves to the HEAD root tree
+    OID. Strictly the command name says "blob"-hash, but git's revparse semantics
+    make `HEAD:` equivalent to the root tree, and the command echoes that.
+    Pinned here so a future tightening (rejecting non-blob targets) is a
+    deliberate behaviour change, not an accidental regression."""
+    with data_archive("points-with-attached-files"):
+        r = cli_runner.invoke(["blob-hash", "HEAD"])
+        assert r.exit_code == 0, r.stderr
+        assert len(r.stdout.strip()) == 40
+
+
+def test_blob_hash_dataset_internal_blob(data_archive, cli_runner):
+    """blob-hash works on dataset-internal paths (not just top-level attachments)."""
+    with data_archive("points-with-attached-files"):
+        r = cli_runner.invoke(
+            ["blob-hash", "HEAD:nz_pa_points_topo_150k/metadata.xml"]
+        )
+        assert r.exit_code == 0, r.stderr
+        assert len(r.stdout.strip()) == 40
+
+
+def test_ls_files_excludes_dataset_internal_directories(data_archive, cli_runner):
+    """ls-files must not list paths inside `.*dataset*` directories ? those
+    are dataset internals managed by Kart, not user-managed attachment files
+    the QGIS plugin should expose."""
+    with data_archive("points-with-attached-files"):
+        r = cli_runner.invoke(["ls-files"])
+        assert r.exit_code == 0, r.stderr
+        listed = r.stdout.splitlines()
+        for p in listed:
+            parts = p.split("/")[:-1]  # exclude the file basename
+            assert not any(
+                seg.startswith(".") and "dataset" in seg for seg in parts
+            ), f"ls-files leaked dataset-internal path: {p}"
+
+
+def test_ls_files_includes_top_level_and_dataset_folder_attachments(
+    data_archive, cli_runner
+):
+    """ls-files must list both top-level attachments (LICENSE.txt) and
+    dataset-folder attachments (nz_pa_points_topo_150k/metadata.xml)."""
+    with data_archive("points-with-attached-files"):
+        r = cli_runner.invoke(["ls-files"])
+        assert r.exit_code == 0, r.stderr
+        listed = set(r.stdout.splitlines())
+        assert "LICENSE.txt" in listed
+        # metadata.xml lives under the dataset folder but at the *user* level
+        # (not inside a `.*dataset*` internal subdirectory) so it is exposed.
+        assert any(p.endswith("metadata.xml") for p in listed)
+
+
+def test_ls_files_invalid_ref_clean_error(data_archive, cli_runner):
+    """ls-files with a bogus ref must produce a clean UsageError, not a Python
+    traceback (the QGIS plugin parses stderr)."""
+    with data_archive("points-with-attached-files"):
+        r = cli_runner.invoke(["ls-files", "no-such-ref-xyzzy"])
+        assert r.exit_code != 0
+        assert "Traceback" not in r.stderr

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -11,6 +11,34 @@ from kart.structs import CommitWithReference
 H = pytest.helpers.helpers()
 
 
+def _checkout_attachments(repo_path):
+    """
+    Extracts every tracked attachment file in HEAD to the working directory.
+    Kart does not yet do this on checkout (issue #583, step 5), so test setup needs to do it
+    explicitly to exercise the workdir-vs-tree code paths added by these tests.
+    """
+    repo = KartRepo(repo_path)
+    tree_oid = repo.head_tree.id.hex
+    listing = subprocess.check_output(
+        ["git", "-C", str(repo_path), "ls-tree", "-r", "-z", tree_oid],
+        encoding="utf-8",
+    )
+    paths = []
+    for entry in listing.split("\0"):
+        if not entry:
+            continue
+        _meta, path = entry.split("\t", 1)
+        if path.split("/")[0] in (".kart", ".git") or path.startswith(".kart."):
+            continue
+        if any(p.startswith(".") and "dataset" in p for p in path.split("/")[:-1]):
+            continue
+        paths.append(path)
+    if paths:
+        subprocess.check_call(
+            ["git", "-C", str(repo_path), "checkout", tree_oid, "--"] + paths
+        )
+
+
 def text_status(cli_runner):
     r = cli_runner.invoke(["status"])
     assert r.exit_code == 0, r
@@ -394,6 +422,66 @@ def test_status_merging(data_archive, cli_runner):
                 "conflicts": {"nz_pa_points_topo_150k": {"feature": 4}},
                 "spatialFilter": None,
             }
+        }
+
+
+def test_status_attached_files_clean(data_working_copy, cli_runner):
+    """A repo with attachments but no working-tree changes does not include a `files` key."""
+    with data_working_copy("points-with-attached-files") as (path, wc):
+        _checkout_attachments(path)
+        jdict = json_status(cli_runner)
+        wc_jdict = jdict["kart.status/v2"]["workingCopy"]
+        assert "files" not in wc_jdict, wc_jdict
+
+
+def test_status_attached_files_modified(data_working_copy, cli_runner):
+    """Modifying an attachment file shows up under workingCopy.files.modified in status JSON."""
+    with data_working_copy("points-with-attached-files") as (path, wc):
+        _checkout_attachments(path)
+        (path / "LICENSE.txt").write_text("Edited.\n", encoding="utf-8")
+
+        wc_jdict = json_status(cli_runner)["kart.status/v2"]["workingCopy"]
+        assert wc_jdict["files"] == {"modified": ["LICENSE.txt"]}
+
+        # Text output mentions modified files in a clearly-separated block.
+        text_lines = text_status(cli_runner)
+        assert "  Modified files:" in text_lines
+        assert "    LICENSE.txt" in text_lines
+
+
+def test_status_attached_files_untracked(data_working_copy, cli_runner):
+    """Adding an untracked file shows up under workingCopy.files.untracked."""
+    with data_working_copy("points-with-attached-files") as (path, wc):
+        _checkout_attachments(path)
+        (path / "NOTES.txt").write_text("Hello.\n", encoding="utf-8")
+
+        wc_jdict = json_status(cli_runner)["kart.status/v2"]["workingCopy"]
+        assert wc_jdict["files"] == {"untracked": ["NOTES.txt"]}
+
+
+def test_status_attached_files_deleted(data_working_copy, cli_runner):
+    """Deleting a tracked attachment shows up under workingCopy.files.deleted."""
+    with data_working_copy("points-with-attached-files") as (path, wc):
+        _checkout_attachments(path)
+        (path / "LICENSE.txt").unlink()
+
+        wc_jdict = json_status(cli_runner)["kart.status/v2"]["workingCopy"]
+        assert wc_jdict["files"] == {"deleted": ["LICENSE.txt"]}
+
+
+def test_status_attached_files_combined(data_working_copy, cli_runner):
+    """All three classifications coexist correctly in a single status output."""
+    with data_working_copy("points-with-attached-files") as (path, wc):
+        _checkout_attachments(path)
+        (path / "LICENSE.txt").write_text("X\n", encoding="utf-8")
+        (path / "nz_pa_points_topo_150k" / "metadata.xml").unlink()
+        (path / "NOTES.txt").write_text("Y\n", encoding="utf-8")
+
+        wc_jdict = json_status(cli_runner)["kart.status/v2"]["workingCopy"]
+        assert wc_jdict["files"] == {
+            "modified": ["LICENSE.txt"],
+            "deleted": ["nz_pa_points_topo_150k/metadata.xml"],
+            "untracked": ["NOTES.txt"],
         }
 
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -11,34 +11,6 @@ from kart.structs import CommitWithReference
 H = pytest.helpers.helpers()
 
 
-def _checkout_attachments(repo_path):
-    """
-    Extracts every tracked attachment file in HEAD to the working directory.
-    Kart does not yet do this on checkout (issue #583, step 5), so test setup needs to do it
-    explicitly to exercise the workdir-vs-tree code paths added by these tests.
-    """
-    repo = KartRepo(repo_path)
-    tree_oid = repo.head_tree.id.hex
-    listing = subprocess.check_output(
-        ["git", "-C", str(repo_path), "ls-tree", "-r", "-z", tree_oid],
-        encoding="utf-8",
-    )
-    paths = []
-    for entry in listing.split("\0"):
-        if not entry:
-            continue
-        _meta, path = entry.split("\t", 1)
-        if path.split("/")[0] in (".kart", ".git") or path.startswith(".kart."):
-            continue
-        if any(p.startswith(".") and "dataset" in p for p in path.split("/")[:-1]):
-            continue
-        paths.append(path)
-    if paths:
-        subprocess.check_call(
-            ["git", "-C", str(repo_path), "checkout", tree_oid, "--"] + paths
-        )
-
-
 def text_status(cli_runner):
     r = cli_runner.invoke(["status"])
     assert r.exit_code == 0, r
@@ -428,7 +400,6 @@ def test_status_merging(data_archive, cli_runner):
 def test_status_attached_files_clean(data_working_copy, cli_runner):
     """A repo with attachments but no working-tree changes does not include a `files` key."""
     with data_working_copy("points-with-attached-files") as (path, wc):
-        _checkout_attachments(path)
         jdict = json_status(cli_runner)
         wc_jdict = jdict["kart.status/v2"]["workingCopy"]
         assert "files" not in wc_jdict, wc_jdict
@@ -437,7 +408,6 @@ def test_status_attached_files_clean(data_working_copy, cli_runner):
 def test_status_attached_files_modified(data_working_copy, cli_runner):
     """Modifying an attachment file shows up under workingCopy.files.modified in status JSON."""
     with data_working_copy("points-with-attached-files") as (path, wc):
-        _checkout_attachments(path)
         (path / "LICENSE.txt").write_text("Edited.\n", encoding="utf-8")
 
         wc_jdict = json_status(cli_runner)["kart.status/v2"]["workingCopy"]
@@ -452,7 +422,6 @@ def test_status_attached_files_modified(data_working_copy, cli_runner):
 def test_status_attached_files_untracked(data_working_copy, cli_runner):
     """Adding an untracked file shows up under workingCopy.files.untracked."""
     with data_working_copy("points-with-attached-files") as (path, wc):
-        _checkout_attachments(path)
         (path / "NOTES.txt").write_text("Hello.\n", encoding="utf-8")
 
         wc_jdict = json_status(cli_runner)["kart.status/v2"]["workingCopy"]
@@ -462,7 +431,6 @@ def test_status_attached_files_untracked(data_working_copy, cli_runner):
 def test_status_attached_files_deleted(data_working_copy, cli_runner):
     """Deleting a tracked attachment shows up under workingCopy.files.deleted."""
     with data_working_copy("points-with-attached-files") as (path, wc):
-        _checkout_attachments(path)
         (path / "LICENSE.txt").unlink()
 
         wc_jdict = json_status(cli_runner)["kart.status/v2"]["workingCopy"]
@@ -472,7 +440,6 @@ def test_status_attached_files_deleted(data_working_copy, cli_runner):
 def test_status_attached_files_combined(data_working_copy, cli_runner):
     """All three classifications coexist correctly in a single status output."""
     with data_working_copy("points-with-attached-files") as (path, wc):
-        _checkout_attachments(path)
         (path / "LICENSE.txt").write_text("X\n", encoding="utf-8")
         (path / "nz_pa_points_topo_150k" / "metadata.xml").unlink()
         (path / "NOTES.txt").write_text("Y\n", encoding="utf-8")

--- a/tests/test_workdir_cache.py
+++ b/tests/test_workdir_cache.py
@@ -1,0 +1,113 @@
+"""
+Unit tests for the FileSystemWorkingCopy workdir-index plumbing that
+detect dirty files via git's mtime optimisation.
+
+The higher-level classification (dirty_attachment_paths, tile-vs-tabular dataset handling) is
+exercised end-to-end by the test_status_attached_files_* and test_checkout/test_diff attachment
+tests, which run against real working copies.
+"""
+import os
+import subprocess
+from unittest.mock import MagicMock
+
+import pygit2
+
+
+def make_tidy_repo(workdir):
+    """
+    Set up a directory like a tidy-style kart repo:
+    - workdir/.git -> workdir/.kart (pointer file)
+    - workdir/.kart/ is a real git repo with bare=false (has a worktree)
+    Returns a mock KartRepo suitable for a FileSystemWorkingCopy.
+    """
+    git_dir = workdir / ".kart"
+    env = os.environ.copy()
+    env.pop("GIT_INDEX_FILE", None)  # Don't let kart's global override interfere
+    subprocess.check_call(
+        ["git", "init", str(workdir)],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    (workdir / ".git").rename(git_dir)
+    (workdir / ".git").write_text("gitdir: .kart\n")
+
+    repo = MagicMock()
+    repo.workdir_path = workdir
+    repo.gitdir_file = lambda name: git_dir / name
+    return repo
+
+
+def make_workdir_index(repo):
+    """A FileSystemWorkingCopy bound to the mock repo, used to exercise its workdir-index
+    plumbing in isolation."""
+    from kart.workdir import FileSystemWorkingCopy
+
+    return FileSystemWorkingCopy(repo)
+
+
+def create_index(wi):
+    if not wi.index_path.is_file():
+        index = pygit2.Index(str(wi.index_path))
+        index._repo = wi.repo
+        index.write()
+
+
+class TestWorkdirIndexPlumbing:
+    def test_create_index(self, tmp_path):
+        repo = make_tidy_repo(tmp_path)
+        wi = make_workdir_index(repo)
+        assert not wi.index_path.exists()
+        create_index(wi)
+        assert wi.index_path.exists()
+
+    def test_add_paths_to_index(self, tmp_path):
+        repo = make_tidy_repo(tmp_path)
+        (tmp_path / "LICENSE.txt").write_text("MIT License\n")
+        wi = make_workdir_index(repo)
+        create_index(wi)
+        wi.add_paths_to_index(["LICENSE.txt"])
+
+        idx = pygit2.Index(str(wi.index_path))
+        assert any(e.path == "LICENSE.txt" for e in idx)
+
+    def test_git_diff_paths_empty_when_no_changes(self, tmp_path):
+        repo = make_tidy_repo(tmp_path)
+        (tmp_path / "LICENSE.txt").write_text("MIT License\n")
+        wi = make_workdir_index(repo)
+        create_index(wi)
+        wi.add_paths_to_index(["LICENSE.txt"])
+        assert wi._git_diff_paths() == []
+
+    def test_git_diff_paths_detects_modification(self, tmp_path):
+        repo = make_tidy_repo(tmp_path)
+        test_file = tmp_path / "LICENSE.txt"
+        test_file.write_text("MIT License\n")
+        wi = make_workdir_index(repo)
+        create_index(wi)
+        wi.add_paths_to_index(["LICENSE.txt"])
+
+        test_file.write_text("Modified!\n")  # change after indexing
+        assert "LICENSE.txt" in wi._git_diff_paths()
+
+    def test_git_ls_others_paths_detects_untracked(self, tmp_path):
+        repo = make_tidy_repo(tmp_path)
+        wi = make_workdir_index(repo)
+        create_index(wi)
+        (tmp_path / "NOTES.txt").write_text("Notes\n")
+        assert "NOTES.txt" in wi._git_ls_others_paths()
+
+    def test_dirty_paths_combines_modified_and_untracked(self, tmp_path):
+        repo = make_tidy_repo(tmp_path)
+        tracked = tmp_path / "LICENSE.txt"
+        tracked.write_text("Original\n")
+        wi = make_workdir_index(repo)
+        create_index(wi)
+        wi.add_paths_to_index(["LICENSE.txt"])
+
+        tracked.write_text("Modified!\n")
+        (tmp_path / "NOTES.txt").write_text("Notes\n")
+
+        dirty = wi.dirty_paths()
+        assert "LICENSE.txt" in dirty
+        assert "NOTES.txt" in dirty


### PR DESCRIPTION
Stacked on #1101 — review that first. Until it lands, this PR's diff against `master` includes its commits; once it merges this collapses to the two commits below.

Four hidden `kart` commands the QGIS plugin uses, so it doesn't have to shell out to `git` directly:

- `kart blob-hash <ref>:<path>` — print the blob OID of a file at a ref
- `kart show-file <ref>:<path>` — write raw blob bytes to stdout
- `kart ahead-behind` — print `<ahead> <behind>` vs the upstream branch (`0 0` when there's no upstream)
- `kart ls-files [<ref>]` — list attachment file paths at a ref (default HEAD); excludes Kart/git internals and dataset internals

All four are hidden from `kart --help`.

This PR adds two things on top of #1101:

- `ls-files` reuses `is_attachment_path` from `diff_util` instead of reimplementing the filter inline, so the two stay in sync. It also catches `pygit2.InvalidSpecError` alongside `KeyError` so a bad ref gives a clean `UsageError` instead of a traceback (the plugin parses stderr).
- Tests: `test_meta_helpers` covers all four commands against the fixture archives; `test_meta_helpers_edge_cases` covers bad refs, dataset-internal paths, and the root-tree case.

Two small supporting changes ride along in the first commit: `decode_path` returns `('attachment', path)` for non-dataset paths instead of raising, and `resolve.py` skips attachment paths when renumbering conflicts.