### PR TITLE
support git bundle-uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - import: `--replace-existing` now preserves attachments (files at the dataset root level, such as licenses or READMEs) instead of deleting them along with the dataset data. [#1083](https://github.com/koordinates/kart/pull/1083)
 - Fixes the HTML diff viewer (`-o html`) failing to load the page if the data contained `<`, `>`, or `/` characters. [#1081](https://github.com/koordinates/kart/issues/1081)
 - Adds support for an env-var flag `KART_ALLOW_FROM_GIT=1` that turns off the safe-guard that stops Kart from running on what appear to be Git repositories. [#1100](https://github.com/koordinates/kart/pull/1100)
+- Adds support for cloning from git bundles to speed up initial clones of large repositories [#1106](https://github.com/koordinates/kart/pull/1106)
 
 ## 0.17.0
 

--- a/kart/clone.py
+++ b/kart/clone.py
@@ -115,6 +115,10 @@ def get_directory_from_url(url, is_bare):
         "may be necessary if the remote doesn't support spatially filtered clones."
     ),
 )
+@click.option(
+    "--bundle-uri",
+    help="Before fetching from the remote, fetch a bundle from the given <uri> and unbundle the data into the local repository.",
+)
 @click.argument("url", nargs=1)
 @click.argument(
     "directory",
@@ -132,6 +136,7 @@ def clone(
     branch,
     spatial_filter_spec,
     spatial_filter_after_clone,
+    bundle_uri,
     url,
     directory,
 ):
@@ -158,6 +163,8 @@ def clone(
         # for the various forms it can take, see
         # https://git-scm.com/docs/git-rev-list#Documentation/git-rev-list.txt---filterltfilter-specgt
         args.append(f"--filter={filterspec}")
+    if bundle_uri is not None:
+        args.append(f"--bundle-uri={bundle_uri}")
 
     repo = KartRepo.clone_repository(
         url,


### PR DESCRIPTION
## Description

git bundles are a way of storing a full copy of a repository as a single file, they can be used to speed up initial clones of repositories, especially in networks where access to the source kart repository is slow but access to a internal bundle store is very fast.


```shell
$ kart clone --no-checkout kart@data.koordinates.com:linz/nz-building-outlines
```
approx 4-5 minutes

```shell
$ kart clone --no-checkout --bundle-uri=https://d1jzh93b1t1cv.cloudfront.net/source/nz-building-outlines.bundle kart@data.koordinates.com:linz/nz-building-outlines
```
< 1 minute (I saw as fast as ~30 seconds when using 10gbps connection to the store)

Bundles can be created with 

```shell
kart git bundle create ./nz-building-outlines.bundle --all
```

## Related links:

<!-- If you have links to [issues](https://github.com/koordinates/kart/issues) etc, link them here. -->

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
