### PR TITLE
Exclude dev-only deps from PyInstaller bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Fixes the HTML diff viewer (`-o html`) failing to load the page if the data contained `<`, `>`, or `/` characters. [#1081](https://github.com/koordinates/kart/issues/1081)
 - Adds support for an env-var flag `KART_ALLOW_FROM_GIT=1` that turns off the safe-guard that stops Kart from running on what appear to be Git repositories. [#1100](https://github.com/koordinates/kart/pull/1100)
 - Adds support for cloning from git bundles to speed up initial clones of large repositories [#1106](https://github.com/koordinates/kart/pull/1106)
+- Removes dev/test-only Python packages (IPython, pytest, etc.) that were being included in release bundles, slightly reducing bundle size. [#1108](https://github.com/koordinates/kart/pull/1108)
 
 ## 0.17.0
 

--- a/kart.spec
+++ b/kart.spec
@@ -186,6 +186,19 @@ pyi_analysis = Analysis(
     runtime_hooks=[],
     excludes=[
         "_kart_env",
+        # ipdb is imported by kart.cli_util for `--post-mortem`, but only installed
+        # in dev venvs (it falls back to stdlib pdb in releases). PyInstaller follows
+        # the static import anyway, dragging in IPython -> pexpect/ptyprocess and
+        # -> executing -> pytest -> pluggy/py/iniconfig. Excluding it (and IPython)
+        # prunes that whole dev-only subtree.
+        "ipdb",
+        "IPython",
+        # SQLAlchemy's test suite, dragged in by collect_submodules('sqlalchemy').
+        # It does `import pytest`, cascading dev/test modules into the bundle.
+        "sqlalchemy.testing",
+        # SQLAlchemy's mypy plugin (dev tooling); dragged in by
+        # collect_submodules('sqlalchemy') and does `import mypy`.
+        "sqlalchemy.ext.mypy",
     ],
     win_no_prefer_redirects=False,
     win_private_assemblies=False,
@@ -197,38 +210,6 @@ if is_linux or is_darwin:
     pyi_analysis.exclude_system_libraries(
         list_of_exceptions=['libffi*', 'libreadline*']
     )
-
-# Post-process to remove dev/test dependencies and their submodules
-# The excludes list only handles top-level imports, this catches submodules too
-DEV_TEST_PREFIXES = (
-    'pytest', '_pytest',  # pytest and internal modules
-    'coverage',
-    'IPython',
-    'ipdb',
-    'mypy', 'mypyc',
-    'sphinx', 'sphinxcontrib',
-    'html5lib',
-    'execnet',
-    'aspectlib',
-    'sqlalchemy_stubs',
-    'types_',  # All type stub packages
-    'gprof2dot',
-)
-
-def should_exclude_module(module_name):
-    """Check if a module is a dev/test dependency that should be excluded."""
-    return module_name.startswith(DEV_TEST_PREFIXES)
-
-print(f"🔍 Filtering dev/test dependencies from PyInstaller bundle...", file=sys.stderr)
-original_pure_count = len(pyi_analysis.pure)
-original_binaries_count = len(pyi_analysis.binaries)
-
-pyi_analysis.pure = [item for item in pyi_analysis.pure if not should_exclude_module(item[0])]
-pyi_analysis.binaries = [item for item in pyi_analysis.binaries if not should_exclude_module(item[0])]
-
-removed_pure = original_pure_count - len(pyi_analysis.pure)
-removed_binaries = original_binaries_count - len(pyi_analysis.binaries)
-print(f"✂️  Removed {removed_pure} pure modules and {removed_binaries} binaries", file=sys.stderr)
 
 pyi_pyz = PYZ(pyi_analysis.pure, pyi_analysis.zipped_data, cipher=None)
 


### PR DESCRIPTION
## What & why

The release bundle was shipping dev/test-only Python packages. The existing `DEV_TEST_PREFIXES` post-filter in `kart.spec` removed dev packages *by name* but left their unique transitive deps orphaned in the bundle (`pexpect`, `ptyprocess`, `pluggy`, `py`, `iniconfig`).

The main vector: `kart/cli_util.py` does a guarded `import ipdb` for `--post-mortem`. It's only installed in dev venvs (falls back to stdlib `pdb` in releases), but PyInstaller follows the static import anyway, dragging in `IPython` → `pexpect`/`ptyprocess` and `executing` → `pytest` → `pluggy`/`py`/`iniconfig`. SQLAlchemy's bundled `testing`/`ext.mypy` subpackages added more (`pytest`, `mypy`).

This replaces the leaky post-filter with `Analysis` `excludes`, which prune the whole unreachable subtree rather than just named modules.

## Result

- Shipped Python modules: **~1715 → 1353** (verified against `PYZ-00.toc`)
- All dev-only deps gone: pytest, _pytest, py, pluggy, iniconfig, pexpect, ptyprocess, executing, IPython, ipdb, mypy, sphinx
- SQLAlchemy core unaffected (203 modules); bundle runs (`--version`, `--help`, command dispatch verified)

## Risks involved

- [x] No notable risks

Packaging-only change. The excluded modules were never available at runtime in releases (ipdb is dev-only; `sqlalchemy.testing`/`ext.mypy` are dev tooling).

## Performance implications

Slightly smaller bundle. No runtime perf change.

## Deployment/migration

n/a