### PR TITLE
Build fix

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -46,7 +46,7 @@ jobs:
             arch_triplet: x64-linux
             build_parallel: ""
 
-          - base: buildjet-4vcpu-ubuntu-2204-arm
+          - base: ubuntu-22.04-arm
             label: manylinux_2_28/arm64
             image: quay.io/pypa/manylinux_2_28_aarch64
             arch: arm64
@@ -348,7 +348,7 @@ jobs:
           - label: amd64
             runner: ubuntu-22.04
           - label: arm64
-            runner: buildjet-2vcpu-ubuntu-2204-arm
+            runner: ubuntu-22.04-arm
         os:
           - label: "tgz-ubuntu-24.04"
             image: "public.ecr.aws/ubuntu/ubuntu:noble"

--- a/kart/__init__.py
+++ b/kart/__init__.py
@@ -175,7 +175,7 @@ try:
         from kart.diagnostics import print_diagnostics
 
         print_diagnostics()
-except (KeyError, pygit2.GitError, ImportError) as e:
+except Exception as e:
     # Silently ignore diagnostics errors - diagnostics are optional debug features
     # that shouldn't prevent Kart from starting
     L.debug(f"Could not print diagnostics: {e}")


### PR DESCRIPTION
## Description

- Switch the linux arm64 runner from buildjet to GH
- Don't let any exception during print_diagnostics cause kart startup to fail.
