### PR TITLE
CI: fix vcpkg binary caching (was never being saved)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -114,6 +114,9 @@ jobs:
         '-DPKG_CONFIG_EXECUTABLE=/__w/kart/kart/vcpkg-vendor/vcpkg/installed/${{ matrix.os.arch_triplet }}/tools/pkgconf/pkgconf',
         '-DCPACK_DEBIAN_PACKAGE_ARCHITECTURE=${{ matrix.os.arch }}'
         ]
+      # Cache vcpkg-built packages in the GitHub Actions cache. Job-level so it applies to
+      # the cmake configure step, where the vendor dependencies actually get built.
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
     container:
       image: ${{ matrix.os.image }}
@@ -173,18 +176,18 @@ jobs:
           echo "=========================="
 
 
-      - name: "setup: restore vcpkg cache"
-        uses: actions/cache/restore@v4
+      # vcpkg's x-gha backend needs the Actions cache endpoint + token, which are only
+      # exposed to actions (not run steps) - export them for the rest of the job.
+      - name: "setup: vcpkg binary cache env"
+        uses: actions/github-script@v7
         with:
-          path: ${{ github.workspace }}/vcpkg_cache
-          key: vcpkg-${{ matrix.os.arch_triplet }}-${{ hashFiles('vcpkg-vendor/vcpkg.json', '.git/modules/vcpkg-vendor/vcpkg/HEAD', 'vcpkg-vendor/vcpkg-overlay-*/**') }}
-          restore-keys: |
-            vcpkg-${{ matrix.os.arch_triplet }}-
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: "setup: vcpkg"
         uses: lukka/run-vcpkg@v11
-        env:
-          VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg_cache,readwrite"
         with:
           vcpkgDirectory: "${{ github.workspace }}/vcpkg-vendor/vcpkg"
           vcpkgJsonGlob: "**/vcpkg-vendor/vcpkg.json"
@@ -195,12 +198,6 @@ jobs:
         shell: bash
         run: |
           ${GITHUB_WORKSPACE}/vcpkg-vendor/vcpkg/vcpkg install pkgconf
-
-      - name: "setup: save vcpkg cache"
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ github.workspace }}/vcpkg_cache
-          key: vcpkg-${{ matrix.os.arch_triplet }}-${{ hashFiles('vcpkg-vendor/vcpkg.json', '.git/modules/vcpkg-vendor/vcpkg/HEAD', 'vcpkg-vendor/vcpkg-overlay-*/**') }}
 
       #
       # App Build

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -114,9 +114,9 @@ jobs:
         '-DPKG_CONFIG_EXECUTABLE=/__w/kart/kart/vcpkg-vendor/vcpkg/installed/${{ matrix.os.arch_triplet }}/tools/pkgconf/pkgconf',
         '-DCPACK_DEBIAN_PACKAGE_ARCHITECTURE=${{ matrix.os.arch }}'
         ]
-      # Cache vcpkg-built packages in the GitHub Actions cache. Job-level so it applies to
-      # the cmake configure step, where the vendor dependencies actually get built.
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+      # Cache vcpkg-built packages. Job-level so it applies to the cmake configure step,
+      # where the vendor dependencies actually get built.
+      VCPKG_BINARY_SOURCES: "clear;files,/__w/kart/kart/vcpkg_cache,readwrite"
 
     container:
       image: ${{ matrix.os.image }}
@@ -176,15 +176,15 @@ jobs:
           echo "=========================="
 
 
-      # vcpkg's x-gha backend needs the Actions cache endpoint + token, which are only
-      # exposed to actions (not run steps) - export them for the rest of the job.
-      - name: "setup: vcpkg binary cache env"
-        uses: actions/github-script@v7
+      - name: "setup: restore vcpkg cache"
+        uses: actions/cache/restore@v4
         with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+          # github.workspace evaluates to the host path in container jobs; use the
+          # container path (same workaround as the GITHUB_WORKSPACE env override above)
+          path: /__w/kart/kart/vcpkg_cache
+          key: vcpkg-${{ matrix.os.arch_triplet }}-${{ hashFiles('vcpkg-vendor/vcpkg.json', '.git/modules/vcpkg-vendor/vcpkg/HEAD', 'vcpkg-vendor/vcpkg-overlay-*/**') }}
+          restore-keys: |
+            vcpkg-${{ matrix.os.arch_triplet }}-
 
       - name: "setup: vcpkg"
         uses: lukka/run-vcpkg@v11
@@ -232,6 +232,17 @@ jobs:
         shell: bash
         run: |
           cmake --build --preset=ci-linux --verbose --parallel ${{ matrix.os.build_parallel }}
+
+      # if: always() so a failed build still saves whatever packages it got through -
+      # the next attempt resumes from there instead of starting cold.
+      - name: "setup: save vcpkg cache"
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          # github.workspace evaluates to the host path in container jobs; use the
+          # container path (same workaround as the GITHUB_WORKSPACE env override above)
+          path: /__w/kart/kart/vcpkg_cache
+          key: vcpkg-${{ matrix.os.arch_triplet }}-${{ hashFiles('vcpkg-vendor/vcpkg.json', '.git/modules/vcpkg-vendor/vcpkg/HEAD', 'vcpkg-vendor/vcpkg-overlay-*/**') }}
 
       - name: "vendor: save archive"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -94,9 +94,9 @@ jobs:
       MACOS_NOTARIZE_KEYCHAIN: "/Users/runner/Library/Keychains/signing_temp.keychain-db"
       # X.Y version needs to match PY_VER:
       PY_VER_INSTALLER: "https://www.python.org/ftp/python/3.12.10/python-3.12.10-macos11.pkg"
-      # Cache vcpkg-built packages in the GitHub Actions cache. Job-level so it applies to
-      # the cmake configure step, where the vendor dependencies actually get built.
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+      # Cache vcpkg-built packages. Job-level so it applies to the cmake configure step,
+      # where the vendor dependencies actually get built.
+      VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg_cache,readwrite"
 
     steps:
       - uses: actions/checkout@v4
@@ -160,15 +160,13 @@ jobs:
           mkdir -p ${{ env.CCACHE_DIR }}
           echo "$(brew --prefix)/opt/ccache/libexec" >> $GITHUB_PATH
 
-      # vcpkg's x-gha backend needs the Actions cache endpoint + token, which are only
-      # exposed to actions (not run steps) - export them for the rest of the job.
-      - name: "setup: vcpkg binary cache env"
-        uses: actions/github-script@v7
+      - name: "setup: restore vcpkg cache"
+        uses: actions/cache/restore@v4
         with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+          path: ${{ github.workspace }}/vcpkg_cache
+          key: vcpkg-${{ matrix.os.arch_triplet }}-${{ hashFiles('vcpkg-vendor/vcpkg.json', '.git/modules/vcpkg-vendor/vcpkg/HEAD', 'vcpkg-vendor/vcpkg-overlay-*/**') }}
+          restore-keys: |
+            vcpkg-${{ matrix.os.arch_triplet }}-
 
       - name: "setup: vcpkg"
         uses: lukka/run-vcpkg@v11
@@ -225,6 +223,15 @@ jobs:
         with:
           configurePreset: ci-macos
           buildPreset: ci-macos
+
+      # if: always() so a failed build still saves whatever packages it got through -
+      # the next attempt resumes from there instead of starting cold.
+      - name: "setup: save vcpkg cache"
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: ${{ github.workspace }}/vcpkg_cache
+          key: vcpkg-${{ matrix.os.arch_triplet }}-${{ hashFiles('vcpkg-vendor/vcpkg.json', '.git/modules/vcpkg-vendor/vcpkg/HEAD', 'vcpkg-vendor/vcpkg-overlay-*/**') }}
 
       - name: "vendor: save archive"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -94,6 +94,9 @@ jobs:
       MACOS_NOTARIZE_KEYCHAIN: "/Users/runner/Library/Keychains/signing_temp.keychain-db"
       # X.Y version needs to match PY_VER:
       PY_VER_INSTALLER: "https://www.python.org/ftp/python/3.12.10/python-3.12.10-macos11.pkg"
+      # Cache vcpkg-built packages in the GitHub Actions cache. Job-level so it applies to
+      # the cmake configure step, where the vendor dependencies actually get built.
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
     steps:
       - uses: actions/checkout@v4
@@ -157,18 +160,18 @@ jobs:
           mkdir -p ${{ env.CCACHE_DIR }}
           echo "$(brew --prefix)/opt/ccache/libexec" >> $GITHUB_PATH
 
-      - name: "setup: restore vcpkg cache"
-        uses: actions/cache/restore@v4
+      # vcpkg's x-gha backend needs the Actions cache endpoint + token, which are only
+      # exposed to actions (not run steps) - export them for the rest of the job.
+      - name: "setup: vcpkg binary cache env"
+        uses: actions/github-script@v7
         with:
-          path: ${{ github.workspace }}/vcpkg_cache
-          key: vcpkg-${{ matrix.os.arch_triplet }}-${{ hashFiles('vcpkg-vendor/vcpkg.json', '.git/modules/vcpkg-vendor/vcpkg/HEAD', 'vcpkg-vendor/vcpkg-overlay-*/**') }}
-          restore-keys: |
-            vcpkg-${{ matrix.os.arch_triplet }}-
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: "setup: vcpkg"
         uses: lukka/run-vcpkg@v11
-        env:
-          VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg_cache,readwrite"
         with:
           vcpkgDirectory: "${{ github.workspace }}/vcpkg-vendor/vcpkg"
           vcpkgJsonGlob: "**/vcpkg-vendor/vcpkg.json"
@@ -222,12 +225,6 @@ jobs:
         with:
           configurePreset: ci-macos
           buildPreset: ci-macos
-
-      - name: "setup: save vcpkg cache"
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ github.workspace }}/vcpkg_cache
-          key: vcpkg-${{ matrix.os.arch_triplet }}-${{ hashFiles('vcpkg-vendor/vcpkg.json', '.git/modules/vcpkg-vendor/vcpkg/HEAD', 'vcpkg-vendor/vcpkg-overlay-*/**') }}
 
       - name: "vendor: save archive"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -54,9 +54,9 @@ jobs:
       AWS_NO_SIGN_REQUEST: ${{ inputs.aws_no_sign_request }}
       NINJA_VERSION: "~1.10.2"  # workaround for python logging output buffering noise
       SIGN_AZURE_CERTIFICATE: ${{ secrets.WIN_SIGN_AZURE_CERTIFICATE }}
-      # Cache vcpkg-built packages in the GitHub Actions cache. Job-level so it applies to
-      # the cmake configure step, where the vendor dependencies actually get built.
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+      # Cache vcpkg-built packages. Job-level so it applies to the cmake configure step,
+      # where the vendor dependencies actually get built.
+      VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg_cache,readwrite"
 
     # Windows builds are expensive, so only run them when:
     # - Pushing a tag/release (always build releases)
@@ -113,15 +113,13 @@ jobs:
           cache: 'pip'
           cache-dependency-path: 'requirements/*.txt'
 
-      # vcpkg's x-gha backend needs the Actions cache endpoint + token, which are only
-      # exposed to actions (not run steps) - export them for the rest of the job.
-      - name: "setup: vcpkg binary cache env"
-        uses: actions/github-script@v7
+      - name: "setup: restore vcpkg cache"
+        uses: actions/cache/restore@v4
         with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+          path: ${{ github.workspace }}/vcpkg_cache
+          key: vcpkg-x64-windows-${{ hashFiles('vcpkg-vendor/vcpkg.json', '.git/modules/vcpkg-vendor/vcpkg/HEAD', 'vcpkg-vendor/vcpkg-overlay-*/**') }}
+          restore-keys: |
+            vcpkg-x64-windows-
 
       - name: "setup: vcpkg"
         uses: lukka/run-vcpkg@v11
@@ -175,6 +173,15 @@ jobs:
         with:
           configurePreset: ci-windows
           buildPreset: ci-windows
+
+      # if: always() so a failed build still saves whatever packages it got through -
+      # the next attempt resumes from there instead of starting cold.
+      - name: "setup: save vcpkg cache"
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: ${{ github.workspace }}/vcpkg_cache
+          key: vcpkg-x64-windows-${{ hashFiles('vcpkg-vendor/vcpkg.json', '.git/modules/vcpkg-vendor/vcpkg/HEAD', 'vcpkg-vendor/vcpkg-overlay-*/**') }}
 
       - name: "vendor: save archive"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -54,6 +54,9 @@ jobs:
       AWS_NO_SIGN_REQUEST: ${{ inputs.aws_no_sign_request }}
       NINJA_VERSION: "~1.10.2"  # workaround for python logging output buffering noise
       SIGN_AZURE_CERTIFICATE: ${{ secrets.WIN_SIGN_AZURE_CERTIFICATE }}
+      # Cache vcpkg-built packages in the GitHub Actions cache. Job-level so it applies to
+      # the cmake configure step, where the vendor dependencies actually get built.
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
     # Windows builds are expensive, so only run them when:
     # - Pushing a tag/release (always build releases)
@@ -110,18 +113,18 @@ jobs:
           cache: 'pip'
           cache-dependency-path: 'requirements/*.txt'
 
-      - name: "setup: restore vcpkg cache"
-        uses: actions/cache/restore@v4
+      # vcpkg's x-gha backend needs the Actions cache endpoint + token, which are only
+      # exposed to actions (not run steps) - export them for the rest of the job.
+      - name: "setup: vcpkg binary cache env"
+        uses: actions/github-script@v7
         with:
-          path: ${{ github.workspace }}/vcpkg_cache
-          key: vcpkg-x64-windows-${{ hashFiles('vcpkg-vendor/vcpkg.json', '.git/modules/vcpkg-vendor/vcpkg/HEAD', 'vcpkg-vendor/vcpkg-overlay-*') }}
-          restore-keys: |
-            vcpkg-x64-windows-
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: "setup: vcpkg"
         uses: lukka/run-vcpkg@v11
-        env:
-          VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg_cache,readwrite"
         with:
           vcpkgDirectory: "${{ github.workspace }}/vcpkg-vendor/vcpkg"
           vcpkgJsonGlob: "**/vcpkg-vendor/vcpkg.json"
@@ -172,12 +175,6 @@ jobs:
         with:
           configurePreset: ci-windows
           buildPreset: ci-windows
-
-      - name: "setup: save vcpkg cache"
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ github.workspace }}/vcpkg_cache
-          key: vcpkg-x64-windows-${{ hashFiles('vcpkg-vendor/vcpkg.json', '.git/modules/vcpkg-vendor/vcpkg/HEAD', 'vcpkg-vendor/vcpkg-overlay-*') }}
 
       - name: "vendor: save archive"
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description

`VCPKG_BINARY_SOURCES` was set as step-scoped env on the `run-vcpkg` setup step, but the vendor dependencies actually build later, during the CMake configure step — so vcpkg wrote built packages to an uncached default path and the `cache/save` step failed every run (`Path Validation Error`). No vcpkg cache was ever saved on any platform (`gh cache list` shows zero `vcpkg-*` keys), and Windows rebuilt ~70 min of C++ deps on every single build. On Linux the save step also ran *before* the main dependency build, and used a host path that doesn't exist inside the manylinux container.

Fixes, in all three build workflows:

- `VCPKG_BINARY_SOURCES` moved to job-level env so it's in effect when the deps build
- cache save moved to after the build, with `if: always()` so a failed build still saves the packages it completed (the next attempt resumes from there)
- Linux cache steps use the container path (`/__w/kart/kart`), matching the existing `GITHUB_WORKSPACE` workaround

Alternative considered: vcpkg's `x-gha` backend (per-package incremental caching, tried in 9401204) — but the pinned vcpkg tool has removed it, so back to the `files` provider.

Note: branches/PRs can read master's cache, but master's Windows/macOS cache is only seeded by a master push containing `ci-build-all`

## Related links:

- #1110 (where the always-cold Windows builds were observed)

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)?
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?