### PR TITLE
Force utf-8 for piped output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## UNRELEASED
 
-- `export`: Fixed a crash (`KeyError: 'GEOMETRY Z'`) when exporting datasets whose geometry type is the generic `GEOMETRY` with a `Z`, `M`, or `ZM` suffix. [#1063](https://github.com/koordinates/kart/issues/1063)
-- `log`: Fixed `<dataset>:tile` and raw-path filters silently matching nothing for point-cloud and raster datasets. [#1119](https://github.com/koordinates/kart/pull/1119)
 - Adds `libkart`, a native shared library exposing a C API for reading Kart repositories in-process (without invoking the `kart` CLI). It is shipped in the bundle alongside the `kart` executable; see the libkart C API reference in the developer docs. [#1110](https://github.com/koordinates/kart/pull/1110)
 - Add pager support to `diff` and `show` commands. [#1080](https://github.com/koordinates/kart/pull/1080)
+- Piped (non-tty) output is now always utf-8 on all platforms. Previously text output used the locale codepage on Windows (e.g. cp1252) - inconsistent with JSON output (always utf-8.) [#1115](https://github.com/koordinates/kart/issues/1115)
+- `export`: Fixed a crash (`KeyError: 'GEOMETRY Z'`) when exporting datasets whose geometry type is the generic `GEOMETRY` with a `Z`, `M`, or `ZM` suffix. [#1063](https://github.com/koordinates/kart/issues/1063)
+- `log`: Fixed `<dataset>:tile` and raw-path filters silently matching nothing for point-cloud and raster datasets. [#1119](https://github.com/koordinates/kart/pull/1119)
 
 ## 0.17.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 - Adds `libkart`, a native shared library exposing a C API for reading Kart repositories in-process (without invoking the `kart` CLI). It is shipped in the bundle alongside the `kart` executable; see the libkart C API reference in the developer docs. [#1110](https://github.com/koordinates/kart/pull/1110)
 - Add pager support to `diff` and `show` commands. [#1080](https://github.com/koordinates/kart/pull/1080)
-- Piped (non-tty) output is now always utf-8 on all platforms. Previously text output used the locale codepage on Windows (e.g. cp1252) - inconsistent with JSON output (always utf-8.) [#1115](https://github.com/koordinates/kart/issues/1115)
+- Piped (non-tty) output is now always UTF-8 on all platforms. Previously text output used the locale codepage on Windows (e.g. cp1252), inconsistent with JSON output (which is always UTF-8). [#1115](https://github.com/koordinates/kart/issues/1115)
 - `export`: Fixed a crash (`KeyError: 'GEOMETRY Z'`) when exporting datasets whose geometry type is the generic `GEOMETRY` with a `Z`, `M`, or `ZM` suffix. [#1063](https://github.com/koordinates/kart/issues/1063)
 - `log`: Fixed `<dataset>:tile` and raw-path filters silently matching nothing for point-cloud and raster datasets. [#1119](https://github.com/koordinates/kart/pull/1119)
 

--- a/kart/cli.py
+++ b/kart/cli.py
@@ -332,8 +332,29 @@ def load_commands_from_args(args, skip_first_arg=True):
             load_all_commands()
 
 
+def _force_utf8_output(*streams):
+    """
+    Ensure non-interactive (piped) text streams use utf-8.
+
+    Kart's JSON output is always utf-8 (msgspec writes raw utf-8 bytes), but
+    human-readable text is written through Python's text streams, which on
+    Windows default to the locale ANSI codepage (e.g. cp1252). That makes piped
+    output inconsistently encoded and breaks consumers that decode it as utf-8
+    (e.g. the QGIS plugin under QGIS 4 - see #1115). Leave interactive ttys
+    alone so console output still matches the terminal's codepage.
+    """
+    for stream in streams:
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None or stream.isatty():
+            continue
+        if (getattr(stream, "encoding", "") or "").lower().replace("-", "") == "utf8":
+            continue
+        reconfigure(encoding="utf-8")
+
+
 def entrypoint():
     freeze_support()
+    _force_utf8_output(sys.stdout, sys.stderr)
     load_commands_from_args(sys.argv)
     # Don't let helper mode mess up the usage-text, or the shell complete environment variables.
     prog_name = "kart" if os.path.basename(sys.argv[0]) == "kart_cli" else None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import contextlib
+import io
 import json
 import os
 import re
@@ -22,6 +23,29 @@ def test_version(cli_runner):
         r"^Kart v(\d+\.\d+.*?)\n» GDAL v",
         r.stdout,
     )
+
+
+def test_force_utf8_output_reconfigures_piped_stream():
+    # A non-tty text stream defaulting to a non-utf-8 codepage (as on Windows)
+    # must be switched to utf-8 so piped output is consistently utf-8 (#1115).
+    raw = io.BytesIO()
+    stream = io.TextIOWrapper(raw, encoding="cp1252")
+    assert not stream.isatty()
+    cli._force_utf8_output(stream)
+    stream.write("»")
+    stream.flush()
+    assert raw.getvalue() == "»".encode("utf-8")
+
+
+def test_force_utf8_output_leaves_tty_alone():
+    # Interactive consoles keep their own codepage to avoid mojibake.
+    class TtyTextIO(io.TextIOWrapper):
+        def isatty(self):
+            return True
+
+    stream = TtyTextIO(io.BytesIO(), encoding="cp1252")
+    cli._force_utf8_output(stream)
+    assert stream.encoding == "cp1252"
 
 
 def test_cli_help():


### PR DESCRIPTION
## Description

Human-readable Kart output is written through Python's text streams, which on Windows default to the locale ANSI codepage (e.g. cp1252) when output is piped. JSON output, however, is always utf-8 (msgspec writes raw utf-8 bytes), so piped output was inconsistently encoded — and any consumer that decodes as utf-8 hit invalid bytes.

This broke the QGIS plugin under QGIS 4.0.3 (Python utf-8 mode): it decoded `kart --version` as utf-8, the `»` banner byte `0xbb` (cp1252) was invalid, the read crashed, and the plugin reported Kart as not installed.

Fix: reconfigure non-tty `stdout`/`stderr` to utf-8 at startup in `entrypoint()`. Interactive ttys are left on the terminal's codepage to avoid mojibake in legacy consoles. Helper mode is unix-only (locale already utf-8) so it's unaffected.

Verified on Windows against a cp1252-default Python: `»` goes from `0xbb` (invalid utf-8) before the fix to `0xc2 0xbb` (valid utf-8) after, with the tty case correctly left alone.

## Related links:

- Fixes #1115
- koordinates/kart-qgis-plugin#137 (the downstream crash)

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?