### PR TITLE
Fix kart log path filters for tile-based datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## UNRELEASED
 
+- `log`: Fixed `<dataset>:tile` and raw-path filters silently matching nothing for point-cloud and raster datasets. [#1119](https://github.com/koordinates/kart/pull/1119)
 - Adds `libkart`, a native shared library exposing a C API for reading Kart repositories in-process (without invoking the `kart` CLI). It is shipped in the bundle alongside the `kart` executable; see the libkart C API reference in the developer docs. [#1110](https://github.com/koordinates/kart/pull/1110)
 - Add pager support to `diff` and `show` commands. [#1080](https://github.com/koordinates/kart/pull/1080)
 

--- a/kart/log.py
+++ b/kart/log.py
@@ -18,6 +18,7 @@ from kart.output_util import (
 )
 from kart.parse_args import PreserveDoubleDash, parse_revisions_and_filters
 from kart.repo import KartRepoState
+from kart.structure import DATASET_DIRNAME_GLOB, DATASET_PATH_PATTERN
 from kart.timestamps import datetime_to_iso8601_utc, timedelta_to_iso8601_tz
 
 L = logging.getLogger("kart.log")
@@ -71,10 +72,9 @@ def convert_user_patterns_to_raw_paths(paths, repo, commits):
     finds the path encoding for the dataset they apply to and converts them to the feature's path, eg:
     path/to/dataset/.table-dataset/feature/F/9/o/6/kc4F9o6L
     """
-    DATASET_DIRNAME = repo.dataset_class.DATASET_DIRNAME
     # Specially handle raw paths, because we can and it's nice for Kart developers
-    result = [p for p in paths if f"/{DATASET_DIRNAME}/" in p]
-    normal_paths = [p for p in paths if f"/{DATASET_DIRNAME}/" not in p]
+    result = [p for p in paths if DATASET_PATH_PATTERN.search(p)]
+    normal_paths = [p for p in paths if not DATASET_PATH_PATTERN.search(p)]
     repo_filter = RepoKeyFilter.build_from_user_patterns(normal_paths)
     if repo_filter.match_all:
         return result
@@ -95,7 +95,7 @@ def convert_user_patterns_to_raw_paths(paths, repo, commits):
         else:
             for ds_part, part_filter in ds_filter.items():
                 if part_filter.match_all:
-                    result.append(f"{ds_path}/{DATASET_DIRNAME}/{ds_part}/*")
+                    result.append(f"{ds_path}/{DATASET_DIRNAME_GLOB}/{ds_part}/*")
                     continue
 
                 for item_key in part_filter:
@@ -114,7 +114,7 @@ def convert_user_patterns_to_raw_paths(paths, repo, commits):
                             )
                     else:
                         result.append(
-                            f"{ds_path}/{DATASET_DIRNAME}/{ds_part}/{item_key}"
+                            f"{ds_path}/{DATASET_DIRNAME_GLOB}/{ds_part}/{item_key}"
                         )
     return result
 

--- a/kart/structure.py
+++ b/kart/structure.py
@@ -37,6 +37,9 @@ _DOT = r"\."
 _NON_SLASHES = "[^/]*"
 DATASET_DIRNAME_PATTERN = re.compile(rf"{_DOT}{_NON_SLASHES}-dataset{_NON_SLASHES}")
 DATASET_PATH_PATTERN = re.compile(f"/{DATASET_DIRNAME_PATTERN.pattern}/")
+# Git-pathspec glob equivalent of DATASET_DIRNAME_PATTERN, matching the dataset
+# dirname of any dataset type (".table-dataset", ".point-cloud-dataset.v1", etc.)
+DATASET_DIRNAME_GLOB = ".*-dataset*"
 
 
 class RepoStructure:

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -303,6 +303,45 @@ def test_path_handling(data_archive, cli_runner, output_format):
 
 
 @pytest.mark.parametrize("output_format", ["text", "json"])
+def test_path_handling_tile_datasets(data_archive, cli_runner, output_format):
+    def num_commits(r):
+        if output_format == "text":
+            return len(re.findall(r"(?m)^commit [0-9a-f]{40}$", r.stdout))
+        else:
+            return len(json.loads(r.stdout))
+
+    with data_archive("point-cloud/auckland.tgz"):
+        # Make a metadata-only commit so we can check that :tile filters exclude it.
+        r = cli_runner.invoke(["meta", "set", "auckland", "title=A new title"])
+        assert r.exit_code == 0, r.stderr
+
+        r = cli_runner.invoke(["log", "-o", output_format, "--", "auckland"])
+        assert r.exit_code == 0, r.stderr
+        assert num_commits(r) == 2
+
+        r = cli_runner.invoke(["log", "-o", output_format, "--", "auckland:tile"])
+        assert r.exit_code == 0, r.stderr
+        assert num_commits(r) == 1
+
+        r = cli_runner.invoke(["log", "-o", output_format, "--", "auckland:meta"])
+        assert r.exit_code == 0, r.stderr
+        assert num_commits(r) == 2
+
+        # The import commit didn't create a title meta item, so only the
+        # meta-set commit touches it:
+        r = cli_runner.invoke(["log", "-o", output_format, "--", "auckland:meta:title"])
+        assert r.exit_code == 0, r.stderr
+        assert num_commits(r) == 1
+
+        # Raw path syntax works for tile datasets too:
+        r = cli_runner.invoke(
+            ["log", "-o", output_format, "--", "auckland/.point-cloud-dataset.v1/tile"]
+        )
+        assert r.exit_code == 0, r.stderr
+        assert num_commits(r) == 1
+
+
+@pytest.mark.parametrize("output_format", ["text", "json"])
 def test_path_handling_where_dataset_needs_finding(
     data_archive, cli_runner, output_format
 ):

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -303,39 +303,55 @@ def test_path_handling(data_archive, cli_runner, output_format):
 
 
 @pytest.mark.parametrize("output_format", ["text", "json"])
-def test_path_handling_tile_datasets(data_archive, cli_runner, output_format):
+@pytest.mark.parametrize(
+    "archive,ds_name,dirname",
+    [
+        pytest.param(
+            "point-cloud/auckland.tgz",
+            "auckland",
+            ".point-cloud-dataset.v1",
+            id="point-cloud",
+        ),
+        pytest.param("raster/aerial.tgz", "aerial", ".raster-dataset.v1", id="raster"),
+    ],
+)
+def test_path_handling_tile_datasets(
+    data_archive, cli_runner, output_format, archive, ds_name, dirname
+):
     def num_commits(r):
         if output_format == "text":
             return len(re.findall(r"(?m)^commit [0-9a-f]{40}$", r.stdout))
         else:
             return len(json.loads(r.stdout))
 
-    with data_archive("point-cloud/auckland.tgz"):
+    with data_archive(archive):
         # Make a metadata-only commit so we can check that :tile filters exclude it.
-        r = cli_runner.invoke(["meta", "set", "auckland", "title=A new title"])
+        r = cli_runner.invoke(["meta", "set", ds_name, "title=A new title"])
         assert r.exit_code == 0, r.stderr
 
-        r = cli_runner.invoke(["log", "-o", output_format, "--", "auckland"])
+        r = cli_runner.invoke(["log", "-o", output_format, "--", ds_name])
         assert r.exit_code == 0, r.stderr
         assert num_commits(r) == 2
 
-        r = cli_runner.invoke(["log", "-o", output_format, "--", "auckland:tile"])
+        r = cli_runner.invoke(["log", "-o", output_format, "--", f"{ds_name}:tile"])
         assert r.exit_code == 0, r.stderr
         assert num_commits(r) == 1
 
-        r = cli_runner.invoke(["log", "-o", output_format, "--", "auckland:meta"])
+        r = cli_runner.invoke(["log", "-o", output_format, "--", f"{ds_name}:meta"])
         assert r.exit_code == 0, r.stderr
         assert num_commits(r) == 2
 
         # The import commit didn't create a title meta item, so only the
         # meta-set commit touches it:
-        r = cli_runner.invoke(["log", "-o", output_format, "--", "auckland:meta:title"])
+        r = cli_runner.invoke(
+            ["log", "-o", output_format, "--", f"{ds_name}:meta:title"]
+        )
         assert r.exit_code == 0, r.stderr
         assert num_commits(r) == 1
 
         # Raw path syntax works for tile datasets too:
         r = cli_runner.invoke(
-            ["log", "-o", output_format, "--", "auckland/.point-cloud-dataset.v1/tile"]
+            ["log", "-o", output_format, "--", f"{ds_name}/{dirname}/tile"]
         )
         assert r.exit_code == 0, r.stderr
         assert num_commits(r) == 1


### PR DESCRIPTION
## Description

`kart log -- <dataset>:tile` silently returned nothing for point-cloud and raster datasets: the filter was converted to a git pathspec using `repo.dataset_class.DATASET_DIRNAME`, which is always the *table* dataset dirname (`.table-dataset`). Raw inner paths like `mydataset/.point-cloud-dataset.v1/tile` were rejected by the filter parser for the same reason.

Fixed by building pathspecs with a glob (`.*-dataset*`) that matches any dataset dirname — wrong-type specs match nothing, so this needs no dataset-type resolution — and by recognising raw paths with the existing `DATASET_PATH_PATTERN` regex instead of the table dirname. An alternative considered was resolving each dataset's actual type at the relevant commit and emitting only its dirname; the glob is simpler and behaves identically.

## Related links:

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?