### PR TITLE
Fix export crash for generic GEOMETRY Z/M/ZM geometry types (#1063)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## UNRELEASED
 
+- `export`: Fixed a crash (`KeyError: 'GEOMETRY Z'`) when exporting datasets whose geometry type is the generic `GEOMETRY` with a `Z`, `M`, or `ZM` suffix. [#1063](https://github.com/koordinates/kart/issues/1063)
 - `log`: Fixed `<dataset>:tile` and raw-path filters silently matching nothing for point-cloud and raster datasets. [#1119](https://github.com/koordinates/kart/pull/1119)
 - Adds `libkart`, a native shared library exposing a C API for reading Kart repositories in-process (without invoking the `kart` CLI). It is shipped in the bundle alongside the `kart` executable; see the libkart C API reference in the developer docs. [#1110](https://github.com/koordinates/kart/pull/1110)
 - Add pager support to `diff` and `show` commands. [#1080](https://github.com/koordinates/kart/pull/1080)

--- a/kart/tabular/ogr_adapter.py
+++ b/kart/tabular/ogr_adapter.py
@@ -66,6 +66,9 @@ def _build_geometry_dicts():
         link_together(f"{kart_type} ZM", base_ogr_type + 3000)
 
     link_together("GEOMETRY", ogr.wkbUnknown)
+    link_together("GEOMETRY Z", ogr.wkbUnknown + 1000)
+    link_together("GEOMETRY M", ogr.wkbUnknown + 2000)
+    link_together("GEOMETRY ZM", ogr.wkbUnknown + 3000)
     return kart_to_ogr, ogr_to_kart
 
 

--- a/tests/test_ogr_adapter.py
+++ b/tests/test_ogr_adapter.py
@@ -47,8 +47,7 @@ def test_ogr_geometry_type_roundtrip():
         "GEOMETRYCOLLECTION",
         "GEOMETRY",
     ]:
-        suffixes = ["", " Z", " M", " ZM"] if base_type != "GEOMETRY" else [""]
-        for suffix in suffixes:
+        for suffix in ["", " Z", " M", " ZM"]:
             kart_type = base_type + suffix
             ogr_type = kart_geometry_type_to_ogr_geometry_type(kart_type)
             roundtripped_type = ogr_geometry_type_to_kart_geometry_type(ogr_type)


### PR DESCRIPTION
## Description

Fixes #1063

`kart export` crashes with `KeyError: 'GEOMETRY Z'` when the dataset's geometry type is the generic `GEOMETRY` with a dimension suffix (`GEOMETRY Z`, `GEOMETRY M`, or `GEOMETRY ZM`).

### Root cause

`kart/tabular/ogr_adapter.py::_build_geometry_dicts()` registers the Z/M/ZM dimension variants for every *named* geometry type (`POINT`, `LINESTRING`, ... `GEOMETRYCOLLECTION`) via the `base + 1000 / 2000 / 3000` OGR convention, but for the generic type it only registers the base entry:

```python
link_together("GEOMETRY", ogr.wkbUnknown)
```

So `KART_GEOM_TYPE_TO_OGR_GEOM_TYPE` contains `GEOMETRY` but not `GEOMETRY Z` / `GEOMETRY M` / `GEOMETRY ZM`. The export planner in `kart/tabular/export.py` (line 244) then does a direct subscript:

```python
ogr_geom_type = KART_GEOM_TYPE_TO_OGR_GEOM_TYPE[kart_geom_type.upper()]
```

which raises `KeyError` for a `GEOMETRY Z` dataset. (The `--override-geometry-type=GEOMETRY` workaround suggested in the issue works precisely because plain `GEOMETRY` *is* in the dict.)

### Reproduction

Looking up the geometry type the way `export.py` does, on unmodified code:

```
'GEOMETRY'     -> 0
'GEOMETRY Z'   -> KeyError: 'GEOMETRY Z'
'GEOMETRY M'   -> KeyError: 'GEOMETRY M'
'GEOMETRY ZM'  -> KeyError: 'GEOMETRY ZM'
```

After the fix:

```
'GEOMETRY'     -> 0
'GEOMETRY Z'   -> 1000
'GEOMETRY M'   -> 2000
'GEOMETRY ZM'  -> 3000
```

OGR names these magic numbers `3D Unknown (any)`, `Measured Unknown (any)`, and `3D Measured Unknown (any)` respectively (`ogr.GeometryTypeToName`), i.e. the Z/M/ZM variants of `wkbUnknown` - exactly the generic `GEOMETRY` variants.

### Fix

Register the three missing variants next to the existing `GEOMETRY` entry, using the same `+1000 / +2000 / +3000` pattern already used for the named types:

```python
link_together("GEOMETRY", ogr.wkbUnknown)
link_together("GEOMETRY Z", ogr.wkbUnknown + 1000)
link_together("GEOMETRY M", ogr.wkbUnknown + 2000)
link_together("GEOMETRY ZM", ogr.wkbUnknown + 3000)
```

`link_together` populates both directions, so the reverse (OGR -> Kart) mapping stays consistent and the values do not collide with any existing entry. The change is localized to the geometry-type table and does not touch export logic.

### Tests

The existing `tests/test_ogr_adapter.py::test_ogr_geometry_type_roundtrip` special-cased `GEOMETRY` to skip the `Z`/`M`/`ZM` suffixes - the very cases that were broken. I removed that exclusion so `GEOMETRY` is now round-tripped with all four dimension suffixes like every other type. Run against the unmodified table this updated test fails with `KeyError: 'GEOMETRY Z'`; with the fix it passes, and all base-type + suffix combinations round-trip cleanly.

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?

Disclosure: prepared with AI assistance; reviewed and verified locally.
