### PR TITLE
libkart: primitives for blob-substitution history rewriting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 ## UNRELEASED
 
 - Adds `libkart`, a native shared library exposing a C API for reading Kart repositories in-process (without invoking the `kart` CLI). It is shipped in the bundle alongside the `kart` executable; see the libkart C API reference in the developer docs. [#1110](https://github.com/koordinates/kart/pull/1110)
+- `libkart`: Adds feature path encoding, feature blob search/update, and generic history-rewrite primitives to the C API.
 - Add pager support to `diff` and `show` commands. [#1080](https://github.com/koordinates/kart/pull/1080)
 - Piped (non-tty) output is now always UTF-8 on all platforms. Previously text output used the locale codepage on Windows (e.g. cp1252), inconsistent with JSON output (which is always UTF-8). [#1115](https://github.com/koordinates/kart/issues/1115)
 - `export`: Fixed a crash (`KeyError: 'GEOMETRY Z'`) when exporting datasets whose geometry type is the generic `GEOMETRY` with a `Z`, `M`, or `ZM` suffix. [#1063](https://github.com/koordinates/kart/issues/1063)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## UNRELEASED
 
-- Update vcpkg to 2026-07-30 upstream master. Fixes CI build failures caused by libaec downloads from gitlab.dkrz.de returning HTTP 429; the port now downloads from GitHub. Also updates PDAL to 2.10.1. [#1121](https://github.com/koordinates/kart/pull/1121)
 - Adds `libkart`, a native shared library exposing a C API for reading Kart repositories in-process (without invoking the `kart` CLI). It is shipped in the bundle alongside the `kart` executable; see the libkart C API reference in the developer docs. [#1110](https://github.com/koordinates/kart/pull/1110)
 - Add pager support to `diff` and `show` commands. [#1080](https://github.com/koordinates/kart/pull/1080)
 - Piped (non-tty) output is now always UTF-8 on all platforms. Previously text output used the locale codepage on Windows (e.g. cp1252), inconsistent with JSON output (which is always UTF-8). [#1115](https://github.com/koordinates/kart/issues/1115)
 - `export`: Fixed a crash (`KeyError: 'GEOMETRY Z'`) when exporting datasets whose geometry type is the generic `GEOMETRY` with a `Z`, `M`, or `ZM` suffix. [#1063](https://github.com/koordinates/kart/issues/1063)
 - `log`: Fixed `<dataset>:tile` and raw-path filters silently matching nothing for point-cloud and raster datasets. [#1119](https://github.com/koordinates/kart/pull/1119)
+- Update PDAL to 2.10.1. [#1121](https://github.com/koordinates/kart/pull/1121)
 
 ## 0.17.1
 

--- a/libkart/Cargo.lock
+++ b/libkart/Cargo.lock
@@ -15,6 +15,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +40,35 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -56,6 +94,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -228,6 +276,7 @@ dependencies = [
  "libc",
  "rmpv",
  "serde_json",
+ "sha2",
 ]
 
 [[package]]
@@ -375,6 +424,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +485,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +519,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasip2"

--- a/libkart/Cargo.lock
+++ b/libkart/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +278,7 @@ dependencies = [
 name = "libkart"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "git2",
  "libc",
  "rmpv",

--- a/libkart/Cargo.toml
+++ b/libkart/Cargo.toml
@@ -23,3 +23,5 @@ serde_json = "1"
 sha2 = "0.10"
 # malloc/free for buffers handed across the C boundary
 libc = "0.2"
+# decoding blob-substitution content passed as JSON across the C boundary
+base64 = "0.22"

--- a/libkart/Cargo.toml
+++ b/libkart/Cargo.toml
@@ -19,5 +19,7 @@ git2 = { version = "0.19", default-features = false }
 rmpv = "1"
 # JSON output for schema / tile summaries
 serde_json = "1"
+# sha256 for msgpack/hash feature path encoding
+sha2 = "0.10"
 # malloc/free for buffers handed across the C boundary
 libc = "0.2"

--- a/libkart/include/libkart.h
+++ b/libkart/include/libkart.h
@@ -5,7 +5,7 @@
  *   - Fallible functions return int rc: 0 = ok, -1 = error. On error, kart_last_error()
  *     returns a message (valid until the next libkart call on the same thread).
  *   - Handles are uint64_t; 0 is never valid. Free repos/datasets with kart_*_free.
- *   - Returned buffers (char**/uint8_t** + size_t*) are malloc'd by libkart; release them
+ *   - Returned buffers (byte pointer + length out-params) are malloc'd by libkart; release them
  *     with kart_free(). An absent/None value yields rc 0 with *out == NULL and *out_len == 0.
  *   - Returned text buffers are NOT NUL-terminated; use the accompanying length.
  */
@@ -25,6 +25,20 @@ void kart_repo_free(uint64_t repo);
 int kart_repo_table_dataset_version(uint64_t repo, int *out_version);
 int kart_repo_list_datasets(uint64_t repo, const char *refish, uint8_t **out_json,
                             size_t *out_len);
+/* commits_json: JSON array of 40-hex commit oids. query_json: {"pk": [..]} or
+ * {"filter": {col: val}}. out: JSON [{"commit": hex, "path": "...", "oid": hex}, ...]
+ * (path is repo-root-relative). */
+int kart_repo_find_feature_blobs(uint64_t repo, const char *commits_json,
+                                 const char *dataset_path, const char *query_json,
+                                 uint8_t **out, size_t *out_len);
+/* substitutions_json: {"<40-hex old blob oid>": "<base64 new content>"}.
+ * backup_ref_prefix: nullable; non-NULL prefixes must start with "refs/".
+ * out: JSON {"commits_rewritten": n, "blobs_written": n, "refs_updated": [...],
+ * "backup_refs": [...]} */
+int kart_repo_rewrite_history(uint64_t repo, const char *substitutions_json,
+                              const char *backup_ref_prefix, uint8_t **out, size_t *out_len);
+/* out: raw blob content for a 40-hex oid (caller reads e.g. generated-pks.json). */
+int kart_repo_blob(uint64_t repo, const char *oid_hex, uint8_t **out, size_t *out_len);
 
 /* dataset */
 int kart_dataset_open(uint64_t repo, const char *refish, const char *path, uint64_t *out_ds);
@@ -33,10 +47,17 @@ int kart_dataset_type(uint64_t ds, uint8_t **out, size_t *out_len);
 int kart_dataset_schema_json(uint64_t ds, uint8_t **out, size_t *out_len);
 int kart_dataset_crs_wkt(uint64_t ds, uint8_t **out, size_t *out_len);
 int kart_dataset_meta_item(uint64_t ds, const char *name, uint8_t **out, size_t *out_len);
+/* pk_values_json: JSON array e.g. "[3]" or "[\"abc\"]". out: path string (relative to
+ * the dataset dir). */
+int kart_dataset_feature_path(uint64_t ds, const char *pk_values_json, uint8_t **out,
+                              size_t *out_len);
 
 /* feature / tile (caller supplies the raw git blob bytes) */
 int kart_feature_geometry(uint64_t ds, const uint8_t *blob, size_t blob_len, uint8_t **out,
                           size_t *out_len);
+/* updates_json: JSON object {column_name: new_value}. out: new blob bytes. */
+int kart_feature_update_blob(uint64_t ds, const uint8_t *blob, size_t blob_len,
+                             const char *updates_json, uint8_t **out, size_t *out_len);
 int kart_tile_summary_json(uint64_t ds, const uint8_t *blob, size_t blob_len, uint8_t **out,
                            size_t *out_len);
 

--- a/libkart/src/capi.rs
+++ b/libkart/src/capi.rs
@@ -86,7 +86,8 @@ fn json_pk_to_msgpack(v: &serde_json::Value) -> Result<rmpv::Value> {
 
 /// Parse a JSON array of primary-key values (e.g. `[3]` or `["abc"]`) to msgpack values.
 fn parse_pk_values(json: &str) -> Result<Vec<rmpv::Value>> {
-    let parsed: serde_json::Value = serde_json::from_str(json)?;
+    let parsed: serde_json::Value =
+        serde_json::from_str(json).map_err(|e| Error::Json(format!("pk values: {e}")))?;
     let arr = parsed
         .as_array()
         .ok_or_else(|| Error::Format(format!("pk values must be a JSON array, got {parsed}")))?;
@@ -95,7 +96,8 @@ fn parse_pk_values(json: &str) -> Result<Vec<rmpv::Value>> {
 
 /// Parse a JSON object holding column-name -> value pairs (updates or filter).
 fn parse_json_object(json: &str, what: &str) -> Result<serde_json::Map<String, serde_json::Value>> {
-    let parsed: serde_json::Value = serde_json::from_str(json)?;
+    let parsed: serde_json::Value =
+        serde_json::from_str(json).map_err(|e| Error::Json(format!("{what}: {e}")))?;
     match parsed {
         serde_json::Value::Object(map) => Ok(map),
         other => Err(Error::Format(format!(
@@ -116,7 +118,8 @@ fn parse_oid(hex: &str) -> Result<Oid> {
 
 /// Parse a JSON array of 40-hex commit oids.
 fn parse_commits(json: &str) -> Result<Vec<Oid>> {
-    let parsed: serde_json::Value = serde_json::from_str(json)?;
+    let parsed: serde_json::Value =
+        serde_json::from_str(json).map_err(|e| Error::Json(format!("commits: {e}")))?;
     let arr = parsed
         .as_array()
         .ok_or_else(|| Error::Format(format!("commits must be a JSON array, got {parsed}")))?;
@@ -601,35 +604,12 @@ pub unsafe extern "C" fn kart_free(ptr: *mut std::os::raw::c_void) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::extract_fixture;
     use git2::{ObjectType, Tree};
     use std::ffi::CString;
-    use std::process::Command;
 
     const POINTS_TGZ: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/points.tgz");
     const EDITING_TGZ: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/editing.tgz");
-
-    /// Extract a fixture tgz into a fresh temp dir, returning the repo root path.
-    /// `label` is a per-test tag so parallel tests on the same fixture don't collide.
-    fn extract_fixture(tgz: &str, subdir: &str, label: &str) -> std::path::PathBuf {
-        crate::test_support::disable_owner_validation();
-        let base = std::env::temp_dir().join(format!(
-            "libkart-capitest-{}-{}-{}",
-            label,
-            subdir,
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&base);
-        std::fs::create_dir_all(&base).unwrap();
-        let status = Command::new("tar")
-            .arg("xzf")
-            .arg(tgz)
-            .arg("-C")
-            .arg(&base)
-            .status()
-            .expect("run tar");
-        assert!(status.success(), "tar failed for {tgz}");
-        base.join(subdir)
-    }
 
     /// Consume a buffer-returning call's out-params: assert rc 0, copy the bytes out, and
     /// free the libkart-owned buffer. Returns None for the absent (NULL) case.

--- a/libkart/src/capi.rs
+++ b/libkart/src/capi.rs
@@ -3,11 +3,17 @@
 //! malloc'd by libkart and must be released by the caller with `kart_free`; a None/absent
 //! result yields rc 0 with `*out == NULL` and `*out_len == 0`.
 
+use std::collections::HashMap;
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_int};
 
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use git2::Oid;
+
 use crate::error::{last_error_ptr, set_last_error, Error, Result};
 use crate::handle::{DATASETS, REPOS};
+use crate::query::{find_feature_blobs, FeatureQuery};
+use crate::rewrite::rewrite_history;
 use crate::{dataset, feature, gpkg, tile};
 
 // ---- small helpers ----------------------------------------------------------
@@ -65,6 +71,116 @@ unsafe fn emit(data: Option<&[u8]>, out: *mut *mut u8, out_len: *mut usize) -> c
     }
 }
 
+/// Convert one JSON primary-key value to msgpack: integers and strings only.
+fn json_pk_to_msgpack(v: &serde_json::Value) -> Result<rmpv::Value> {
+    match v {
+        serde_json::Value::Number(n) => n.as_i64().map(rmpv::Value::from).ok_or_else(|| {
+            Error::Format(format!("pk value must be an integer or string, got {v}"))
+        }),
+        serde_json::Value::String(s) => Ok(rmpv::Value::from(s.as_str())),
+        _ => Err(Error::Format(format!(
+            "pk value must be an integer or string, got {v}"
+        ))),
+    }
+}
+
+/// Parse a JSON array of primary-key values (e.g. `[3]` or `["abc"]`) to msgpack values.
+fn parse_pk_values(json: &str) -> Result<Vec<rmpv::Value>> {
+    let parsed: serde_json::Value = serde_json::from_str(json)?;
+    let arr = parsed
+        .as_array()
+        .ok_or_else(|| Error::Format(format!("pk values must be a JSON array, got {parsed}")))?;
+    arr.iter().map(json_pk_to_msgpack).collect()
+}
+
+/// Parse a JSON object holding column-name -> value pairs (updates or filter).
+fn parse_json_object(json: &str, what: &str) -> Result<serde_json::Map<String, serde_json::Value>> {
+    let parsed: serde_json::Value = serde_json::from_str(json)?;
+    match parsed {
+        serde_json::Value::Object(map) => Ok(map),
+        other => Err(Error::Format(format!(
+            "{what} must be a JSON object, got {other}"
+        ))),
+    }
+}
+
+/// Parse a 40-hex git object id.
+fn parse_oid(hex: &str) -> Result<Oid> {
+    if hex.len() != 40 {
+        return Err(Error::Format(format!(
+            "expected a 40-hex object id, got '{hex}'"
+        )));
+    }
+    Oid::from_str(hex).map_err(|_| Error::Format(format!("invalid object id '{hex}'")))
+}
+
+/// Parse a JSON array of 40-hex commit oids.
+fn parse_commits(json: &str) -> Result<Vec<Oid>> {
+    let parsed: serde_json::Value = serde_json::from_str(json)?;
+    let arr = parsed
+        .as_array()
+        .ok_or_else(|| Error::Format(format!("commits must be a JSON array, got {parsed}")))?;
+    arr.iter()
+        .map(|v| {
+            let hex = v
+                .as_str()
+                .ok_or_else(|| Error::Format(format!("commit must be a 40-hex string, got {v}")))?;
+            parse_oid(hex)
+        })
+        .collect()
+}
+
+/// Parse a feature query: a JSON object with exactly one of "pk" (a JSON array of pk
+/// values) or "filter" (a JSON object of column-name -> value).
+fn parse_feature_query(json: &str) -> Result<FeatureQuery> {
+    let mut map = parse_json_object(json, "query")?;
+    if map.len() != 1 {
+        return Err(Error::Format(format!(
+            "query must be an object with exactly one of \"pk\" or \"filter\", got {}",
+            serde_json::Value::Object(map)
+        )));
+    }
+    let (key, value) = map.iter_mut().next().expect("len checked above");
+    match key.as_str() {
+        "pk" => {
+            let arr = value.as_array().ok_or_else(|| {
+                Error::Format(format!("query \"pk\" must be a JSON array, got {value}"))
+            })?;
+            Ok(FeatureQuery::Pk(
+                arr.iter().map(json_pk_to_msgpack).collect::<Result<_>>()?,
+            ))
+        }
+        "filter" => match value.take() {
+            serde_json::Value::Object(filter) => Ok(FeatureQuery::Filter(filter)),
+            other => Err(Error::Format(format!(
+                "query \"filter\" must be a JSON object, got {other}"
+            ))),
+        },
+        other => Err(Error::Format(format!(
+            "query must be an object with exactly one of \"pk\" or \"filter\", got key \"{other}\""
+        ))),
+    }
+}
+
+/// Parse blob substitutions: a JSON object of 40-hex old blob oid -> base64 new content.
+fn parse_substitutions(json: &str) -> Result<HashMap<Oid, Vec<u8>>> {
+    let map = parse_json_object(json, "substitutions")?;
+    let mut subs = HashMap::with_capacity(map.len());
+    for (hex, value) in &map {
+        let oid = parse_oid(hex)?;
+        let b64 = value.as_str().ok_or_else(|| {
+            Error::Format(format!(
+                "substitution for '{hex}' must be a base64 string, got {value}"
+            ))
+        })?;
+        let content = BASE64.decode(b64).map_err(|e| {
+            Error::Format(format!("substitution for '{hex}' is not valid base64: {e}"))
+        })?;
+        subs.insert(oid, content);
+    }
+    Ok(subs)
+}
+
 // ---- repo -------------------------------------------------------------------
 
 #[no_mangle]
@@ -119,6 +235,119 @@ pub unsafe extern "C" fn kart_repo_list_datasets(
     });
     match result {
         Some(Ok(bytes_vec)) => emit(Some(&bytes_vec), out_json, out_len),
+        Some(Err(e)) => fail(e),
+        None => fail(Error::NotFound("repo handle".into())),
+    }
+}
+
+/// Find feature blobs matching a query at each of the given commits. `commits_json` is a
+/// JSON array of 40-hex commit oids; `query_json` is `{"pk": [..]}` or `{"filter": {col:
+/// val}}`. Out: JSON `[{"commit": hex, "path": "...", "oid": hex}, ...]` (path is
+/// repo-root-relative).
+#[no_mangle]
+pub unsafe extern "C" fn kart_repo_find_feature_blobs(
+    repo: u64,
+    commits_json: *const c_char,
+    dataset_path: *const c_char,
+    query_json: *const c_char,
+    out: *mut *mut u8,
+    out_len: *mut usize,
+) -> c_int {
+    let commits = match cstr(commits_json).and_then(parse_commits) {
+        Ok(c) => c,
+        Err(e) => return fail(e),
+    };
+    let dataset_path = match cstr(dataset_path) {
+        Ok(s) => s,
+        Err(e) => return fail(e),
+    };
+    let query = match cstr(query_json).and_then(parse_feature_query) {
+        Ok(q) => q,
+        Err(e) => return fail(e),
+    };
+    let result = REPOS.with(repo, |r| {
+        let hits = find_feature_blobs(r, &commits, dataset_path, &query)?;
+        let json: Vec<serde_json::Value> = hits
+            .iter()
+            .map(|h| {
+                serde_json::json!({
+                    "commit": h.commit.to_string(),
+                    "path": h.path,
+                    "oid": h.blob_oid.to_string(),
+                })
+            })
+            .collect();
+        serde_json::to_vec(&json).map_err(Error::from)
+    });
+    match result {
+        Some(Ok(b)) => emit(Some(&b), out, out_len),
+        Some(Err(e)) => fail(e),
+        None => fail(Error::NotFound("repo handle".into())),
+    }
+}
+
+/// Rewrite history substituting blobs. `substitutions_json` is a JSON object of
+/// `{"<40-hex old blob oid>": "<base64 new content>"}`; `backup_ref_prefix` is nullable
+/// (non-NULL prefixes must start with "refs/"). Out: JSON `{"commits_rewritten": n,
+/// "blobs_written": n, "refs_updated": [...], "backup_refs": [...]}`.
+#[no_mangle]
+pub unsafe extern "C" fn kart_repo_rewrite_history(
+    repo: u64,
+    substitutions_json: *const c_char,
+    backup_ref_prefix: *const c_char,
+    out: *mut *mut u8,
+    out_len: *mut usize,
+) -> c_int {
+    let substitutions = match cstr(substitutions_json).and_then(parse_substitutions) {
+        Ok(s) => s,
+        Err(e) => return fail(e),
+    };
+    // NULL prefix means "no backup refs".
+    let prefix = if backup_ref_prefix.is_null() {
+        None
+    } else {
+        match cstr(backup_ref_prefix) {
+            Ok(s) => Some(s),
+            Err(e) => return fail(e),
+        }
+    };
+    let result = REPOS.with(repo, |r| {
+        let stats = rewrite_history(r, &substitutions, prefix)?;
+        let json = serde_json::json!({
+            "commits_rewritten": stats.commits_rewritten,
+            "blobs_written": stats.blobs_written,
+            "refs_updated": stats.refs_updated,
+            "backup_refs": stats.backup_refs,
+        });
+        serde_json::to_vec(&json).map_err(Error::from)
+    });
+    match result {
+        Some(Ok(b)) => emit(Some(&b), out, out_len),
+        Some(Err(e)) => fail(e),
+        None => fail(Error::NotFound("repo handle".into())),
+    }
+}
+
+/// Raw content of the blob with the given 40-hex oid (e.g. to read generated-pks.json).
+#[no_mangle]
+pub unsafe extern "C" fn kart_repo_blob(
+    repo: u64,
+    oid_hex: *const c_char,
+    out: *mut *mut u8,
+    out_len: *mut usize,
+) -> c_int {
+    let oid = match cstr(oid_hex).and_then(parse_oid) {
+        Ok(o) => o,
+        Err(e) => return fail(e),
+    };
+    let result = REPOS.with(repo, |r| {
+        r.git
+            .find_blob(oid)
+            .map(|b| b.content().to_vec())
+            .map_err(Error::from)
+    });
+    match result {
+        Some(Ok(b)) => emit(Some(&b), out, out_len),
         Some(Err(e)) => fail(e),
         None => fail(Error::NotFound("repo handle".into())),
     }
@@ -213,6 +442,26 @@ pub unsafe extern "C" fn kart_dataset_meta_item(
     }
 }
 
+/// Path of the feature with the given primary key values, relative to the dataset dir.
+/// `pk_values_json` is a JSON array, e.g. `[3]` or `["abc"]` (integers and strings only).
+#[no_mangle]
+pub unsafe extern "C" fn kart_dataset_feature_path(
+    ds: u64,
+    pk_values_json: *const c_char,
+    out: *mut *mut u8,
+    out_len: *mut usize,
+) -> c_int {
+    let pk_values = match cstr(pk_values_json).and_then(parse_pk_values) {
+        Ok(v) => v,
+        Err(e) => return fail(e),
+    };
+    match DATASETS.with(ds, |d| d.feature_path(&pk_values)) {
+        Some(Ok(p)) => emit(Some(p.as_bytes()), out, out_len),
+        Some(Err(e)) => fail(e),
+        None => fail(Error::NotFound("dataset handle".into())),
+    }
+}
+
 // ---- feature / tile ---------------------------------------------------------
 
 #[no_mangle]
@@ -226,6 +475,29 @@ pub unsafe extern "C" fn kart_feature_geometry(
     let blob = bytes(blob, blob_len);
     match DATASETS.with(ds, |d| feature::feature_geometry(d, blob)) {
         Some(Ok(opt)) => emit(opt.as_deref(), out, out_len),
+        Some(Err(e)) => fail(e),
+        None => fail(Error::NotFound("dataset handle".into())),
+    }
+}
+
+/// Copy of a feature blob with the values of the named columns replaced. `updates_json`
+/// is a JSON object of `{column_name: new_value}`. Out: the new blob bytes.
+#[no_mangle]
+pub unsafe extern "C" fn kart_feature_update_blob(
+    ds: u64,
+    blob: *const u8,
+    blob_len: usize,
+    updates_json: *const c_char,
+    out: *mut *mut u8,
+    out_len: *mut usize,
+) -> c_int {
+    let updates = match cstr(updates_json).and_then(|s| parse_json_object(s, "updates")) {
+        Ok(m) => m,
+        Err(e) => return fail(e),
+    };
+    let blob = bytes(blob, blob_len);
+    match DATASETS.with(ds, |d| feature::update_feature_blob(d, blob, &updates)) {
+        Some(Ok(b)) => emit(Some(&b), out, out_len),
         Some(Err(e)) => fail(e),
         None => fail(Error::NotFound("dataset handle".into())),
     }
@@ -334,12 +606,15 @@ mod tests {
     use std::process::Command;
 
     const POINTS_TGZ: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/points.tgz");
+    const EDITING_TGZ: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/editing.tgz");
 
     /// Extract a fixture tgz into a fresh temp dir, returning the repo root path.
-    fn extract_fixture(tgz: &str, subdir: &str) -> std::path::PathBuf {
+    /// `label` is a per-test tag so parallel tests on the same fixture don't collide.
+    fn extract_fixture(tgz: &str, subdir: &str, label: &str) -> std::path::PathBuf {
         crate::test_support::disable_owner_validation();
         let base = std::env::temp_dir().join(format!(
-            "libkart-capitest-{}-{}",
+            "libkart-capitest-{}-{}-{}",
+            label,
             subdir,
             std::process::id()
         ));
@@ -431,7 +706,7 @@ mod tests {
 
     #[test]
     fn test_capi_full_flow() {
-        let root = extract_fixture(POINTS_TGZ, "points");
+        let root = extract_fixture(POINTS_TGZ, "points", "flow");
         let path_c = CString::new(root.to_str().unwrap()).unwrap();
         let head = CString::new("HEAD").unwrap();
 
@@ -578,6 +853,352 @@ mod tests {
             );
         }
 
+        let _ = std::fs::remove_dir_all(root.parent().unwrap());
+    }
+
+    /// Open the editing fixture via the ABI: (root, repo handle, dataset handle,
+    /// [head, head~1] commit hex). The fixture has one branch `main` with two commits
+    /// over dataset `editing` (int pk `id`, text `value`); pk 3 has value "c" at both.
+    unsafe fn open_editing_capi(label: &str) -> (std::path::PathBuf, u64, u64, [String; 2]) {
+        let root = extract_fixture(EDITING_TGZ, "editing", label);
+        let path_c = CString::new(root.to_str().unwrap()).unwrap();
+        let mut repo: u64 = 0;
+        let rc = kart_repo_open(path_c.as_ptr(), &mut repo);
+        assert_eq!(rc, 0, "open failed: {}", last_error_str());
+
+        let head = CString::new("HEAD").unwrap();
+        let ds_path = CString::new("editing").unwrap();
+        let mut ds: u64 = 0;
+        let rc = kart_dataset_open(repo, head.as_ptr(), ds_path.as_ptr(), &mut ds);
+        assert_eq!(rc, 0, "dataset open failed: {}", last_error_str());
+
+        let git = crate::repo::Repo::open(root.to_str().unwrap()).unwrap();
+        let head_oid = git.git.revparse_single("HEAD").unwrap().id().to_string();
+        let prev_oid = git.git.revparse_single("HEAD~1").unwrap().id().to_string();
+        (root, repo, ds, [head_oid, prev_oid])
+    }
+
+    /// Call a buffer-returning ABI function, asserting rc 0 and a non-NULL result.
+    unsafe fn call_out(f: impl FnOnce(*mut *mut u8, *mut usize) -> c_int) -> Vec<u8> {
+        let mut ptr: *mut u8 = std::ptr::null_mut();
+        let mut len: usize = 0;
+        let rc = f(&mut ptr, &mut len);
+        read_out(rc, ptr, len).expect("non-NULL out buffer")
+    }
+
+    /// Call a buffer-returning ABI function, asserting rc -1 (out-params untouched
+    /// semantics aside, the buffer must not need freeing) and a non-empty last error.
+    unsafe fn call_err(f: impl FnOnce(*mut *mut u8, *mut usize) -> c_int) -> String {
+        let mut ptr: *mut u8 = std::ptr::null_mut();
+        let mut len: usize = 0;
+        let rc = f(&mut ptr, &mut len);
+        assert_eq!(rc, -1, "expected rc -1");
+        let msg = last_error_str();
+        assert!(!msg.is_empty(), "expected an error message");
+        msg
+    }
+
+    #[test]
+    fn test_capi_feature_path() {
+        let (root, repo, ds, _commits) = unsafe { open_editing_capi("featpath") };
+        unsafe {
+            // Happy path: pk 3 -> dataset-relative feature path.
+            let pks = CString::new("[3]").unwrap();
+            let path = call_out(|o, n| kart_dataset_feature_path(ds, pks.as_ptr(), o, n));
+            assert_eq!(
+                String::from_utf8(path).unwrap(),
+                ".table-dataset/feature/A/A/A/A/kQM="
+            );
+
+            // NULL pk json => rc -1.
+            call_err(|o, n| kart_dataset_feature_path(ds, std::ptr::null(), o, n));
+            // Invalid JSON => rc -1.
+            let bad = CString::new("not json").unwrap();
+            call_err(|o, n| kart_dataset_feature_path(ds, bad.as_ptr(), o, n));
+            // Non-array JSON => rc -1.
+            let obj = CString::new("{}").unwrap();
+            call_err(|o, n| kart_dataset_feature_path(ds, obj.as_ptr(), o, n));
+            // Float pk value => rc -1 (only integers and strings are supported).
+            let float = CString::new("[1.5]").unwrap();
+            let msg = call_err(|o, n| kart_dataset_feature_path(ds, float.as_ptr(), o, n));
+            assert!(msg.contains("integer or string"), "got: {msg}");
+            // Unknown dataset handle => rc -1 "not found".
+            let pks2 = CString::new("[3]").unwrap();
+            let msg = call_err(|o, n| kart_dataset_feature_path(99999, pks2.as_ptr(), o, n));
+            assert!(msg.contains("not found"), "got: {msg}");
+
+            kart_dataset_free(ds);
+            kart_repo_free(repo);
+        }
+        let _ = std::fs::remove_dir_all(root.parent().unwrap());
+    }
+
+    #[test]
+    fn test_capi_find_blobs_and_repo_blob_and_update() {
+        let (root, repo, ds, [head_hex, prev_hex]) = unsafe { open_editing_capi("findupd") };
+        let ds_path = CString::new("editing").unwrap();
+        unsafe {
+            // ---- kart_repo_find_feature_blobs: pk query over both commits --------
+            let commits = CString::new(format!("[\"{head_hex}\", \"{prev_hex}\"]")).unwrap();
+            let query = CString::new("{\"pk\": [3]}").unwrap();
+            let out = call_out(|o, n| {
+                kart_repo_find_feature_blobs(
+                    repo,
+                    commits.as_ptr(),
+                    ds_path.as_ptr(),
+                    query.as_ptr(),
+                    o,
+                    n,
+                )
+            });
+            let hits: serde_json::Value = serde_json::from_slice(&out).unwrap();
+            let hits = hits.as_array().unwrap();
+            assert_eq!(hits.len(), 2);
+            assert_eq!(hits[0]["commit"], head_hex.as_str());
+            assert_eq!(hits[1]["commit"], prev_hex.as_str());
+            for hit in hits {
+                assert_eq!(hit["path"], "editing/.table-dataset/feature/A/A/A/A/kQM=");
+            }
+            let blob_hex = hits[0]["oid"].as_str().unwrap().to_string();
+            assert_eq!(blob_hex.len(), 40);
+
+            // A filter query finds the same feature (pk 3 has value "c").
+            let filter_q = CString::new("{\"filter\": {\"value\": \"c\"}}").unwrap();
+            let out2 = call_out(|o, n| {
+                kart_repo_find_feature_blobs(
+                    repo,
+                    commits.as_ptr(),
+                    ds_path.as_ptr(),
+                    filter_q.as_ptr(),
+                    o,
+                    n,
+                )
+            });
+            assert_eq!(out, out2);
+
+            // ---- kart_repo_blob round-trip ---------------------------------------
+            let blob_hex_c = CString::new(blob_hex.clone()).unwrap();
+            let content = call_out(|o, n| kart_repo_blob(repo, blob_hex_c.as_ptr(), o, n));
+            let git = crate::repo::Repo::open(root.to_str().unwrap()).unwrap();
+            let expected = git
+                .git
+                .find_blob(git2::Oid::from_str(&blob_hex).unwrap())
+                .unwrap()
+                .content()
+                .to_vec();
+            assert_eq!(content, expected);
+
+            // ---- kart_feature_update_blob ----------------------------------------
+            let updates = CString::new("{\"value\": \"updated!\"}").unwrap();
+            let new_blob = call_out(|o, n| {
+                kart_feature_update_blob(
+                    ds,
+                    content.as_ptr(),
+                    content.len(),
+                    updates.as_ptr(),
+                    o,
+                    n,
+                )
+            });
+            assert_ne!(new_blob, content);
+            let (_, values) = crate::feature::decode_feature(&new_blob).unwrap();
+            assert_eq!(values, vec![rmpv::Value::from("updated!")]);
+
+            // ---- error paths -----------------------------------------------------
+            // find: query with both keys / neither / bad commits / bad hex.
+            for bad_query in ["{\"pk\": [3], \"filter\": {}}", "{}", "[]", "{\"nope\": 1}"] {
+                let q = CString::new(bad_query).unwrap();
+                call_err(|o, n| {
+                    kart_repo_find_feature_blobs(
+                        repo,
+                        commits.as_ptr(),
+                        ds_path.as_ptr(),
+                        q.as_ptr(),
+                        o,
+                        n,
+                    )
+                });
+            }
+            let bad_commits = CString::new("[\"zzzz\"]").unwrap();
+            call_err(|o, n| {
+                kart_repo_find_feature_blobs(
+                    repo,
+                    bad_commits.as_ptr(),
+                    ds_path.as_ptr(),
+                    query.as_ptr(),
+                    o,
+                    n,
+                )
+            });
+            let not_array = CString::new("{}").unwrap();
+            call_err(|o, n| {
+                kart_repo_find_feature_blobs(
+                    repo,
+                    not_array.as_ptr(),
+                    ds_path.as_ptr(),
+                    query.as_ptr(),
+                    o,
+                    n,
+                )
+            });
+            call_err(|o, n| {
+                kart_repo_find_feature_blobs(
+                    repo,
+                    std::ptr::null(),
+                    ds_path.as_ptr(),
+                    query.as_ptr(),
+                    o,
+                    n,
+                )
+            });
+
+            // repo_blob: malformed hex and missing object.
+            let bad_hex = CString::new("nothex").unwrap();
+            call_err(|o, n| kart_repo_blob(repo, bad_hex.as_ptr(), o, n));
+            let zeros = CString::new("0000000000000000000000000000000000000000").unwrap();
+            call_err(|o, n| kart_repo_blob(repo, zeros.as_ptr(), o, n));
+
+            // update: non-object updates / unknown column / NULL updates.
+            let arr = CString::new("[1]").unwrap();
+            call_err(|o, n| {
+                kart_feature_update_blob(ds, content.as_ptr(), content.len(), arr.as_ptr(), o, n)
+            });
+            let unknown = CString::new("{\"no_such_col\": 1}").unwrap();
+            call_err(|o, n| {
+                kart_feature_update_blob(
+                    ds,
+                    content.as_ptr(),
+                    content.len(),
+                    unknown.as_ptr(),
+                    o,
+                    n,
+                )
+            });
+            call_err(|o, n| {
+                kart_feature_update_blob(
+                    ds,
+                    content.as_ptr(),
+                    content.len(),
+                    std::ptr::null(),
+                    o,
+                    n,
+                )
+            });
+
+            kart_dataset_free(ds);
+            kart_repo_free(repo);
+        }
+        let _ = std::fs::remove_dir_all(root.parent().unwrap());
+    }
+
+    #[test]
+    fn test_capi_rewrite_history() {
+        use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+
+        let (root, repo, ds, [head_hex, _prev_hex]) = unsafe { open_editing_capi("rewrite") };
+        let ds_path = CString::new("editing").unwrap();
+        unsafe {
+            // Find pk 3's blob oid at HEAD via the ABI.
+            let commits = CString::new(format!("[\"{head_hex}\"]")).unwrap();
+            let query = CString::new("{\"pk\": [3]}").unwrap();
+            let out = call_out(|o, n| {
+                kart_repo_find_feature_blobs(
+                    repo,
+                    commits.as_ptr(),
+                    ds_path.as_ptr(),
+                    query.as_ptr(),
+                    o,
+                    n,
+                )
+            });
+            let hits: serde_json::Value = serde_json::from_slice(&out).unwrap();
+            let old_hex = hits[0]["oid"].as_str().unwrap().to_string();
+            let path = hits[0]["path"].as_str().unwrap().to_string();
+
+            // Error paths first (nothing must be mutated by these).
+            let bad_b64 = CString::new(format!("{{\"{old_hex}\": \"!!not-base64!!\"}}")).unwrap();
+            let prefix = CString::new("refs/backup/t1").unwrap();
+            call_err(|o, n| {
+                kart_repo_rewrite_history(repo, bad_b64.as_ptr(), prefix.as_ptr(), o, n)
+            });
+            let bad_oid = CString::new("{\"nothex\": \"aGk=\"}").unwrap();
+            call_err(|o, n| {
+                kart_repo_rewrite_history(repo, bad_oid.as_ptr(), prefix.as_ptr(), o, n)
+            });
+            let not_obj = CString::new("[]").unwrap();
+            call_err(|o, n| {
+                kart_repo_rewrite_history(repo, not_obj.as_ptr(), prefix.as_ptr(), o, n)
+            });
+            call_err(|o, n| {
+                kart_repo_rewrite_history(repo, std::ptr::null(), prefix.as_ptr(), o, n)
+            });
+            // Bad backup prefix (doesn't start with refs/) => rc -1.
+            let subs_json = format!(
+                "{{\"{old_hex}\": \"{}\"}}",
+                B64.encode(b"substituted content")
+            );
+            let subs = CString::new(subs_json).unwrap();
+            let bad_prefix = CString::new("backup/t1").unwrap();
+            call_err(|o, n| {
+                kart_repo_rewrite_history(repo, subs.as_ptr(), bad_prefix.as_ptr(), o, n)
+            });
+
+            // Happy path, with a backup prefix. pk 3 is untouched between the two
+            // commits, so both get rewritten.
+            let out = call_out(|o, n| {
+                kart_repo_rewrite_history(repo, subs.as_ptr(), prefix.as_ptr(), o, n)
+            });
+            let stats: serde_json::Value = serde_json::from_slice(&out).unwrap();
+            assert_eq!(stats["commits_rewritten"], 2);
+            assert_eq!(stats["blobs_written"], 1);
+            assert_eq!(
+                stats["refs_updated"],
+                serde_json::json!(["refs/heads/main"])
+            );
+            assert_eq!(
+                stats["backup_refs"],
+                serde_json::json!(["refs/backup/t1/refs/heads/main"])
+            );
+
+            // Verify via git2: new tip's blob at `path` holds the new content, and the
+            // backup ref preserves the old tip.
+            let git = crate::repo::Repo::open(root.to_str().unwrap()).unwrap();
+            let new_head = git.git.refname_to_id("refs/heads/main").unwrap();
+            assert_ne!(new_head.to_string(), head_hex);
+            let tree = git.git.find_commit(new_head).unwrap().tree().unwrap();
+            let entry = tree.get_path(std::path::Path::new(&path)).unwrap();
+            let blob = git.git.find_blob(entry.id()).unwrap();
+            assert_eq!(blob.content(), b"substituted content");
+            assert_eq!(
+                git.git
+                    .refname_to_id("refs/backup/t1/refs/heads/main")
+                    .unwrap()
+                    .to_string(),
+                head_hex
+            );
+
+            // NULL backup prefix: substitute the NEW blob again => refs move, but no
+            // backup refs are created.
+            let subs2_json = format!(
+                "{{\"{}\": \"{}\"}}",
+                entry.id(),
+                B64.encode(b"substituted again")
+            );
+            let subs2 = CString::new(subs2_json).unwrap();
+            let out = call_out(|o, n| {
+                kart_repo_rewrite_history(repo, subs2.as_ptr(), std::ptr::null(), o, n)
+            });
+            let stats: serde_json::Value = serde_json::from_slice(&out).unwrap();
+            assert_eq!(stats["commits_rewritten"], 2);
+            assert!(stats["refs_updated"]
+                .as_array()
+                .unwrap()
+                .contains(&serde_json::json!("refs/heads/main")));
+            assert_eq!(stats["backup_refs"], serde_json::json!([]));
+
+            kart_dataset_free(ds);
+            kart_repo_free(repo);
+        }
         let _ = std::fs::remove_dir_all(root.parent().unwrap());
     }
 }

--- a/libkart/src/dataset.rs
+++ b/libkart/src/dataset.rs
@@ -31,6 +31,8 @@ pub struct Dataset {
     pub(crate) dataset_type: String,
     /// Dataset path within the repo, e.g. "mylayer".
     pub(crate) path: String,
+    /// Name of the inner dataset dir, e.g. ".table-dataset" or ".sno-dataset".
+    pub(crate) inner_name: String,
     /// Raw contents of the dataset's `meta/` subtree, keyed by path relative to `meta/`
     /// (e.g. "schema.json", "crs/EPSG:4326.wkt", "legend/<hash>").
     pub(crate) meta: HashMap<String, Vec<u8>>,
@@ -99,6 +101,7 @@ impl Dataset {
         Ok(Dataset {
             dataset_type,
             path: path.to_string(),
+            inner_name,
             meta,
             geom_column_name,
             geom_column_id,
@@ -217,6 +220,26 @@ impl Dataset {
         let pk_ids = legend_id_list(it.next().unwrap(), "pk")?;
         let non_pk_ids = legend_id_list(it.next().unwrap(), "non-pk")?;
         Ok((pk_ids, non_pk_ids))
+    }
+
+    /// Path of the feature with the given pk values, relative to the dataset dir,
+    /// e.g. ".table-dataset/feature/A/A/A/B/kUA=". The encoding is configured by
+    /// the `path-structure.json` meta item (absent = legacy encoding).
+    pub fn feature_path(&self, pk_values: &[rmpv::Value]) -> Result<String> {
+        if self.dataset_type != "table" {
+            return Err(Error::Format(format!(
+                "feature paths only apply to table datasets, not {}",
+                self.dataset_type
+            )));
+        }
+        let encoder = crate::paths::PathEncoder::from_path_structure_json(
+            self.meta.get("path-structure.json").map(Vec::as_slice),
+        )?;
+        Ok(format!(
+            "{}/feature/{}",
+            self.inner_name,
+            encoder.encode_pks_to_path(pk_values)?
+        ))
     }
 }
 

--- a/libkart/src/dataset.rs
+++ b/libkart/src/dataset.rs
@@ -6,7 +6,7 @@
 //! access and no live `Repo`.
 
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 
 use git2::{ObjectType, Tree};
 use serde_json::Value;
@@ -44,6 +44,8 @@ pub struct Dataset {
     pub(crate) primary_key: Option<String>,
     /// Cache: legend hash -> index of the geometry value within that legend's non-pk values.
     pub(crate) legend_geom_index: Mutex<HashMap<String, Option<usize>>>,
+    /// Lazily-built feature path encoder (see `feature_path`).
+    pub(crate) path_encoder: OnceLock<crate::paths::PathEncoder>,
 }
 
 impl Dataset {
@@ -107,6 +109,7 @@ impl Dataset {
             geom_column_id,
             primary_key,
             legend_geom_index: Mutex::new(HashMap::new()),
+            path_encoder: OnceLock::new(),
         })
     }
 
@@ -232,9 +235,15 @@ impl Dataset {
                 self.dataset_type
             )));
         }
-        let encoder = crate::paths::PathEncoder::from_path_structure_json(
-            self.meta.get("path-structure.json").map(Vec::as_slice),
-        )?;
+        let encoder = match self.path_encoder.get() {
+            Some(enc) => enc,
+            None => {
+                let enc = crate::paths::PathEncoder::from_path_structure_json(
+                    self.meta.get("path-structure.json").map(Vec::as_slice),
+                )?;
+                self.path_encoder.get_or_init(|| enc)
+            }
+        };
         Ok(format!(
             "{}/feature/{}",
             self.inner_name,

--- a/libkart/src/dataset.rs
+++ b/libkart/src/dataset.rs
@@ -336,21 +336,35 @@ fn parse_columns(bytes: &[u8]) -> Result<Vec<(ColumnInfo, Option<i64>)>> {
 }
 
 /// Parse schema.json bytes, returning (geom_column_name, geom_column_id, primary_key).
+/// Lenient about missing fields: this runs eagerly at open time for every dataset type,
+/// and non-table datasets (e.g. point-cloud) have columns without `id`. The strict
+/// per-column parse (`parse_columns`) is reserved for the table-only helpers.
 fn parse_schema(bytes: &[u8]) -> Result<(Option<String>, Option<String>, Option<String>)> {
-    let cols = parse_columns(bytes)?;
+    let cols: Value = serde_json::from_slice(bytes)?;
+    let arr = cols
+        .as_array()
+        .ok_or_else(|| Error::Format("schema.json is not an array".to_string()))?;
 
-    let geom = cols.iter().find(|(col, _)| col.data_type == "geometry");
-    let geom_name = geom.map(|(col, _)| col.name.clone());
-    let geom_id = geom.map(|(col, _)| col.id.clone());
+    let geom = arr
+        .iter()
+        .find(|col| col.get("dataType").and_then(Value::as_str) == Some("geometry"));
+    let get_str = |col: &Value, field: &str| -> Option<String> {
+        col.get(field).and_then(Value::as_str).map(str::to_string)
+    };
+    let geom_name = geom.and_then(|col| get_str(col, "name"));
+    let geom_id = geom.and_then(|col| get_str(col, "id"));
 
     // Primary key column(s): those with a primaryKeyIndex, sorted by it. Single PK only.
-    let mut pks: Vec<(i64, &ColumnInfo)> = cols
+    let mut pks: Vec<(i64, String)> = arr
         .iter()
-        .filter_map(|(col, idx)| idx.map(|i| (i, col)))
+        .filter_map(|col| {
+            let idx = col.get("primaryKeyIndex").and_then(Value::as_i64)?;
+            Some((idx, get_str(col, "name")?))
+        })
         .collect();
     pks.sort_by_key(|(idx, _)| *idx);
     let primary_key = if pks.len() == 1 {
-        Some(pks[0].1.name.clone())
+        Some(pks.into_iter().next().unwrap().1)
     } else {
         None
     };

--- a/libkart/src/dataset.rs
+++ b/libkart/src/dataset.rs
@@ -14,6 +14,18 @@ use serde_json::Value;
 use crate::error::{Error, Result};
 use crate::repo::{dataset_type_for_dirname, Repo};
 
+/// One column parsed from a dataset's schema.json.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ColumnInfo {
+    /// Kart column id (stable across renames; used in legends).
+    pub id: String,
+    pub name: String,
+    /// Kart data type, e.g. "integer", "text", "geometry".
+    pub data_type: String,
+    /// True iff the column is part of the primary key.
+    pub is_pk: bool,
+}
+
 pub struct Dataset {
     /// Kart dataset type, e.g. "table" or "point-cloud".
     pub(crate) dataset_type: String,
@@ -148,6 +160,80 @@ impl Dataset {
     pub fn meta_item(&self, name: &str) -> Result<Option<Vec<u8>>> {
         Ok(self.meta.get(name).cloned())
     }
+
+    /// All columns from schema.json, paired with their primaryKeyIndex (if any),
+    /// in schema order.
+    fn schema_columns(&self) -> Result<Vec<(ColumnInfo, Option<i64>)>> {
+        let bytes = self
+            .meta
+            .get("schema.json")
+            .ok_or_else(|| Error::NotFound("schema.json not found in dataset meta".to_string()))?;
+        parse_columns(bytes)
+    }
+
+    /// Look up a column by name in schema.json. Returns None if no such column.
+    pub fn column_by_name(&self, name: &str) -> Result<Option<ColumnInfo>> {
+        Ok(self
+            .schema_columns()?
+            .into_iter()
+            .map(|(col, _)| col)
+            .find(|col| col.name == name))
+    }
+
+    /// The primary key columns, in ascending primaryKeyIndex order.
+    pub fn pk_columns(&self) -> Result<Vec<ColumnInfo>> {
+        let mut pks: Vec<(i64, ColumnInfo)> = self
+            .schema_columns()?
+            .into_iter()
+            .filter_map(|(col, idx)| idx.map(|i| (i, col)))
+            .collect();
+        pks.sort_by_key(|(idx, _)| *idx);
+        Ok(pks.into_iter().map(|(_, col)| col).collect())
+    }
+
+    /// Decode the legend blob for `legend_hash` (`meta/legend/<hash>` =
+    /// `msg_pack([pk_ids, non_pk_ids])`), returning (pk column ids, non-pk column ids).
+    pub fn legend(&self, legend_hash: &str) -> Result<(Vec<String>, Vec<String>)> {
+        let key = format!("legend/{legend_hash}");
+        let bytes = self
+            .meta
+            .get(&key)
+            .ok_or_else(|| Error::NotFound(format!("legend not found in meta: {key}")))?;
+
+        let mut cur: &[u8] = bytes;
+        let val = rmpv::decode::read_value(&mut cur)
+            .map_err(|e| Error::Msgpack(format!("legend blob: {e}")))?;
+        let arr = match val {
+            rmpv::Value::Array(arr) => arr,
+            _ => return Err(Error::Format("legend is not a msgpack array".to_string())),
+        };
+        if arr.len() != 2 {
+            return Err(Error::Format(format!(
+                "legend array has {} elements, expected 2",
+                arr.len()
+            )));
+        }
+        let mut it = arr.into_iter();
+        let pk_ids = legend_id_list(it.next().unwrap(), "pk")?;
+        let non_pk_ids = legend_id_list(it.next().unwrap(), "non-pk")?;
+        Ok((pk_ids, non_pk_ids))
+    }
+}
+
+/// Convert one element of a legend array (a msgpack array of strings) to a Vec<String>.
+fn legend_id_list(val: rmpv::Value, label: &str) -> Result<Vec<String>> {
+    let arr = match val {
+        rmpv::Value::Array(arr) => arr,
+        _ => return Err(Error::Format(format!("legend {label} ids is not an array"))),
+    };
+    arr.into_iter()
+        .map(|v| match v {
+            rmpv::Value::String(s) => s
+                .into_str()
+                .ok_or_else(|| Error::Format(format!("legend {label} id is not a string"))),
+            _ => Err(Error::Format(format!("legend {label} id is not a string"))),
+        })
+        .collect()
 }
 
 /// Recursively load all blobs under `tree` into `out`, keyed by path relative to the
@@ -187,35 +273,52 @@ fn load_tree_blobs(
     Ok(())
 }
 
-/// Parse schema.json bytes, returning (geom_column_name, geom_column_id, primary_key).
-fn parse_schema(bytes: &[u8]) -> Result<(Option<String>, Option<String>, Option<String>)> {
+/// Parse schema.json bytes into columns paired with their primaryKeyIndex (if present
+/// and non-null), in schema order.
+fn parse_columns(bytes: &[u8]) -> Result<Vec<(ColumnInfo, Option<i64>)>> {
     let cols: Value = serde_json::from_slice(bytes)?;
     let arr = cols
         .as_array()
         .ok_or_else(|| Error::Format("schema.json is not an array".to_string()))?;
 
-    let mut geom_name = None;
-    let mut geom_id = None;
+    let mut out = Vec::with_capacity(arr.len());
     for col in arr {
-        if col.get("dataType").and_then(Value::as_str) == Some("geometry") {
-            geom_id = col.get("id").and_then(Value::as_str).map(str::to_string);
-            geom_name = col.get("name").and_then(Value::as_str).map(str::to_string);
-            break;
-        }
+        let get_str = |field: &str| -> Result<String> {
+            col.get(field)
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .ok_or_else(|| Error::Format(format!("schema.json column missing {field}")))
+        };
+        let pk_index = col.get("primaryKeyIndex").and_then(Value::as_i64);
+        out.push((
+            ColumnInfo {
+                id: get_str("id")?,
+                name: get_str("name")?,
+                data_type: get_str("dataType")?,
+                is_pk: pk_index.is_some(),
+            },
+            pk_index,
+        ));
     }
+    Ok(out)
+}
+
+/// Parse schema.json bytes, returning (geom_column_name, geom_column_id, primary_key).
+fn parse_schema(bytes: &[u8]) -> Result<(Option<String>, Option<String>, Option<String>)> {
+    let cols = parse_columns(bytes)?;
+
+    let geom = cols.iter().find(|(col, _)| col.data_type == "geometry");
+    let geom_name = geom.map(|(col, _)| col.name.clone());
+    let geom_id = geom.map(|(col, _)| col.id.clone());
 
     // Primary key column(s): those with a primaryKeyIndex, sorted by it. Single PK only.
-    let mut pks: Vec<(i64, String)> = Vec::new();
-    for col in arr {
-        if let Some(idx) = col.get("primaryKeyIndex").and_then(Value::as_i64) {
-            if let Some(name) = col.get("name").and_then(Value::as_str) {
-                pks.push((idx, name.to_string()));
-            }
-        }
-    }
+    let mut pks: Vec<(i64, &ColumnInfo)> = cols
+        .iter()
+        .filter_map(|(col, idx)| idx.map(|i| (i, col)))
+        .collect();
     pks.sort_by_key(|(idx, _)| *idx);
     let primary_key = if pks.len() == 1 {
-        Some(pks.into_iter().next().unwrap().1)
+        Some(pks[0].1.name.clone())
     } else {
         None
     };
@@ -230,10 +333,14 @@ mod tests {
     use std::process::Command;
 
     /// Extract a fixture tgz into a fresh temp dir, returning the repo root path.
-    fn extract_fixture(tgz: &str, subdir: &str) -> std::path::PathBuf {
+    fn extract_fixture(tgz: &str, subdir: &str, label: &str) -> std::path::PathBuf {
         disable_owner_validation();
-        let base =
-            std::env::temp_dir().join(format!("libkart-test-{}-{}", subdir, std::process::id()));
+        let base = std::env::temp_dir().join(format!(
+            "libkart-test-{}-{}-{}",
+            label,
+            subdir,
+            std::process::id()
+        ));
         let _ = std::fs::remove_dir_all(&base);
         std::fs::create_dir_all(&base).unwrap();
         let status = Command::new("tar")
@@ -252,7 +359,7 @@ mod tests {
 
     #[test]
     fn test_points_repo_and_dataset() {
-        let root = extract_fixture(POINTS_TGZ, "points");
+        let root = extract_fixture(POINTS_TGZ, "points", "ds");
         let repo = Repo::open(root.to_str().unwrap()).unwrap();
 
         // Version.
@@ -301,9 +408,82 @@ mod tests {
         let _ = std::fs::remove_dir_all(root.parent().unwrap());
     }
 
+    /// Return the raw bytes of the first blob found (depth-first) under `tree`.
+    fn first_blob(repo: &Repo, tree: &Tree<'_>) -> Option<Vec<u8>> {
+        for entry in tree.iter() {
+            match entry.kind() {
+                Some(ObjectType::Blob) => {
+                    let obj = entry.to_object(&repo.git).unwrap();
+                    if let Some(blob) = obj.as_blob() {
+                        return Some(blob.content().to_vec());
+                    }
+                }
+                Some(ObjectType::Tree) => {
+                    let child = entry.to_object(&repo.git).unwrap().peel_to_tree().unwrap();
+                    if let Some(found) = first_blob(repo, &child) {
+                        return Some(found);
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn test_column_lookup_and_legend() {
+        let root = extract_fixture(POINTS_TGZ, "points", "cols");
+        let repo = Repo::open(root.to_str().unwrap()).unwrap();
+        let ds = Dataset::open(&repo, "HEAD", "nz_pa_points_topo_150k").unwrap();
+
+        // column_by_name
+        let col = ds.column_by_name("name_ascii").unwrap().unwrap();
+        assert_eq!(col.data_type, "text");
+        assert!(!col.is_pk);
+        let fid = ds.column_by_name("fid").unwrap().unwrap();
+        assert!(fid.is_pk);
+        assert!(ds.column_by_name("no_such_col").unwrap().is_none());
+
+        // legend lookup, via the legend hash referenced by a real feature blob
+        let tree = repo.resolve_tree("HEAD").unwrap();
+        let feat_entry = tree
+            .get_path(std::path::Path::new(
+                "nz_pa_points_topo_150k/.table-dataset/feature",
+            ))
+            .unwrap();
+        let feat_tree = feat_entry
+            .to_object(&repo.git)
+            .unwrap()
+            .peel_to_tree()
+            .unwrap();
+        let blob = first_blob(&repo, &feat_tree).expect("no feature blob found");
+        let (legend_hash, _) = crate::feature::decode_feature(&blob).unwrap();
+
+        let (pk_ids, non_pk_ids) = ds.legend(&legend_hash).unwrap();
+        assert_eq!(pk_ids.len(), 1);
+        let fid_col = ds.column_by_name("fid").unwrap().unwrap();
+        assert_eq!(pk_ids[0], fid_col.id);
+        assert!(non_pk_ids.contains(ds.geom_column_id.as_ref().unwrap()));
+        assert!(!non_pk_ids.contains(&pk_ids[0]));
+
+        // unknown legend hash errors
+        assert!(ds
+            .legend("0000000000000000000000000000000000000000")
+            .is_err());
+
+        // pk_columns
+        let pks = ds.pk_columns().unwrap();
+        assert_eq!(pks.len(), 1);
+        assert_eq!(pks[0].name, "fid");
+        assert_eq!(pks[0].data_type, "integer");
+        assert!(pks[0].is_pk);
+
+        let _ = std::fs::remove_dir_all(root.parent().unwrap());
+    }
+
     #[test]
     fn test_au_census_multi_dataset() {
-        let root = extract_fixture(AU_CENSUS_TGZ, "au-census");
+        let root = extract_fixture(AU_CENSUS_TGZ, "au-census", "ds");
         let repo = Repo::open(root.to_str().unwrap()).unwrap();
         assert_eq!(repo.table_dataset_version().unwrap(), 3);
 

--- a/libkart/src/dataset.rs
+++ b/libkart/src/dataset.rs
@@ -375,30 +375,7 @@ fn parse_schema(bytes: &[u8]) -> Result<(Option<String>, Option<String>, Option<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::disable_owner_validation;
-    use std::process::Command;
-
-    /// Extract a fixture tgz into a fresh temp dir, returning the repo root path.
-    fn extract_fixture(tgz: &str, subdir: &str, label: &str) -> std::path::PathBuf {
-        disable_owner_validation();
-        let base = std::env::temp_dir().join(format!(
-            "libkart-test-{}-{}-{}",
-            label,
-            subdir,
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&base);
-        std::fs::create_dir_all(&base).unwrap();
-        let status = Command::new("tar")
-            .arg("xzf")
-            .arg(tgz)
-            .arg("-C")
-            .arg(&base)
-            .status()
-            .expect("run tar");
-        assert!(status.success(), "tar failed for {tgz}");
-        base.join(subdir)
-    }
+    use crate::test_support::extract_fixture;
 
     const POINTS_TGZ: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/points.tgz");
     const AU_CENSUS_TGZ: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/au-census.tgz");

--- a/libkart/src/feature.rs
+++ b/libkart/src/feature.rs
@@ -23,28 +23,10 @@ pub fn feature_geometry(ds: &Dataset, blob: &[u8]) -> Result<Option<Vec<u8>>> {
         None => return Ok(None),
     };
 
-    // Top level: [legend_hash, non_pk_values].
-    let mut cur = &blob[..];
-    let top = rmpv::decode::read_value(&mut cur)
-        .map_err(|e| Error::Msgpack(format!("feature blob: {e}")))?;
-    let arr = top
-        .as_array()
-        .ok_or_else(|| Error::Format("feature blob is not a msgpack array".to_string()))?;
-    if arr.len() < 2 {
-        return Err(Error::Format(format!(
-            "feature blob array has {} elements, expected >= 2",
-            arr.len()
-        )));
-    }
-    let legend_hash = arr[0]
-        .as_str()
-        .ok_or_else(|| Error::Format("feature legend hash is not a string".to_string()))?;
-    let non_pk_values = arr[1]
-        .as_array()
-        .ok_or_else(|| Error::Format("feature non-pk values is not an array".to_string()))?;
+    let (legend_hash, non_pk_values) = decode_feature(blob)?;
 
     // Resolve (and cache) the geometry value's index within non_pk_values for this legend.
-    let geom_index = resolve_geom_index(ds, legend_hash, geom_id)?;
+    let geom_index = resolve_geom_index(ds, &legend_hash, geom_id)?;
     let geom_index = match geom_index {
         Some(i) => i,
         None => return Ok(None),
@@ -64,6 +46,69 @@ pub fn feature_geometry(ds: &Dataset, blob: &[u8]) -> Result<Option<Vec<u8>>> {
             "expected geometry ext (0x47) or nil, got {other:?}"
         ))),
     }
+}
+
+/// Split a feature blob (`msg_pack([legend_hash, non_pk_values])`) into its
+/// (legend hash, non-pk values) parts. PK values are not in the blob; they're
+/// encoded in the feature's tree path.
+pub fn decode_feature(blob: &[u8]) -> Result<(String, Vec<Value>)> {
+    let mut cur = blob;
+    let top = rmpv::decode::read_value(&mut cur)
+        .map_err(|e| Error::Msgpack(format!("feature blob: {e}")))?;
+    if !cur.is_empty() {
+        return Err(Error::Format(format!(
+            "feature blob has {} trailing bytes after msgpack value",
+            cur.len()
+        )));
+    }
+    let arr = match top {
+        Value::Array(arr) => arr,
+        _ => {
+            return Err(Error::Format(
+                "feature blob is not a msgpack array".to_string(),
+            ))
+        }
+    };
+    if arr.len() != 2 {
+        return Err(Error::Format(format!(
+            "feature blob array has {} elements, expected 2",
+            arr.len()
+        )));
+    }
+    let mut it = arr.into_iter();
+    let legend_hash = match it.next().unwrap() {
+        Value::String(s) => s
+            .into_str()
+            .ok_or_else(|| Error::Format("feature legend hash is not a string".to_string()))?,
+        _ => {
+            return Err(Error::Format(
+                "feature legend hash is not a string".to_string(),
+            ))
+        }
+    };
+    let values = match it.next().unwrap() {
+        Value::Array(v) => v,
+        _ => {
+            return Err(Error::Format(
+                "feature non-pk values is not an array".to_string(),
+            ))
+        }
+    };
+    Ok((legend_hash, values))
+}
+
+/// Inverse of `decode_feature`: serialize (legend_hash, values) back to feature blob
+/// bytes. Must be byte-identical to what kart (msgspec) writes, so that re-encoding
+/// an unmodified feature yields the same blob OID.
+pub fn encode_feature(legend_hash: &str, values: &[Value]) -> Result<Vec<u8>> {
+    let top = Value::Array(vec![
+        Value::from(legend_hash),
+        Value::Array(values.to_vec()),
+    ]);
+    let mut out = Vec::new();
+    rmpv::encode::write_value(&mut out, &top)
+        .map_err(|e| Error::Msgpack(format!("encode feature blob: {e}")))?;
+    Ok(out)
 }
 
 /// Look up the index of the geometry column within the non-pk values list for a given legend,
@@ -127,12 +172,16 @@ mod tests {
     use git2::{ObjectType, Tree};
     use std::process::Command;
 
+    const POINTS_TGZ: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/points.tgz");
     const POLYGONS_TGZ: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/polygons.tgz");
+    const STRING_PKS_TGZ: &str =
+        concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/string-pks.tgz");
 
-    fn extract_fixture(tgz: &str, subdir: &str) -> std::path::PathBuf {
+    fn extract_fixture(tgz: &str, subdir: &str, label: &str) -> std::path::PathBuf {
         crate::test_support::disable_owner_validation();
         let base = std::env::temp_dir().join(format!(
-            "libkart-feattest-{}-{}",
+            "libkart-feattest-{}-{}-{}",
+            label,
             subdir,
             std::process::id()
         ));
@@ -203,9 +252,123 @@ mod tests {
         }
     }
 
+    /// Collect (path, bytes) of every feature blob under the dataset's inner `feature/` tree
+    /// at HEAD.
+    fn all_feature_blobs(repo: &Repo, dataset_path: &str) -> Vec<(String, Vec<u8>)> {
+        let root = repo.resolve_tree("HEAD").unwrap();
+        let ds_entry = root.get_path(std::path::Path::new(dataset_path)).unwrap();
+        let ds_tree = ds_entry
+            .to_object(&repo.git)
+            .unwrap()
+            .peel_to_tree()
+            .unwrap();
+        let inner = ds_tree
+            .iter()
+            .find(|e| e.name() == Some(".table-dataset"))
+            .unwrap();
+        let inner_tree = inner.to_object(&repo.git).unwrap().peel_to_tree().unwrap();
+        let feat_entry = inner_tree.get_name("feature").unwrap();
+        let feat_tree = feat_entry
+            .to_object(&repo.git)
+            .unwrap()
+            .peel_to_tree()
+            .unwrap();
+
+        let mut out = Vec::new();
+        collect_blobs(repo, &feat_tree, "feature", &mut out);
+        out
+    }
+
+    fn collect_blobs(repo: &Repo, tree: &Tree<'_>, prefix: &str, out: &mut Vec<(String, Vec<u8>)>) {
+        for entry in tree.iter() {
+            let name = entry.name().unwrap_or("?");
+            let path = format!("{prefix}/{name}");
+            match entry.kind() {
+                Some(ObjectType::Blob) => {
+                    let obj = entry.to_object(&repo.git).unwrap();
+                    if let Some(blob) = obj.as_blob() {
+                        out.push((path, blob.content().to_vec()));
+                    }
+                }
+                Some(ObjectType::Tree) => {
+                    let obj = entry.to_object(&repo.git).unwrap();
+                    if let Some(child) = obj.as_tree() {
+                        collect_blobs(repo, child, &path, out);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    #[test]
+    fn test_decode_encode_roundtrip_all_fixtures() {
+        for (tgz, subdir, ds_name) in [
+            (POINTS_TGZ, "points", Some("nz_pa_points_topo_150k")),
+            (POLYGONS_TGZ, "polygons", Some("nz_waca_adjustments")),
+            (STRING_PKS_TGZ, "string-pks", None), // discover via list_datasets
+        ] {
+            let root = extract_fixture(tgz, subdir, "roundtrip");
+            let repo = Repo::open(root.to_str().unwrap()).unwrap();
+            let datasets = repo.list_datasets("HEAD").unwrap();
+            let ds_name = match ds_name {
+                Some(n) => n.to_string(),
+                None => {
+                    assert_eq!(datasets.len(), 1, "expected single dataset in {subdir}");
+                    datasets[0].clone()
+                }
+            };
+            assert!(datasets.contains(&ds_name));
+
+            let blobs = all_feature_blobs(&repo, &ds_name);
+            assert!(!blobs.is_empty(), "no feature blobs in {subdir}");
+            for (path, blob) in &blobs {
+                let (legend_hash, values) = decode_feature(blob).unwrap();
+                assert_eq!(legend_hash.len(), 40, "{subdir} {path}: bad legend hash");
+                let encoded = encode_feature(&legend_hash, &values).unwrap();
+                assert_eq!(
+                    &encoded, blob,
+                    "{subdir} {path}: re-encode not byte-identical"
+                );
+            }
+
+            let _ = std::fs::remove_dir_all(root.parent().unwrap());
+        }
+    }
+
+    #[test]
+    fn test_decode_feature_rejects_wrong_element_count() {
+        let legend = "0123456789abcdef0123456789abcdef01234567";
+        // 3-element top-level array: would round-trip lossily, must error.
+        let top = Value::Array(vec![
+            Value::from(legend),
+            Value::Array(vec![Value::from(1)]),
+            Value::from("extra"),
+        ]);
+        let mut blob = Vec::new();
+        rmpv::encode::write_value(&mut blob, &top).unwrap();
+        let err = decode_feature(&blob).unwrap_err();
+        assert!(
+            err.to_string().contains("3 elements, expected 2"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_decode_feature_rejects_trailing_bytes() {
+        let legend = "0123456789abcdef0123456789abcdef01234567";
+        let mut blob = encode_feature(legend, &[Value::from(1)]).unwrap();
+        blob.push(0x00);
+        let err = decode_feature(&blob).unwrap_err();
+        assert!(
+            err.to_string().contains("trailing bytes"),
+            "unexpected error: {err}"
+        );
+    }
+
     #[test]
     fn test_feature_geometry_polygons() {
-        let root = extract_fixture(POLYGONS_TGZ, "polygons");
+        let root = extract_fixture(POLYGONS_TGZ, "polygons", "geom");
         let repo = Repo::open(root.to_str().unwrap()).unwrap();
         let ds = Dataset::open(&repo, "HEAD", "nz_waca_adjustments").unwrap();
         assert_eq!(

--- a/libkart/src/feature.rs
+++ b/libkart/src/feature.rs
@@ -111,6 +111,92 @@ pub fn encode_feature(legend_hash: &str, values: &[Value]) -> Result<Vec<u8>> {
     Ok(out)
 }
 
+/// Return a copy of `blob` with the values of the named columns replaced.
+///
+/// `updates` maps column name -> JSON value; each value is coerced to msgpack
+/// according to the column's Kart data type (this is the only place JSON->msgpack
+/// value coercion lives). Errors if a column is unknown, is part of the primary key,
+/// isn't present in the feature's legend, or the JSON value doesn't fit the column's
+/// data type. Geometry and blob columns can only be set to null (JSON can't express
+/// their binary values).
+pub fn update_feature_blob(
+    ds: &Dataset,
+    blob: &[u8],
+    updates: &serde_json::Map<String, serde_json::Value>,
+) -> Result<Vec<u8>> {
+    let (legend_hash, mut values) = decode_feature(blob)?;
+    let (_, non_pk_ids) = ds.legend(&legend_hash)?;
+
+    for (name, json_val) in updates {
+        let col = ds
+            .column_by_name(name)?
+            .ok_or_else(|| Error::NotFound(format!("no column named '{name}' in schema")))?;
+        if col.is_pk {
+            return Err(Error::Format(format!(
+                "cannot update primary key column '{name}'"
+            )));
+        }
+        let index = non_pk_ids
+            .iter()
+            .position(|id| *id == col.id)
+            .ok_or_else(|| {
+                Error::Format(format!(
+                    "column '{name}' is not in this feature's legend {legend_hash}"
+                ))
+            })?;
+        let n_values = values.len();
+        let slot = values.get_mut(index).ok_or_else(|| {
+            Error::Format(format!(
+                "column '{name}' index {index} out of range ({n_values} values)"
+            ))
+        })?;
+        *slot = json_to_msgpack_value(name, &col.data_type, json_val)?;
+    }
+
+    encode_feature(&legend_hash, &values)
+}
+
+/// Coerce a JSON value to the msgpack value kart would store for a column of
+/// `data_type`. Null maps to Nil for any type; otherwise the JSON type must match.
+fn json_to_msgpack_value(name: &str, data_type: &str, val: &serde_json::Value) -> Result<Value> {
+    if val.is_null() {
+        return Ok(Value::Nil);
+    }
+    match data_type {
+        "geometry" => Err(Error::Format(format!(
+            "geometry column '{name}' can only be set to null"
+        ))),
+        "blob" => Err(Error::Format(format!(
+            "blob column '{name}' can only be set to null"
+        ))),
+        "integer" => val.as_i64().map(Value::from).ok_or_else(|| {
+            Error::Format(format!(
+                "integer column '{name}' requires a JSON integer, got {val}"
+            ))
+        }),
+        "float" => val.as_f64().map(Value::F64).ok_or_else(|| {
+            Error::Format(format!(
+                "float column '{name}' requires a JSON number, got {val}"
+            ))
+        }),
+        "boolean" => val.as_bool().map(Value::from).ok_or_else(|| {
+            Error::Format(format!(
+                "boolean column '{name}' requires a JSON boolean, got {val}"
+            ))
+        }),
+        "text" | "date" | "time" | "timestamp" | "interval" | "numeric" => {
+            val.as_str().map(Value::from).ok_or_else(|| {
+                Error::Format(format!(
+                    "{data_type} column '{name}' requires a JSON string, got {val}"
+                ))
+            })
+        }
+        other => Err(Error::Format(format!(
+            "unsupported data type '{other}' for column '{name}'"
+        ))),
+    }
+}
+
 /// Look up the index of the geometry column within the non-pk values list for a given legend,
 /// using the cache in `ds.legend_geom_index`. Returns None if the legend has no geometry column.
 fn resolve_geom_index(ds: &Dataset, legend_hash: &str, geom_id: &str) -> Result<Option<usize>> {
@@ -364,6 +450,72 @@ mod tests {
             err.to_string().contains("trailing bytes"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn test_update_feature_blob_values() {
+        let root = extract_fixture(POINTS_TGZ, "points", "update");
+        let repo = Repo::open(root.to_str().unwrap()).unwrap();
+        let ds = Dataset::open(&repo, "HEAD", "nz_pa_points_topo_150k").unwrap();
+        let blob = first_feature_blob(&repo, "nz_pa_points_topo_150k");
+
+        let updates = serde_json::json!({"name_ascii": "REDACTED", "t50_fid": null});
+        let updates = updates.as_object().unwrap();
+        let new_blob = update_feature_blob(&ds, &blob, updates).unwrap();
+        assert_ne!(new_blob, blob);
+
+        // Legend unchanged; updated indexes hold new values; all others byte-identical.
+        let (old_lh, old_values) = decode_feature(&blob).unwrap();
+        let (new_lh, new_values) = decode_feature(&new_blob).unwrap();
+        assert_eq!(new_lh, old_lh);
+        assert_eq!(new_values.len(), old_values.len());
+        let (_, non_pk_ids) = ds.legend(&old_lh).unwrap();
+        let idx_of = |name: &str| {
+            let col = ds.column_by_name(name).unwrap().unwrap();
+            non_pk_ids.iter().position(|id| *id == col.id).unwrap()
+        };
+        let name_idx = idx_of("name_ascii");
+        let t50_idx = idx_of("t50_fid");
+        assert_eq!(new_values[name_idx], Value::from("REDACTED"));
+        assert_eq!(new_values[t50_idx], Value::Nil);
+        for (i, (old, new)) in old_values.iter().zip(new_values.iter()).enumerate() {
+            if i != name_idx && i != t50_idx {
+                assert_eq!(old, new, "value {i} changed unexpectedly");
+            }
+        }
+
+        // Idempotency: applying the same updates to new_blob returns new_blob.
+        let again = update_feature_blob(&ds, &new_blob, updates).unwrap();
+        assert_eq!(again, new_blob);
+
+        // Integer column accepts a JSON integer, rejects string / non-integer number.
+        let int_ok = serde_json::json!({"t50_fid": 99});
+        let int_blob = update_feature_blob(&ds, &blob, int_ok.as_object().unwrap()).unwrap();
+        let (_, int_values) = decode_feature(&int_blob).unwrap();
+        assert_eq!(int_values[t50_idx], Value::from(99));
+        let int_str = serde_json::json!({"t50_fid": "hello"});
+        assert!(update_feature_blob(&ds, &blob, int_str.as_object().unwrap()).is_err());
+        let int_frac = serde_json::json!({"t50_fid": 1.5});
+        assert!(update_feature_blob(&ds, &blob, int_frac.as_object().unwrap()).is_err());
+
+        // Geometry column: null accepted, non-null rejected.
+        let geom_null = serde_json::json!({"geom": null});
+        let geom_blob = update_feature_blob(&ds, &blob, geom_null.as_object().unwrap()).unwrap();
+        assert_eq!(feature_geometry(&ds, &geom_blob).unwrap(), None);
+        let geom_str = serde_json::json!({"geom": "not allowed"});
+        assert!(update_feature_blob(&ds, &blob, geom_str.as_object().unwrap()).is_err());
+
+        // Unknown column and pk column rejected.
+        let unknown = serde_json::json!({"nope": 1});
+        assert!(update_feature_blob(&ds, &blob, unknown.as_object().unwrap()).is_err());
+        let pk = serde_json::json!({"fid": 1});
+        assert!(update_feature_blob(&ds, &blob, pk.as_object().unwrap()).is_err());
+
+        // Empty updates round-trip byte-identically.
+        let empty = serde_json::Map::new();
+        assert_eq!(update_feature_blob(&ds, &blob, &empty).unwrap(), blob);
+
+        let _ = std::fs::remove_dir_all(root.parent().unwrap());
     }
 
     #[test]

--- a/libkart/src/feature.rs
+++ b/libkart/src/feature.rs
@@ -255,34 +255,13 @@ fn geom_index_from_legend(bytes: &[u8], geom_id: &str) -> Result<Option<usize>> 
 mod tests {
     use super::*;
     use crate::repo::Repo;
+    use crate::test_support::extract_fixture;
     use git2::{ObjectType, Tree};
-    use std::process::Command;
 
     const POINTS_TGZ: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/points.tgz");
     const POLYGONS_TGZ: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/polygons.tgz");
     const STRING_PKS_TGZ: &str =
         concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/string-pks.tgz");
-
-    fn extract_fixture(tgz: &str, subdir: &str, label: &str) -> std::path::PathBuf {
-        crate::test_support::disable_owner_validation();
-        let base = std::env::temp_dir().join(format!(
-            "libkart-feattest-{}-{}-{}",
-            label,
-            subdir,
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&base);
-        std::fs::create_dir_all(&base).unwrap();
-        let status = Command::new("tar")
-            .arg("xzf")
-            .arg(tgz)
-            .arg("-C")
-            .arg(&base)
-            .status()
-            .expect("run tar");
-        assert!(status.success(), "tar failed for {tgz}");
-        base.join(subdir)
-    }
 
     /// Find the first feature blob bytes under the dataset's inner `feature/` tree.
     fn first_feature_blob(repo: &Repo, dataset_path: &str) -> Vec<u8> {

--- a/libkart/src/gpkg.rs
+++ b/libkart/src/gpkg.rs
@@ -216,7 +216,7 @@ fn swap_geometry(wkb: &[u8], pos: &mut usize, out: &mut Vec<u8>) -> Result<()> {
                 swap_doubles(wkb, pos, out, dims * n as usize, src_le)?;
             }
         }
-        4 | 5 | 6 | 7 => {
+        4..=7 => {
             // Multi* / GeometryCollection: u32 sub count, each is a full sub-geometry
             let subs = swap_count(wkb, pos, out, src_le)?;
             for _ in 0..subs {

--- a/libkart/src/lib.rs
+++ b/libkart/src/lib.rs
@@ -22,6 +22,7 @@ mod handle;
 pub mod dataset;
 pub mod feature;
 pub mod gpkg;
+pub mod paths;
 pub mod repo;
 pub mod tile;
 

--- a/libkart/src/lib.rs
+++ b/libkart/src/lib.rs
@@ -25,6 +25,7 @@ pub mod gpkg;
 pub mod paths;
 pub mod query;
 pub mod repo;
+pub mod rewrite;
 pub mod tile;
 
 pub use error::{Error, Result};

--- a/libkart/src/lib.rs
+++ b/libkart/src/lib.rs
@@ -23,6 +23,7 @@ pub mod dataset;
 pub mod feature;
 pub mod gpkg;
 pub mod paths;
+pub mod query;
 pub mod repo;
 pub mod tile;
 

--- a/libkart/src/lib.rs
+++ b/libkart/src/lib.rs
@@ -47,4 +47,28 @@ pub(crate) mod test_support {
             let _ = git2::opts::set_verify_owner_validation(false);
         }
     }
+
+    /// Extract a `.tgz` fixture repo into a fresh per-test temp dir and return the
+    /// path to `subdir` within it. `label` must be unique per (fixture, test) so
+    /// parallel tests don't clobber each other's directories.
+    pub(crate) fn extract_fixture(tgz: &str, subdir: &str, label: &str) -> std::path::PathBuf {
+        disable_owner_validation();
+        let base = std::env::temp_dir().join(format!(
+            "libkart-test-{}-{}-{}",
+            label,
+            subdir,
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).unwrap();
+        let status = std::process::Command::new("tar")
+            .arg("xzf")
+            .arg(tgz)
+            .arg("-C")
+            .arg(&base)
+            .status()
+            .expect("run tar");
+        assert!(status.success(), "tar failed for {tgz}");
+        base.join(subdir)
+    }
 }

--- a/libkart/src/paths.rs
+++ b/libkart/src/paths.rs
@@ -243,8 +243,8 @@ mod tests {
     use super::*;
     use crate::dataset::Dataset;
     use crate::repo::Repo;
+    use crate::test_support::extract_fixture;
     use git2::{ObjectType, Tree};
-    use std::process::Command;
 
     const POINTS_TGZ: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/points.tgz");
     const STRING_PKS_TGZ: &str =
@@ -353,27 +353,6 @@ mod tests {
     }
 
     // ---- fixture round-trip: re-encode every feature path in real repos ----
-
-    fn extract_fixture(tgz: &str, subdir: &str, label: &str) -> std::path::PathBuf {
-        crate::test_support::disable_owner_validation();
-        let base = std::env::temp_dir().join(format!(
-            "libkart-pathtest-{}-{}-{}",
-            label,
-            subdir,
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&base);
-        std::fs::create_dir_all(&base).unwrap();
-        let status = Command::new("tar")
-            .arg("xzf")
-            .arg(tgz)
-            .arg("-C")
-            .arg(&base)
-            .status()
-            .expect("run tar");
-        assert!(status.success(), "tar failed for {tgz}");
-        base.join(subdir)
-    }
 
     /// Collect the dataset-relative path of every feature blob (e.g.
     /// ".table-dataset/feature/A/A/A/B/kUA=").

--- a/libkart/src/paths.rs
+++ b/libkart/src/paths.rs
@@ -1,0 +1,470 @@
+//! Feature path encoding (table datasets).
+//!
+//! A feature's blob lives at `<ds_path>/<inner>/feature/<tree path>/<filename>` where
+//! the tree path and filename are computed from the primary key values. The encoding is
+//! configured by the dataset's `meta/path-structure.json`; datasets without that meta
+//! item use the legacy encoding. Reference: kart/tabular/v3_paths.py.
+
+use rmpv::Value;
+use sha2::{Digest, Sha256};
+
+use crate::error::{Error, Result};
+
+const HEX_ALPHABET: &[u8] = b"0123456789abcdef";
+// RFC 3548 urlsafe base64 alphabet.
+const BASE64_URLSAFE_ALPHABET: &[u8] =
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Scheme {
+    /// Single integer pk: tree path is `(pk // branches) % branches**levels` in
+    /// fixed-length base-`alphabet` digits.
+    Int,
+    /// Any pks: tree path is the first `levels` groups of the encoded
+    /// `sha256(msg_pack(pk_values))`.
+    MsgpackHash,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Encoding {
+    Hex,
+    Base64,
+}
+
+/// Computes the feature path (tree path + filename) for a set of pk values.
+pub struct PathEncoder {
+    scheme: Scheme,
+    branches: u64,
+    levels: usize,
+    encoding: Encoding,
+    alphabet: &'static [u8],
+    /// Number of alphabet chars per tree level (1 for base64/64, 2 for hex/256).
+    group_length: usize,
+}
+
+impl PathEncoder {
+    /// Build an encoder from the raw bytes of `meta/path-structure.json`.
+    /// `None` (meta item absent) means the legacy encoding: msgpack/hash,
+    /// 256 branches, 2 levels, hex.
+    pub fn from_path_structure_json(bytes: Option<&[u8]>) -> Result<PathEncoder> {
+        let (scheme, branches, levels, encoding) = match bytes {
+            None => ("msgpack/hash".to_string(), 256, 2, "hex".to_string()),
+            Some(bytes) => {
+                let val: serde_json::Value = serde_json::from_slice(bytes)?;
+                let get_str = |field: &str| -> Result<String> {
+                    val.get(field)
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_string)
+                        .ok_or_else(|| {
+                            Error::Format(format!("path-structure.json missing {field}"))
+                        })
+                };
+                let get_u64 = |field: &str| -> Result<u64> {
+                    val.get(field)
+                        .and_then(serde_json::Value::as_u64)
+                        .ok_or_else(|| {
+                            Error::Format(format!("path-structure.json missing {field}"))
+                        })
+                };
+                (
+                    get_str("scheme")?,
+                    get_u64("branches")?,
+                    get_u64("levels")? as usize,
+                    get_str("encoding")?,
+                )
+            }
+        };
+
+        let scheme = match scheme.as_str() {
+            "int" => Scheme::Int,
+            "msgpack/hash" => Scheme::MsgpackHash,
+            other => {
+                return Err(Error::Format(format!(
+                    "unsupported feature path scheme: {other:?}"
+                )))
+            }
+        };
+        let (encoding, alphabet) = match encoding.as_str() {
+            "hex" => (Encoding::Hex, HEX_ALPHABET),
+            "base64" => (Encoding::Base64, BASE64_URLSAFE_ALPHABET),
+            other => {
+                return Err(Error::Format(format!(
+                    "unsupported feature path encoding: {other:?}"
+                )))
+            }
+        };
+
+        // group_length: how many base-`alphabet` digits make up one level (branches
+        // must be an exact power of the alphabet size).
+        let base = alphabet.len() as u64;
+        let group_length = (1..=8)
+            .find(|gl| base.checked_pow(*gl as u32) == Some(branches))
+            .ok_or_else(|| {
+                Error::Format(format!(
+                    "invalid path specification: {encoding:?} encoding and {branches} branches are incompatible"
+                ))
+            })?;
+
+        // Sanity-bound levels so later arithmetic/slicing can't overflow or panic.
+        // (Kart only ever writes levels=2 or levels=4; hash tree paths can't be longer
+        // than the encoded hash.)
+        let max_levels = match encoding {
+            Encoding::Hex => 64 / group_length,    // sha256 hexdigest
+            Encoding::Base64 => 27 / group_length, // b64 of 20 digest bytes, minus padding
+        };
+        if levels == 0 || levels > max_levels {
+            return Err(Error::Format(format!(
+                "invalid path specification: {levels} levels not in range 1..={max_levels}"
+            )));
+        }
+
+        Ok(PathEncoder {
+            scheme,
+            branches,
+            levels,
+            encoding,
+            alphabet,
+            group_length,
+        })
+    }
+
+    /// The path (tree path + `/` + filename) for a feature with the given pk values,
+    /// relative to the dataset's `feature/` tree. e.g. "A/A/A/B/kUA=".
+    pub fn encode_pks_to_path(&self, pk_values: &[Value]) -> Result<String> {
+        let packed = pack_pk_values(pk_values)?;
+        let filename = b64_urlsafe_encode(&packed);
+        let tree_path = match self.scheme {
+            Scheme::Int => self.int_tree_path(pk_values)?,
+            Scheme::MsgpackHash => self.hash_tree_path(&packed),
+        };
+        Ok(format!("{tree_path}/{filename}"))
+    }
+
+    /// Tree path for the int scheme: requires exactly one integer pk.
+    fn int_tree_path(&self, pk_values: &[Value]) -> Result<String> {
+        let pk: i128 = match pk_values {
+            [Value::Integer(i)] => i
+                .as_i64()
+                .map(i128::from)
+                .or_else(|| i.as_u64().map(i128::from))
+                .ok_or_else(|| {
+                    Error::Format("int path scheme: pk out of integer range".to_string())
+                })?,
+            _ => {
+                return Err(Error::Format(
+                    "int path scheme can only encode a single integer pk value".to_string(),
+                ))
+            }
+        };
+        // Python semantics: (pk // branches) % branches**levels (floor div, non-negative mod).
+        let branches = self.branches as i128;
+        let max_trees = branches.checked_pow(self.levels as u32).ok_or_else(|| {
+            Error::Format(format!(
+                "invalid path specification: {}**{} overflows",
+                self.branches, self.levels
+            ))
+        })?;
+        let n = pk.div_euclid(branches).rem_euclid(max_trees) as u128;
+        Ok(self.encode_fixed_int(n))
+    }
+
+    /// Render `n` as `levels * group_length` base-`alphabet` digits (most significant
+    /// first), `/`-joined in groups of `group_length` chars.
+    fn encode_fixed_int(&self, mut n: u128) -> String {
+        let base = self.alphabet.len() as u128;
+        let total = self.levels * self.group_length;
+        let mut digits = vec![0u8; total];
+        for slot in digits.iter_mut().rev() {
+            *slot = self.alphabet[(n % base) as usize];
+            n /= base;
+        }
+        digits
+            .chunks(self.group_length)
+            .map(|g| std::str::from_utf8(g).unwrap())
+            .collect::<Vec<_>>()
+            .join("/")
+    }
+
+    /// Tree path for the msgpack/hash scheme: the first `levels` groups of
+    /// `group_length` chars of the encoded `sha256(packed_pks)`.
+    fn hash_tree_path(&self, packed: &[u8]) -> String {
+        let digest = Sha256::digest(packed);
+        let encoded = match self.encoding {
+            // hexhash: hexdigest()[:40]; only levels*group_length chars are used.
+            Encoding::Hex => digest
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect::<String>(),
+            // b64hash: urlsafe base64 of the first 20 digest bytes.
+            Encoding::Base64 => b64_urlsafe_encode(&digest[..20]),
+        };
+        (0..self.levels)
+            .map(|i| &encoded[i * self.group_length..(i + 1) * self.group_length])
+            .collect::<Vec<_>>()
+            .join("/")
+    }
+}
+
+/// msg_pack the pk values array with the canonical msgpack encoding (identical to
+/// what kart writes; see `encode_feature`).
+fn pack_pk_values(pk_values: &[Value]) -> Result<Vec<u8>> {
+    let mut out = Vec::new();
+    rmpv::encode::write_value(&mut out, &Value::Array(pk_values.to_vec()))
+        .map_err(|e| Error::Msgpack(format!("pack pk values: {e}")))?;
+    Ok(out)
+}
+
+/// urlsafe base64 with `=` padding (python `base64.urlsafe_b64encode`).
+fn b64_urlsafe_encode(data: &[u8]) -> String {
+    let mut out = String::with_capacity(data.len().div_ceil(3) * 4);
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = chunk.get(1).map_or(0, |&b| b as u32);
+        let b2 = chunk.get(2).map_or(0, |&b| b as u32);
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        out.push(BASE64_URLSAFE_ALPHABET[(n >> 18) as usize & 63] as char);
+        out.push(BASE64_URLSAFE_ALPHABET[(n >> 12) as usize & 63] as char);
+        out.push(if chunk.len() > 1 {
+            BASE64_URLSAFE_ALPHABET[(n >> 6) as usize & 63] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            BASE64_URLSAFE_ALPHABET[n as usize & 63] as char
+        } else {
+            '='
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dataset::Dataset;
+    use crate::repo::Repo;
+    use git2::{ObjectType, Tree};
+    use std::process::Command;
+
+    const POINTS_TGZ: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/points.tgz");
+    const STRING_PKS_TGZ: &str =
+        concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/string-pks.tgz");
+
+    const INT_PK_JSON: &[u8] =
+        br#"{"scheme": "int", "branches": 64, "levels": 4, "encoding": "base64"}"#;
+    const GENERAL_JSON: &[u8] =
+        br#"{"scheme": "msgpack/hash", "branches": 64, "levels": 4, "encoding": "base64"}"#;
+
+    fn int_pk_encoder() -> PathEncoder {
+        PathEncoder::from_path_structure_json(Some(INT_PK_JSON)).unwrap()
+    }
+
+    fn general_encoder() -> PathEncoder {
+        PathEncoder::from_path_structure_json(Some(GENERAL_JSON)).unwrap()
+    }
+
+    fn legacy_encoder() -> PathEncoder {
+        PathEncoder::from_path_structure_json(None).unwrap()
+    }
+
+    fn path(enc: &PathEncoder, pks: &[Value]) -> String {
+        enc.encode_pks_to_path(pks).unwrap()
+    }
+
+    // Golden values generated with kart's Python implementation
+    // (kart.tabular.v3_paths.PathEncoder.*.encode_pks_to_path).
+
+    #[test]
+    fn test_int_pk_encoder_golden() {
+        let enc = int_pk_encoder();
+        assert_eq!(path(&enc, &[Value::from(1)]), "A/A/A/A/kQE=");
+        assert_eq!(path(&enc, &[Value::from(5)]), "A/A/A/A/kQU=");
+        assert_eq!(path(&enc, &[Value::from(64)]), "A/A/A/B/kUA=");
+        assert_eq!(path(&enc, &[Value::from(4096)]), "A/A/B/A/kc0QAA==");
+        assert_eq!(path(&enc, &[Value::from(-3)]), "_/_/_/_/kf0=");
+
+        // Non-integer or multiple pks are rejected.
+        assert!(enc.encode_pks_to_path(&[Value::from("abc")]).is_err());
+        assert!(enc.encode_pks_to_path(&[Value::from("ID-0042")]).is_err());
+        assert!(enc
+            .encode_pks_to_path(&[Value::from(1), Value::from(2)])
+            .is_err());
+        assert!(enc.encode_pks_to_path(&[]).is_err());
+    }
+
+    #[test]
+    fn test_general_encoder_golden() {
+        let enc = general_encoder();
+        assert_eq!(path(&enc, &[Value::from(1)]), "z/c/q/L/kQE=");
+        assert_eq!(path(&enc, &[Value::from(5)]), "d/a/-/3/kQU=");
+        assert_eq!(path(&enc, &[Value::from(64)]), "c/u/2/I/kUA=");
+        assert_eq!(path(&enc, &[Value::from(4096)]), "-/T/Y/0/kc0QAA==");
+        assert_eq!(path(&enc, &[Value::from(-3)]), "A/0/x/i/kf0=");
+        assert_eq!(path(&enc, &[Value::from("abc")]), "b/9/t/Y/kaNhYmM=");
+        assert_eq!(
+            path(&enc, &[Value::from("ID-0042")]),
+            "7/I/4/S/kadJRC0wMDQy"
+        );
+    }
+
+    #[test]
+    fn test_legacy_encoder_golden() {
+        let enc = legacy_encoder();
+        assert_eq!(path(&enc, &[Value::from(1)]), "cd/ca/kQE=");
+        assert_eq!(path(&enc, &[Value::from(5)]), "75/af/kQU=");
+        assert_eq!(path(&enc, &[Value::from(64)]), "72/ed/kUA=");
+        assert_eq!(path(&enc, &[Value::from(4096)]), "f9/36/kc0QAA==");
+        assert_eq!(path(&enc, &[Value::from(-3)]), "03/4c/kf0=");
+        assert_eq!(path(&enc, &[Value::from("abc")]), "6f/db/kaNhYmM=");
+        assert_eq!(path(&enc, &[Value::from("ID-0042")]), "ec/8e/kadJRC0wMDQy");
+    }
+
+    #[test]
+    fn test_invalid_path_structures() {
+        // unknown scheme
+        assert!(PathEncoder::from_path_structure_json(Some(
+            br#"{"scheme": "nope", "branches": 64, "levels": 4, "encoding": "base64"}"#
+        ))
+        .is_err());
+        // unknown encoding
+        assert!(PathEncoder::from_path_structure_json(Some(
+            br#"{"scheme": "int", "branches": 64, "levels": 4, "encoding": "base32"}"#
+        ))
+        .is_err());
+        // branches not a power of the alphabet size
+        assert!(PathEncoder::from_path_structure_json(Some(
+            br#"{"scheme": "int", "branches": 100, "levels": 4, "encoding": "base64"}"#
+        ))
+        .is_err());
+        // missing field
+        assert!(PathEncoder::from_path_structure_json(Some(
+            br#"{"scheme": "int", "levels": 4, "encoding": "base64"}"#
+        ))
+        .is_err());
+        // levels out of range (0, or longer than the encoded hash)
+        assert!(PathEncoder::from_path_structure_json(Some(
+            br#"{"scheme": "int", "branches": 64, "levels": 0, "encoding": "base64"}"#
+        ))
+        .is_err());
+        assert!(PathEncoder::from_path_structure_json(Some(
+            br#"{"scheme": "msgpack/hash", "branches": 64, "levels": 28, "encoding": "base64"}"#
+        ))
+        .is_err());
+    }
+
+    // ---- fixture round-trip: re-encode every feature path in real repos ----
+
+    fn extract_fixture(tgz: &str, subdir: &str, label: &str) -> std::path::PathBuf {
+        crate::test_support::disable_owner_validation();
+        let base = std::env::temp_dir().join(format!(
+            "libkart-pathtest-{}-{}-{}",
+            label,
+            subdir,
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).unwrap();
+        let status = Command::new("tar")
+            .arg("xzf")
+            .arg(tgz)
+            .arg("-C")
+            .arg(&base)
+            .status()
+            .expect("run tar");
+        assert!(status.success(), "tar failed for {tgz}");
+        base.join(subdir)
+    }
+
+    /// Collect the dataset-relative path of every feature blob (e.g.
+    /// ".table-dataset/feature/A/A/A/B/kUA=").
+    fn all_feature_blob_paths(repo: &Repo, dataset_path: &str, inner_name: &str) -> Vec<String> {
+        let root = repo.resolve_tree("HEAD").unwrap();
+        let feat_entry = root
+            .get_path(std::path::Path::new(&format!(
+                "{dataset_path}/{inner_name}/feature"
+            )))
+            .unwrap();
+        let feat_tree = feat_entry
+            .to_object(&repo.git)
+            .unwrap()
+            .peel_to_tree()
+            .unwrap();
+        let mut out = Vec::new();
+        collect_blob_paths(repo, &feat_tree, &format!("{inner_name}/feature"), &mut out);
+        out
+    }
+
+    fn collect_blob_paths(repo: &Repo, tree: &Tree<'_>, prefix: &str, out: &mut Vec<String>) {
+        for entry in tree.iter() {
+            let name = entry.name().unwrap();
+            let path = format!("{prefix}/{name}");
+            match entry.kind() {
+                Some(ObjectType::Blob) => out.push(path),
+                Some(ObjectType::Tree) => {
+                    let child = entry.to_object(&repo.git).unwrap().peel_to_tree().unwrap();
+                    collect_blob_paths(repo, &child, &path, out);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// Inverse of `b64_urlsafe_encode` (test-only).
+    fn b64_urlsafe_decode(s: &str) -> Vec<u8> {
+        let val = |c: u8| -> u32 {
+            BASE64_URLSAFE_ALPHABET
+                .iter()
+                .position(|&a| a == c)
+                .unwrap_or_else(|| panic!("bad base64 char {:?}", c as char)) as u32
+        };
+        let chars: Vec<u8> = s.bytes().filter(|&c| c != b'=').collect();
+        let mut out = Vec::new();
+        for chunk in chars.chunks(4) {
+            let mut n: u32 = 0;
+            for &c in chunk {
+                n = (n << 6) | val(c);
+            }
+            match chunk.len() {
+                4 => out.extend_from_slice(&[(n >> 16) as u8, (n >> 8) as u8, n as u8]),
+                3 => out.extend_from_slice(&[(n >> 10) as u8, (n >> 2) as u8]),
+                2 => out.push((n >> 4) as u8),
+                _ => panic!("bad base64 length"),
+            }
+        }
+        out
+    }
+
+    /// Decode a feature filename back into its pk values.
+    fn decode_filename_to_pks(filename: &str) -> Vec<Value> {
+        let packed = b64_urlsafe_decode(filename);
+        let mut cur: &[u8] = &packed;
+        let val = rmpv::decode::read_value(&mut cur).unwrap();
+        match val {
+            Value::Array(arr) => arr,
+            other => panic!("pk msgpack is not an array: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_feature_path_matches_fixture_tree() {
+        for (tgz, subdir, ds_name) in [
+            (POINTS_TGZ, "points", "nz_pa_points_topo_150k"), // int pk scheme
+            (STRING_PKS_TGZ, "string-pks", "nz_waca_adjustments"), // msgpack/hash base64
+        ] {
+            let root = extract_fixture(tgz, subdir, "tree");
+            let repo = Repo::open(root.to_str().unwrap()).unwrap();
+            let ds = Dataset::open(&repo, "HEAD", ds_name).unwrap();
+
+            let paths = all_feature_blob_paths(&repo, ds_name, ".table-dataset");
+            assert!(!paths.is_empty(), "no feature blobs in {subdir}");
+            for expected_path in &paths {
+                let filename = expected_path.rsplit('/').next().unwrap();
+                let pks = decode_filename_to_pks(filename);
+                let actual = ds.feature_path(&pks).unwrap();
+                assert_eq!(&actual, expected_path, "{subdir}: pks {pks:?}");
+            }
+
+            let _ = std::fs::remove_dir_all(root.parent().unwrap());
+        }
+    }
+}

--- a/libkart/src/query.rs
+++ b/libkart/src/query.rs
@@ -361,32 +361,11 @@ fn value_matches(actual: &MpValue, expected: &JsonValue) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::extract_fixture;
     use serde_json::json;
-    use std::process::Command;
 
     const EDITING_TGZ: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/editing.tgz");
     const POINTS_TGZ: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/points.tgz");
-
-    fn extract_fixture(tgz: &str, subdir: &str, label: &str) -> std::path::PathBuf {
-        crate::test_support::disable_owner_validation();
-        let base = std::env::temp_dir().join(format!(
-            "libkart-querytest-{}-{}-{}",
-            label,
-            subdir,
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&base);
-        std::fs::create_dir_all(&base).unwrap();
-        let status = Command::new("tar")
-            .arg("xzf")
-            .arg(tgz)
-            .arg("-C")
-            .arg(&base)
-            .status()
-            .expect("run tar");
-        assert!(status.success(), "tar failed for {tgz}");
-        base.join(subdir)
-    }
 
     /// The editing fixture has two commits on the `editing` dataset (columns:
     /// integer pk `id`, text `value`): the import, then "R1 edits" which modifies

--- a/libkart/src/query.rs
+++ b/libkart/src/query.rs
@@ -49,6 +49,24 @@ pub fn find_feature_blobs(
     dataset_path: &str,
     query: &FeatureQuery,
 ) -> Result<Vec<FeatureHit>> {
+    // Schema-independent query validation: a malformed query always errors, even
+    // with no commits or no features to look at.
+    if let FeatureQuery::Filter(filter) = query {
+        if filter.is_empty() {
+            return Err(Error::Format("empty feature filter".to_string()));
+        }
+        for (name, expected) in filter {
+            if !matches!(
+                expected,
+                JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) | JsonValue::String(_)
+            ) {
+                return Err(Error::Format(format!(
+                    "filter value for column '{name}' must be a JSON scalar, got {expected}"
+                )));
+            }
+        }
+    }
+
     let mut hits: Vec<FeatureHit> = Vec::new();
     // Pk memo: (feature tree oid, feature-tree-relative path) -> blob oid (if present).
     let mut pk_memo: HashMap<(Oid, String), Option<Oid>> = HashMap::new();
@@ -87,7 +105,9 @@ pub fn find_feature_blobs(
                 let ds_rel = ds.feature_path(pk_values)?;
                 let in_feature = ds_rel
                     .strip_prefix(&format!("{}/feature/", ds.inner_name))
-                    .expect("feature_path returns <inner>/feature/...")
+                    .ok_or_else(|| {
+                        Error::Format(format!("unexpected feature path form: {ds_rel}"))
+                    })?
                     .to_string();
                 let key = (feature_tree.id(), in_feature.clone());
                 let blob_oid = match pk_memo.get(&key) {
@@ -156,11 +176,8 @@ fn filter_matches_at_commit(
     filter: &serde_json::Map<String, JsonValue>,
     memo: &mut FilterMemo,
 ) -> Result<Vec<(String, Oid)>> {
-    if filter.is_empty() {
-        return Err(Error::Format("empty feature filter".to_string()));
-    }
-
     // Resolve column names to ids for this commit's schema; validate column types.
+    // (Schema-independent validation already happened in `find_feature_blobs`.)
     let mut cols: Vec<(String, &JsonValue)> = Vec::with_capacity(filter.len());
     for (name, expected) in filter {
         let col = match ds.column_by_name(name)? {
@@ -177,14 +194,6 @@ fn filter_matches_at_commit(
         if col.is_pk {
             return Err(Error::Format(format!(
                 "cannot filter on primary key column '{name}'; use a pk query instead"
-            )));
-        }
-        if !matches!(
-            expected,
-            JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) | JsonValue::String(_)
-        ) {
-            return Err(Error::Format(format!(
-                "filter value for column '{name}' must be a JSON scalar, got {expected}"
             )));
         }
         cols.push((col.id, expected));
@@ -544,6 +553,16 @@ mod tests {
         .is_err());
         // Empty filter.
         assert!(find_feature_blobs(&repo, &commits, ds_path, &filter(&[])).is_err());
+
+        // Schema-independent validation applies even with an empty commits list.
+        assert!(find_feature_blobs(&repo, &[], ds_path, &filter(&[])).is_err());
+        assert!(find_feature_blobs(
+            &repo,
+            &[],
+            ds_path,
+            &filter(&[("name_ascii", json!({"nested": 1}))])
+        )
+        .is_err());
 
         let _ = std::fs::remove_dir_all(root.parent().unwrap());
     }

--- a/libkart/src/query.rs
+++ b/libkart/src/query.rs
@@ -1,0 +1,550 @@
+//! Multi-commit feature blob search (table datasets).
+//!
+//! Given a list of commits, find the (path, blob oid) of a feature at each commit —
+//! either by primary key (direct tree lookup) or by attribute-equality filter (feature
+//! tree scan + blob decode). Work is memoized across commits: a feature tree (or blob)
+//! already seen at an earlier commit is not re-examined.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use git2::{ObjectType, Oid, Tree};
+use rmpv::Value as MpValue;
+use serde_json::Value as JsonValue;
+
+use crate::dataset::Dataset;
+use crate::error::{Error, Result};
+use crate::feature::decode_feature;
+use crate::repo::Repo;
+
+/// How to locate a feature within a dataset.
+pub enum FeatureQuery {
+    /// Match the feature with exactly these primary key values.
+    Pk(Vec<MpValue>),
+    /// Match every feature whose named columns all equal the given JSON values.
+    /// Filtering on geometry, blob or primary-key columns is an error (use `Pk`
+    /// for the latter). A column name that doesn't exist in a commit's schema, or
+    /// isn't present in a feature's legend, simply matches nothing at that commit /
+    /// for that feature.
+    Filter(serde_json::Map<String, JsonValue>),
+}
+
+/// One matching feature blob at one commit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FeatureHit {
+    pub commit: Oid,
+    /// Blob path relative to the repo root,
+    /// e.g. "mylayer/.table-dataset/feature/A/A/A/A/kQE=".
+    pub path: String,
+    pub blob_oid: Oid,
+}
+
+/// Find the feature blob(s) matching `query` in the dataset at `dataset_path`, at each
+/// of `commits`. Returns hits in `commits` order (for a filter, multiple hits per
+/// commit in feature-tree order). Commits where the dataset or feature is absent
+/// contribute no hits.
+pub fn find_feature_blobs(
+    repo: &Repo,
+    commits: &[Oid],
+    dataset_path: &str,
+    query: &FeatureQuery,
+) -> Result<Vec<FeatureHit>> {
+    let mut hits: Vec<FeatureHit> = Vec::new();
+    // Pk memo: (feature tree oid, feature-tree-relative path) -> blob oid (if present).
+    let mut pk_memo: HashMap<(Oid, String), Option<Oid>> = HashMap::new();
+    let mut filter_memo = FilterMemo::default();
+
+    for &commit in commits {
+        let refish = commit.to_string();
+        let ds = match Dataset::open(repo, &refish, dataset_path) {
+            Ok(ds) => ds,
+            // Dataset doesn't exist at this commit: no hits for it.
+            Err(Error::NotFound(_)) => continue,
+            Err(e) => return Err(e),
+        };
+        if ds.dataset_type != "table" {
+            return Err(Error::Format(format!(
+                "feature queries only apply to table datasets, not {}",
+                ds.dataset_type
+            )));
+        }
+
+        let root = repo.resolve_tree(&refish)?;
+        let feature_prefix = format!("{dataset_path}/{}/feature", ds.inner_name);
+        let feature_tree = match root.get_path(Path::new(&feature_prefix)) {
+            Ok(entry) if entry.kind() == Some(ObjectType::Tree) => {
+                entry.to_object(&repo.git)?.peel_to_tree()?
+            }
+            // No feature tree (e.g. empty dataset): no hits for this commit.
+            Ok(_) => continue,
+            Err(e) if e.code() == git2::ErrorCode::NotFound => continue,
+            Err(e) => return Err(e.into()),
+        };
+
+        match query {
+            FeatureQuery::Pk(pk_values) => {
+                // "<inner>/feature/<tree path>/<filename>" -> "<tree path>/<filename>".
+                let ds_rel = ds.feature_path(pk_values)?;
+                let in_feature = ds_rel
+                    .strip_prefix(&format!("{}/feature/", ds.inner_name))
+                    .expect("feature_path returns <inner>/feature/...")
+                    .to_string();
+                let key = (feature_tree.id(), in_feature.clone());
+                let blob_oid = match pk_memo.get(&key) {
+                    Some(cached) => *cached,
+                    None => {
+                        let found = lookup_blob(&feature_tree, &in_feature)?;
+                        pk_memo.insert(key, found);
+                        found
+                    }
+                };
+                if let Some(blob_oid) = blob_oid {
+                    hits.push(FeatureHit {
+                        commit,
+                        path: format!("{dataset_path}/{ds_rel}"),
+                        blob_oid,
+                    });
+                }
+            }
+            FeatureQuery::Filter(filter) => {
+                let matches =
+                    filter_matches_at_commit(repo, &ds, &feature_tree, filter, &mut filter_memo)?;
+                for (rel, blob_oid) in matches {
+                    hits.push(FeatureHit {
+                        commit,
+                        path: format!("{feature_prefix}/{rel}"),
+                        blob_oid,
+                    });
+                }
+            }
+        }
+    }
+    Ok(hits)
+}
+
+/// Look up `path` under `tree`, returning the blob oid if it names a blob.
+fn lookup_blob(tree: &Tree<'_>, path: &str) -> Result<Option<Oid>> {
+    match tree.get_path(Path::new(path)) {
+        Ok(entry) if entry.kind() == Some(ObjectType::Blob) => Ok(Some(entry.id())),
+        Ok(_) => Ok(None),
+        Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Cross-commit memoization state for filter queries.
+///
+/// Both maps are only valid for a particular column-name -> column-id resolution;
+/// if a commit's schema resolves the filter names to different ids (e.g. a column
+/// was dropped and re-added), the memos are cleared.
+#[derive(Default)]
+struct FilterMemo {
+    /// The column ids the memoized entries were computed with.
+    ids: Vec<String>,
+    /// feature tree oid -> matches within it, as (feature-tree-relative path, blob oid).
+    trees: HashMap<Oid, Vec<(String, Oid)>>,
+    /// feature blob oid -> whether it matches the filter.
+    blobs: HashMap<Oid, bool>,
+}
+
+/// Evaluate `filter` against every feature in `feature_tree`, using and updating
+/// `memo`. Returns (feature-tree-relative path, blob oid) for each match.
+fn filter_matches_at_commit(
+    repo: &Repo,
+    ds: &Dataset,
+    feature_tree: &Tree<'_>,
+    filter: &serde_json::Map<String, JsonValue>,
+    memo: &mut FilterMemo,
+) -> Result<Vec<(String, Oid)>> {
+    if filter.is_empty() {
+        return Err(Error::Format("empty feature filter".to_string()));
+    }
+
+    // Resolve column names to ids for this commit's schema; validate column types.
+    let mut cols: Vec<(String, &JsonValue)> = Vec::with_capacity(filter.len());
+    for (name, expected) in filter {
+        let col = match ds.column_by_name(name)? {
+            Some(col) => col,
+            // Column doesn't exist in this commit's schema: nothing can match.
+            None => return Ok(Vec::new()),
+        };
+        if col.data_type == "geometry" || col.data_type == "blob" {
+            return Err(Error::Format(format!(
+                "cannot filter on {} column '{name}'",
+                col.data_type
+            )));
+        }
+        if col.is_pk {
+            return Err(Error::Format(format!(
+                "cannot filter on primary key column '{name}'; use a pk query instead"
+            )));
+        }
+        if !matches!(
+            expected,
+            JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) | JsonValue::String(_)
+        ) {
+            return Err(Error::Format(format!(
+                "filter value for column '{name}' must be a JSON scalar, got {expected}"
+            )));
+        }
+        cols.push((col.id, expected));
+    }
+
+    // The memos assume a fixed name->id resolution; reset them if it changed.
+    let ids: Vec<String> = cols.iter().map(|(id, _)| id.clone()).collect();
+    if memo.ids != ids {
+        memo.ids = ids;
+        memo.trees.clear();
+        memo.blobs.clear();
+    }
+
+    if let Some(cached) = memo.trees.get(&feature_tree.id()) {
+        return Ok(cached.clone());
+    }
+
+    // Per-commit cache: legend hash -> index of each filter column within the legend's
+    // non-pk values (None = some filter column absent from that legend => no match).
+    let mut legend_indices: HashMap<String, Option<Vec<usize>>> = HashMap::new();
+
+    let mut matches: Vec<(String, Oid)> = Vec::new();
+    walk_filter(
+        repo,
+        ds,
+        feature_tree,
+        "",
+        &cols,
+        &mut legend_indices,
+        &mut memo.blobs,
+        &mut matches,
+    )?;
+    memo.trees.insert(feature_tree.id(), matches.clone());
+    Ok(matches)
+}
+
+/// Recursively walk `tree` (a feature tree or subtree), appending each matching blob
+/// as (`prefix`-relative path, blob oid) to `matches`, in tree order.
+#[allow(clippy::too_many_arguments)]
+fn walk_filter(
+    repo: &Repo,
+    ds: &Dataset,
+    tree: &Tree<'_>,
+    prefix: &str,
+    cols: &[(String, &JsonValue)],
+    legend_indices: &mut HashMap<String, Option<Vec<usize>>>,
+    blob_memo: &mut HashMap<Oid, bool>,
+    matches: &mut Vec<(String, Oid)>,
+) -> Result<()> {
+    for entry in tree.iter() {
+        let name = match entry.name() {
+            Some(n) => n,
+            None => continue,
+        };
+        let rel = if prefix.is_empty() {
+            name.to_string()
+        } else {
+            format!("{prefix}/{name}")
+        };
+        match entry.kind() {
+            Some(ObjectType::Blob) => {
+                let blob_oid = entry.id();
+                let is_match = match blob_memo.get(&blob_oid) {
+                    Some(&m) => m,
+                    None => {
+                        let obj = entry.to_object(&repo.git)?;
+                        let blob = obj
+                            .as_blob()
+                            .ok_or_else(|| Error::Format("blob entry is not a blob".to_string()))?;
+                        let m = blob_matches(ds, blob.content(), cols, legend_indices)?;
+                        blob_memo.insert(blob_oid, m);
+                        m
+                    }
+                };
+                if is_match {
+                    matches.push((rel, blob_oid));
+                }
+            }
+            Some(ObjectType::Tree) => {
+                let child = entry.to_object(&repo.git)?.peel_to_tree()?;
+                walk_filter(
+                    repo,
+                    ds,
+                    &child,
+                    &rel,
+                    cols,
+                    legend_indices,
+                    blob_memo,
+                    matches,
+                )?;
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// Decode one feature blob and test it against the filter columns.
+fn blob_matches(
+    ds: &Dataset,
+    blob: &[u8],
+    cols: &[(String, &JsonValue)],
+    legend_indices: &mut HashMap<String, Option<Vec<usize>>>,
+) -> Result<bool> {
+    let (legend_hash, values) = decode_feature(blob)?;
+
+    let indices = match legend_indices.get(&legend_hash) {
+        Some(cached) => cached.clone(),
+        None => {
+            let (_, non_pk_ids) = ds.legend(&legend_hash)?;
+            let resolved: Option<Vec<usize>> = cols
+                .iter()
+                .map(|(id, _)| non_pk_ids.iter().position(|nid| nid == id))
+                .collect();
+            legend_indices.insert(legend_hash.clone(), resolved.clone());
+            resolved
+        }
+    };
+    // A legend lacking one of the filter columns means the feature can't match.
+    let indices = match indices {
+        Some(idx) => idx,
+        None => return Ok(false),
+    };
+
+    for (i, (_, expected)) in indices.iter().zip(cols) {
+        let actual = values.get(*i).ok_or_else(|| {
+            Error::Format(format!(
+                "feature value index {i} out of range ({} values)",
+                values.len()
+            ))
+        })?;
+        if !value_matches(actual, expected) {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+/// Compare a decoded msgpack feature value against a JSON filter value.
+/// Numbers cross-compare via f64 when the msgpack/JSON numeric types differ.
+fn value_matches(actual: &MpValue, expected: &JsonValue) -> bool {
+    match (actual, expected) {
+        (MpValue::Nil, JsonValue::Null) => true,
+        (MpValue::Boolean(a), JsonValue::Bool(e)) => a == e,
+        (MpValue::String(a), JsonValue::String(e)) => a.as_str() == Some(e.as_str()),
+        (MpValue::Integer(a), JsonValue::Number(e)) => {
+            if let (Some(a), Some(e)) = (a.as_i64(), e.as_i64()) {
+                a == e
+            } else if let (Some(a), Some(e)) = (a.as_u64(), e.as_u64()) {
+                a == e
+            } else {
+                // Mixed numeric types (e.g. msgpack int vs JSON float): compare as f64.
+                match (a.as_f64(), e.as_f64()) {
+                    (Some(a), Some(e)) => a == e,
+                    _ => false,
+                }
+            }
+        }
+        (MpValue::F64(a), JsonValue::Number(e)) => e.as_f64() == Some(*a),
+        (MpValue::F32(a), JsonValue::Number(e)) => e.as_f64() == Some(f64::from(*a)),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::process::Command;
+
+    const EDITING_TGZ: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/editing.tgz");
+    const POINTS_TGZ: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/points.tgz");
+
+    fn extract_fixture(tgz: &str, subdir: &str, label: &str) -> std::path::PathBuf {
+        crate::test_support::disable_owner_validation();
+        let base = std::env::temp_dir().join(format!(
+            "libkart-querytest-{}-{}-{}",
+            label,
+            subdir,
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).unwrap();
+        let status = Command::new("tar")
+            .arg("xzf")
+            .arg(tgz)
+            .arg("-C")
+            .arg(&base)
+            .status()
+            .expect("run tar");
+        assert!(status.success(), "tar failed for {tgz}");
+        base.join(subdir)
+    }
+
+    /// The editing fixture has two commits on the `editing` dataset (columns:
+    /// integer pk `id`, text `value`): the import, then "R1 edits" which modifies
+    /// pks 1/2/4/5, deletes 6/7/12 and adds 8/9/10. pk 3 (value "c") is untouched.
+    fn open_editing(label: &str) -> (std::path::PathBuf, Repo, [Oid; 2]) {
+        let root = extract_fixture(EDITING_TGZ, "editing", label);
+        let repo = Repo::open(root.to_str().unwrap()).unwrap();
+        let head = repo.git.revparse_single("HEAD").unwrap().id();
+        let prev = repo.git.revparse_single("HEAD~1").unwrap().id();
+        (root, repo, [head, prev])
+    }
+
+    fn filter(pairs: &[(&str, JsonValue)]) -> FeatureQuery {
+        let mut map = serde_json::Map::new();
+        for (k, v) in pairs {
+            map.insert(k.to_string(), v.clone());
+        }
+        FeatureQuery::Filter(map)
+    }
+
+    #[test]
+    fn test_find_by_pk_across_commits() {
+        let (root, repo, commits) = open_editing("pk");
+
+        // pk 3 exists at both commits and is untouched between them.
+        let hits = find_feature_blobs(
+            &repo,
+            &commits,
+            "editing",
+            &FeatureQuery::Pk(vec![MpValue::from(3)]),
+        )
+        .unwrap();
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].commit, commits[0]);
+        assert_eq!(hits[1].commit, commits[1]);
+        for hit in &hits {
+            assert_eq!(hit.path, "editing/.table-dataset/feature/A/A/A/A/kQM=");
+        }
+        assert_eq!(hits[0].blob_oid, hits[1].blob_oid);
+
+        // pk 1 was modified by "R1 edits": same path, different blob at each commit.
+        let hits = find_feature_blobs(
+            &repo,
+            &commits,
+            "editing",
+            &FeatureQuery::Pk(vec![MpValue::from(1)]),
+        )
+        .unwrap();
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].path, "editing/.table-dataset/feature/A/A/A/A/kQE=");
+        assert_eq!(hits[1].path, hits[0].path);
+        assert_ne!(hits[0].blob_oid, hits[1].blob_oid);
+
+        // pk 8 was added by "R1 edits": present at HEAD only.
+        let hits = find_feature_blobs(
+            &repo,
+            &commits,
+            "editing",
+            &FeatureQuery::Pk(vec![MpValue::from(8)]),
+        )
+        .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].commit, commits[0]);
+
+        let _ = std::fs::remove_dir_all(root.parent().unwrap());
+    }
+
+    #[test]
+    fn test_find_by_filter() {
+        let (root, repo, commits) = open_editing("filter");
+
+        // value "c" is pk 3's value at both commits; the filter result must equal
+        // the pk lookup result exactly.
+        let by_filter = find_feature_blobs(
+            &repo,
+            &commits,
+            "editing",
+            &filter(&[("value", json!("c"))]),
+        )
+        .unwrap();
+        let by_pk = find_feature_blobs(
+            &repo,
+            &commits,
+            "editing",
+            &FeatureQuery::Pk(vec![MpValue::from(3)]),
+        )
+        .unwrap();
+        assert_eq!(by_filter, by_pk);
+        assert_eq!(by_filter.len(), 2);
+
+        // value "a" only exists at the older commit (pk 1 was edited to "a1" at HEAD).
+        let hits = find_feature_blobs(
+            &repo,
+            &commits,
+            "editing",
+            &filter(&[("value", json!("a"))]),
+        )
+        .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].commit, commits[1]);
+        assert_eq!(hits[0].path, "editing/.table-dataset/feature/A/A/A/A/kQE=");
+
+        // A filter matching nothing anywhere.
+        let hits = find_feature_blobs(
+            &repo,
+            &commits,
+            "editing",
+            &filter(&[("value", json!("no-such-value"))]),
+        )
+        .unwrap();
+        assert!(hits.is_empty());
+
+        // A column that exists in no commit's schema matches nothing (not an error).
+        let hits = find_feature_blobs(
+            &repo,
+            &commits,
+            "editing",
+            &filter(&[("no_such_column", json!(1))]),
+        )
+        .unwrap();
+        assert!(hits.is_empty());
+
+        let _ = std::fs::remove_dir_all(root.parent().unwrap());
+    }
+
+    #[test]
+    fn test_find_missing_pk_returns_empty() {
+        let (root, repo, commits) = open_editing("missing");
+        let hits = find_feature_blobs(
+            &repo,
+            &commits,
+            "editing",
+            &FeatureQuery::Pk(vec![MpValue::from(999999)]),
+        )
+        .unwrap();
+        assert!(hits.is_empty());
+        let _ = std::fs::remove_dir_all(root.parent().unwrap());
+    }
+
+    #[test]
+    fn test_filter_on_geometry_or_pk_column_errors() {
+        let root = extract_fixture(POINTS_TGZ, "points", "badfilter");
+        let repo = Repo::open(root.to_str().unwrap()).unwrap();
+        let head = repo.git.revparse_single("HEAD").unwrap().id();
+        let commits = [head];
+        let ds_path = "nz_pa_points_topo_150k";
+
+        // Geometry column.
+        assert!(
+            find_feature_blobs(&repo, &commits, ds_path, &filter(&[("geom", json!(null))]))
+                .is_err()
+        );
+        // Primary key column.
+        assert!(
+            find_feature_blobs(&repo, &commits, ds_path, &filter(&[("fid", json!(1))])).is_err()
+        );
+        // Non-scalar filter value.
+        assert!(find_feature_blobs(
+            &repo,
+            &commits,
+            ds_path,
+            &filter(&[("name_ascii", json!(["a", "b"]))])
+        )
+        .is_err());
+        // Empty filter.
+        assert!(find_feature_blobs(&repo, &commits, ds_path, &filter(&[])).is_err());
+
+        let _ = std::fs::remove_dir_all(root.parent().unwrap());
+    }
+}

--- a/libkart/src/repo.rs
+++ b/libkart/src/repo.rs
@@ -107,10 +107,10 @@ impl Repo {
         // 2) Fall back to git config.
         let cfg = self.git.config()?;
         if let Ok(v) = cfg.get_i32("kart.repostructure.version") {
-            return Ok(v as i32);
+            return Ok(v);
         }
         if let Ok(v) = cfg.get_i32("sno.repository.version") {
-            return Ok(v as i32);
+            return Ok(v);
         }
         // 3) Default.
         Ok(3)
@@ -176,34 +176,10 @@ impl Repo {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::disable_owner_validation;
-    use std::process::Command;
+    use crate::test_support::extract_fixture;
 
     const POINTS_TGZ: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/points.tgz");
     const AU_CENSUS_TGZ: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/au-census.tgz");
-
-    /// Extract a fixture tgz into a fresh temp dir, returning the repo root path.
-    /// `tag` is a per-test label so parallel tests on the same fixture don't collide.
-    fn extract_fixture(tgz: &str, subdir: &str, tag: &str) -> std::path::PathBuf {
-        disable_owner_validation();
-        let base = std::env::temp_dir().join(format!(
-            "libkart-repotest-{}-{}-{}",
-            tag,
-            subdir,
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&base);
-        std::fs::create_dir_all(&base).unwrap();
-        let status = Command::new("tar")
-            .arg("xzf")
-            .arg(tgz)
-            .arg("-C")
-            .arg(&base)
-            .status()
-            .expect("run tar");
-        assert!(status.success(), "tar failed for {tgz}");
-        base.join(subdir)
-    }
 
     #[test]
     fn test_is_dataset_dirname() {
@@ -221,7 +197,7 @@ mod tests {
         let root = extract_fixture(POINTS_TGZ, "points", "open");
         let repo = Repo::open(root.to_str().unwrap()).unwrap();
         // HEAD resolves to a non-empty tree.
-        assert!(repo.resolve_tree("HEAD").unwrap().len() > 0);
+        assert!(!repo.resolve_tree("HEAD").unwrap().is_empty());
         let _ = std::fs::remove_dir_all(root.parent().unwrap());
     }
 

--- a/libkart/src/rewrite.rs
+++ b/libkart/src/rewrite.rs
@@ -1,0 +1,594 @@
+//! Generic history rewrite with blob substitution.
+//!
+//! Given a map of `blob oid -> replacement content`, rewrite every commit reachable
+//! from the repo's refs so that no tree references the old blobs, preserving commit
+//! identity for untouched history, then atomically flip the refs to the rewritten
+//! tips. Optional backup refs keep the pre-rewrite tips reachable so a bad rewrite
+//! can be undone without data loss.
+
+use std::collections::HashMap;
+
+use git2::{ObjectType, Oid, Sort};
+
+use crate::error::{Error, Result};
+use crate::repo::Repo;
+
+/// Statistics returned by [`rewrite_history`].
+#[derive(Debug)]
+pub struct RewriteStats {
+    /// Number of new commit objects created.
+    pub commits_rewritten: usize,
+    /// Number of substitution blobs written to the object database.
+    pub blobs_written: usize,
+    /// Original ref names whose tips were moved to rewritten commits.
+    pub refs_updated: Vec<String>,
+    /// Backup ref names created (empty when no prefix was given or nothing changed).
+    pub backup_refs: Vec<String>,
+}
+
+/// Rewrite all commits reachable from the repo's direct refs, replacing every tree
+/// entry whose blob oid is a key of `substitutions` with a new blob holding the
+/// mapped content (filemode preserved). Commits whose tree and parents are unchanged
+/// keep their original oid. When `backup_ref_prefix` is given (it must start with
+/// `refs/`), a backup ref `{prefix}/{original_ref_name}` pointing at the old tip is
+/// created for each changed ref, and refs under the prefix are excluded from the
+/// rewrite. Backup creation and ref flips happen in ONE atomic ref transaction, so
+/// either all backups exist and all refs are flipped, or nothing changed. Errors
+/// before mutating any ref if a needed backup ref already exists, or if any ref
+/// points to an annotated tag (which would silently keep old history reachable).
+pub fn rewrite_history(
+    repo: &Repo,
+    substitutions: &HashMap<Oid, Vec<u8>>,
+    backup_ref_prefix: Option<&str>,
+) -> Result<RewriteStats> {
+    // Backup refs must live under refs/ or git reachability (and gc) would ignore
+    // them, silently defeating their whole purpose.
+    let backup_prefix = backup_ref_prefix.map(|p| p.trim_end_matches('/'));
+    if let Some(prefix) = backup_prefix {
+        if !prefix.starts_with("refs/") {
+            return Err(Error::Format(format!(
+                "backup ref prefix '{prefix}' must start with 'refs/'"
+            )));
+        }
+    }
+
+    // 1. Write the replacement blobs up front (object writes are additive/safe).
+    let odb = repo.git.odb()?;
+    let mut blob_map: HashMap<Oid, Oid> = HashMap::with_capacity(substitutions.len());
+    for (&old_oid, content) in substitutions {
+        let new_oid = odb.write(ObjectType::Blob, content)?;
+        blob_map.insert(old_oid, new_oid);
+    }
+    let blobs_written = blob_map.len();
+
+    // 2. Collect the direct refs to rewrite. Backup refs (from this run's prefix,
+    // including any created by prior runs) are excluded; symbolic refs (e.g. HEAD)
+    // follow their target so they need no rewriting of their own.
+    let mut ref_tips: Vec<(String, Oid)> = Vec::new();
+    for reference in repo.git.references()? {
+        let reference = reference?;
+        if reference.kind() != Some(git2::ReferenceType::Direct) {
+            continue;
+        }
+        let name = match reference.name() {
+            Some(n) => n.to_string(),
+            None => {
+                return Err(Error::Format(
+                    "cannot rewrite history: ref with non-UTF-8 name".to_string(),
+                ))
+            }
+        };
+        if let Some(prefix) = backup_prefix {
+            if name == prefix || name.starts_with(&format!("{prefix}/")) {
+                continue;
+            }
+        }
+        let target = reference
+            .target()
+            .expect("direct reference always has a target");
+        match repo.git.find_object(target, None)?.kind() {
+            Some(ObjectType::Commit) => ref_tips.push((name, target)),
+            Some(ObjectType::Tag) => {
+                return Err(Error::Format(format!(
+                    "cannot rewrite history: ref '{name}' points to an annotated tag, \
+                     which is not supported"
+                )))
+            }
+            kind => {
+                return Err(Error::Format(format!(
+                    "cannot rewrite history: ref '{name}' points to a {} object, \
+                     not a commit",
+                    kind.map_or("unknown", |k| k.str())
+                )))
+            }
+        }
+    }
+
+    // 3. Walk every commit parents-first, rewriting trees and remapping parents.
+    let mut walk = repo.git.revwalk()?;
+    walk.set_sorting(Sort::TOPOLOGICAL | Sort::REVERSE)?;
+    for (_, tip) in &ref_tips {
+        walk.push(*tip)?;
+    }
+
+    let mut tree_memo: HashMap<Oid, Oid> = HashMap::new();
+    // old commit oid -> new commit oid; absent means the commit kept its identity.
+    let mut commit_map: HashMap<Oid, Oid> = HashMap::new();
+    let mut commits_rewritten = 0usize;
+
+    for oid in walk {
+        let oid = oid?;
+        let commit = repo.git.find_commit(oid)?;
+        let new_tree_oid = rewrite_tree(repo, commit.tree_id(), &blob_map, &mut tree_memo)?;
+        let new_parents: Vec<Oid> = commit
+            .parent_ids()
+            .map(|p| commit_map.get(&p).copied().unwrap_or(p))
+            .collect();
+        let unchanged =
+            new_tree_oid == commit.tree_id() && new_parents.iter().copied().eq(commit.parent_ids());
+        if unchanged {
+            continue;
+        }
+
+        // git2's commit-creation API only takes &str messages, so a non-UTF-8
+        // message (or a non-UTF-8 encoding header) can't be preserved faithfully.
+        if let Some(encoding) = commit.message_encoding() {
+            if !encoding.eq_ignore_ascii_case("utf-8") {
+                return Err(Error::Format(format!(
+                    "cannot rewrite commit {oid}: unsupported message encoding '{encoding}'"
+                )));
+            }
+        }
+        let message = std::str::from_utf8(commit.message_raw_bytes()).map_err(|_| {
+            Error::Format(format!("cannot rewrite commit {oid}: non-UTF-8 message"))
+        })?;
+
+        let tree = repo.git.find_tree(new_tree_oid)?;
+        let parent_commits: Vec<git2::Commit<'_>> = new_parents
+            .iter()
+            .map(|p| repo.git.find_commit(*p))
+            .collect::<std::result::Result<_, git2::Error>>()?;
+        let parent_refs: Vec<&git2::Commit<'_>> = parent_commits.iter().collect();
+        // No ref update yet (update_ref=None); refs flip atomically below.
+        // GPG signatures are dropped, as is standard for history rewrites.
+        let new_oid = repo.git.commit(
+            None,
+            &commit.author(),
+            &commit.committer(),
+            message,
+            &tree,
+            &parent_refs,
+        )?;
+        commit_map.insert(oid, new_oid);
+        commits_rewritten += 1;
+    }
+
+    // 4. Which ref tips changed?
+    let changed: Vec<(String, Oid, Oid)> = ref_tips
+        .into_iter()
+        .filter_map(|(name, tip)| commit_map.get(&tip).map(|&new| (name, tip, new)))
+        .collect();
+    if changed.is_empty() {
+        // Noop: no backup refs are created and no refs move.
+        return Ok(RewriteStats {
+            commits_rewritten,
+            blobs_written,
+            refs_updated: Vec::new(),
+            backup_refs: Vec::new(),
+        });
+    }
+
+    // 5a. Pre-check EVERY backup name before creating (or flipping) anything: a
+    // prior backup must never be silently clobbered, and erroring here — before
+    // any ref mutation — keeps a retry with a fresh prefix fully clean.
+    let backups: Vec<(String, Oid)> = match backup_prefix {
+        Some(prefix) => changed
+            .iter()
+            .map(|(name, old_tip, _)| (format!("{prefix}/{name}"), *old_tip))
+            .collect(),
+        None => Vec::new(),
+    };
+    for (backup_name, _) in &backups {
+        if repo.git.find_reference(backup_name).is_ok() {
+            return Err(Error::Format(format!(
+                "backup ref '{backup_name}' already exists; refusing to overwrite it"
+            )));
+        }
+    }
+
+    // 5b. Create the backup refs and flip the changed refs in ONE atomic ref
+    // transaction (locking a nonexistent name and set_target-ing it creates the
+    // ref at commit time). All-or-nothing: either every backup exists and every
+    // ref is flipped, or nothing changed.
+    let mut tx = repo.git.transaction()?;
+    for (backup_name, _) in &backups {
+        tx.lock_ref(backup_name)?;
+    }
+    for (name, _, _) in &changed {
+        tx.lock_ref(name)?;
+    }
+    for (backup_name, old_tip) in &backups {
+        tx.set_target(
+            backup_name,
+            *old_tip,
+            None,
+            "libkart rewrite_history: backup of pre-rewrite tip",
+        )?;
+    }
+    for (name, _, new_tip) in &changed {
+        tx.set_target(name, *new_tip, None, "libkart rewrite_history")?;
+    }
+    tx.commit()?;
+    let backup_refs: Vec<String> = backups.into_iter().map(|(name, _)| name).collect();
+
+    Ok(RewriteStats {
+        commits_rewritten,
+        blobs_written,
+        refs_updated: changed.into_iter().map(|(name, _, _)| name).collect(),
+        backup_refs,
+    })
+}
+
+/// Rewrite `tree_oid` applying `blob_map`, returning the new tree oid — or the
+/// ORIGINAL oid when nothing inside changed, so untouched (sub)trees keep their
+/// identity and the memo stays effective across commits.
+fn rewrite_tree(
+    repo: &Repo,
+    tree_oid: Oid,
+    blob_map: &HashMap<Oid, Oid>,
+    memo: &mut HashMap<Oid, Oid>,
+) -> Result<Oid> {
+    if let Some(&mapped) = memo.get(&tree_oid) {
+        return Ok(mapped);
+    }
+    let tree = repo.git.find_tree(tree_oid)?;
+    // (name, new oid, raw filemode) for entries that change.
+    let mut replacements: Vec<(Vec<u8>, Oid, i32)> = Vec::new();
+    for entry in tree.iter() {
+        let new_id = match entry.kind() {
+            Some(ObjectType::Blob) => blob_map.get(&entry.id()).copied().unwrap_or(entry.id()),
+            Some(ObjectType::Tree) => rewrite_tree(repo, entry.id(), blob_map, memo)?,
+            // Submodule commits etc. are left untouched.
+            _ => entry.id(),
+        };
+        if new_id != entry.id() {
+            replacements.push((entry.name_bytes().to_vec(), new_id, entry.filemode_raw()));
+        }
+    }
+    let new_oid = if replacements.is_empty() {
+        tree_oid
+    } else {
+        let mut builder = repo.git.treebuilder(Some(&tree))?;
+        for (name, id, filemode) in &replacements {
+            builder.insert(name.as_slice(), *id, *filemode)?;
+        }
+        builder.write()?
+    };
+    memo.insert(tree_oid, new_oid);
+    Ok(new_oid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::{find_feature_blobs, FeatureQuery};
+    use git2::ObjectType;
+    use rmpv::Value as MpValue;
+    use std::collections::HashSet;
+    use std::process::Command;
+
+    const EDITING_TGZ: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/editing.tgz");
+
+    fn extract_fixture(tgz: &str, subdir: &str, label: &str) -> std::path::PathBuf {
+        crate::test_support::disable_owner_validation();
+        let base = std::env::temp_dir().join(format!(
+            "libkart-rewritetest-{}-{}-{}",
+            label,
+            subdir,
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).unwrap();
+        let status = Command::new("tar")
+            .arg("xzf")
+            .arg(tgz)
+            .arg("-C")
+            .arg(&base)
+            .status()
+            .expect("run tar");
+        assert!(status.success(), "tar failed for {tgz}");
+        base.join(subdir)
+    }
+
+    /// Editing fixture: two commits on branch `main` ("Import ..." then "R1 edits")
+    /// over dataset `editing` (int pk `id`, text `value`). Returns [head, head~1].
+    fn open_editing(label: &str) -> (std::path::PathBuf, Repo, [Oid; 2]) {
+        let root = extract_fixture(EDITING_TGZ, "editing", label);
+        let repo = Repo::open(root.to_str().unwrap()).unwrap();
+        let head = repo.git.revparse_single("HEAD").unwrap().id();
+        let prev = repo.git.revparse_single("HEAD~1").unwrap().id();
+        (root, repo, [head, prev])
+    }
+
+    /// The blob oid + repo-relative path for the feature with the given pk, at `commit`.
+    fn feature_blob_at(repo: &Repo, commit: Oid, pk: i64) -> (Oid, String) {
+        let hits = find_feature_blobs(
+            repo,
+            &[commit],
+            "editing",
+            &FeatureQuery::Pk(vec![MpValue::from(pk)]),
+        )
+        .unwrap();
+        assert_eq!(hits.len(), 1);
+        (hits[0].blob_oid, hits[0].path.clone())
+    }
+
+    /// All blob oids in any tree of any commit reachable from refs NOT under
+    /// `exclude_prefix`.
+    fn reachable_blob_oids(repo: &Repo, exclude_prefix: &str) -> HashSet<Oid> {
+        let mut walk = repo.git.revwalk().unwrap();
+        for reference in repo.git.references().unwrap() {
+            let reference = reference.unwrap();
+            let name = reference.name().unwrap();
+            if name.starts_with(exclude_prefix) {
+                continue;
+            }
+            if let Some(target) = reference.target() {
+                walk.push(target).unwrap();
+            }
+        }
+        let mut blobs = HashSet::new();
+        let mut seen_trees = HashSet::new();
+        for oid in walk {
+            let commit = repo.git.find_commit(oid.unwrap()).unwrap();
+            collect_blobs(repo, commit.tree_id(), &mut seen_trees, &mut blobs);
+        }
+        blobs
+    }
+
+    fn collect_blobs(
+        repo: &Repo,
+        tree_oid: Oid,
+        seen_trees: &mut HashSet<Oid>,
+        blobs: &mut HashSet<Oid>,
+    ) {
+        if !seen_trees.insert(tree_oid) {
+            return;
+        }
+        let tree = repo.git.find_tree(tree_oid).unwrap();
+        for entry in tree.iter() {
+            match entry.kind() {
+                Some(ObjectType::Blob) => {
+                    blobs.insert(entry.id());
+                }
+                Some(ObjectType::Tree) => collect_blobs(repo, entry.id(), seen_trees, blobs),
+                _ => {}
+            }
+        }
+    }
+
+    fn assert_signatures_equal(a: &git2::Signature<'_>, b: &git2::Signature<'_>) {
+        assert_eq!(a.name_bytes(), b.name_bytes());
+        assert_eq!(a.email_bytes(), b.email_bytes());
+        assert_eq!(a.when().seconds(), b.when().seconds());
+        assert_eq!(a.when().offset_minutes(), b.when().offset_minutes());
+    }
+
+    #[test]
+    fn test_rewrite_history_substitutes_blob() {
+        let (root, repo, [head, prev]) = open_editing("subst");
+        // pk 3 is untouched between the two commits: same blob in BOTH commits, so
+        // both must be rewritten.
+        let (old_oid, path) = feature_blob_at(&repo, head, 3);
+        let new_content = b"substituted content".to_vec();
+
+        let stats = rewrite_history(
+            &repo,
+            &HashMap::from([(old_oid, new_content.clone())]),
+            Some("refs/backup/t1"),
+        )
+        .unwrap();
+
+        assert_eq!(stats.commits_rewritten, 2);
+        assert_eq!(stats.blobs_written, 1);
+        assert_eq!(stats.refs_updated, vec!["refs/heads/main".to_string()]);
+        assert_eq!(
+            stats.backup_refs,
+            vec!["refs/backup/t1/refs/heads/main".to_string()]
+        );
+
+        // 1. HEAD tree has a different blob at `path`, whose content is new_content.
+        let new_head = repo.git.refname_to_id("refs/heads/main").unwrap();
+        assert_ne!(new_head, head);
+        let new_tree = repo.git.find_commit(new_head).unwrap().tree().unwrap();
+        let entry = new_tree.get_path(std::path::Path::new(&path)).unwrap();
+        assert_ne!(entry.id(), old_oid);
+        let blob = repo.git.find_blob(entry.id()).unwrap();
+        assert_eq!(blob.content(), new_content.as_slice());
+
+        // 2. old_oid is NOT reachable from any ref outside refs/backup/.
+        assert!(!reachable_blob_oids(&repo, "refs/backup/").contains(&old_oid));
+        // ... but IS still reachable via the backup namespace.
+        assert!(reachable_blob_oids(&repo, "refs/nosuchprefix/").contains(&old_oid));
+
+        // 3. Backup ref points at the old tip.
+        let backup = repo
+            .git
+            .refname_to_id("refs/backup/t1/refs/heads/main")
+            .unwrap();
+        assert_eq!(backup, head);
+
+        // 4. Rewritten HEAD commit preserves author/committer/message; parent remapped.
+        let old_commit = repo.git.find_commit(head).unwrap();
+        let new_commit = repo.git.find_commit(new_head).unwrap();
+        assert_signatures_equal(&old_commit.author(), &new_commit.author());
+        assert_signatures_equal(&old_commit.committer(), &new_commit.committer());
+        assert_eq!(
+            old_commit.message_raw_bytes(),
+            new_commit.message_raw_bytes()
+        );
+        assert_eq!(new_commit.parent_count(), 1);
+        // The blob was in both commits, so the parent ("Import") was rewritten too.
+        let new_parent = new_commit.parent(0).unwrap();
+        assert_ne!(new_parent.id(), prev);
+        let old_parent = repo.git.find_commit(prev).unwrap();
+        assert_signatures_equal(&old_parent.author(), &new_parent.author());
+        assert_eq!(
+            old_parent.message_raw_bytes(),
+            new_parent.message_raw_bytes()
+        );
+        assert_eq!(new_parent.parent_count(), 0);
+        // The rewritten parent's tree also has the substitution.
+        let parent_entry = new_parent
+            .tree()
+            .unwrap()
+            .get_path(std::path::Path::new(&path))
+            .unwrap();
+        assert_eq!(parent_entry.id(), entry.id());
+
+        let _ = std::fs::remove_dir_all(root.parent().unwrap());
+    }
+
+    #[test]
+    fn test_rewrite_preserves_untouched_commit_identity() {
+        let (root, repo, [head, prev]) = open_editing("identity");
+        // pk 8 was added by "R1 edits": present at HEAD only, so the root commit
+        // ("Import") contains neither the blob nor a rewritten ancestor and must
+        // keep its original oid.
+        let (old_oid, _path) = feature_blob_at(&repo, head, 8);
+
+        let stats = rewrite_history(
+            &repo,
+            &HashMap::from([(old_oid, b"changed".to_vec())]),
+            Some("refs/backup/t1"),
+        )
+        .unwrap();
+
+        assert_eq!(stats.commits_rewritten, 1);
+        let new_head = repo.git.refname_to_id("refs/heads/main").unwrap();
+        assert_ne!(new_head, head);
+        let new_commit = repo.git.find_commit(new_head).unwrap();
+        assert_eq!(new_commit.parent_id(0).unwrap(), prev);
+        assert!(!reachable_blob_oids(&repo, "refs/backup/").contains(&old_oid));
+
+        let _ = std::fs::remove_dir_all(root.parent().unwrap());
+    }
+
+    #[test]
+    fn test_rewrite_history_empty_map_is_noop() {
+        let (root, repo, [head, _prev]) = open_editing("empty");
+        let stats = rewrite_history(&repo, &HashMap::new(), Some("refs/backup/t1")).unwrap();
+        assert_eq!(stats.commits_rewritten, 0);
+        assert_eq!(stats.blobs_written, 0);
+        assert!(stats.refs_updated.is_empty());
+        assert!(stats.backup_refs.is_empty());
+        // Refs untouched, no backup ref created.
+        assert_eq!(repo.git.refname_to_id("refs/heads/main").unwrap(), head);
+        assert!(repo
+            .git
+            .find_reference("refs/backup/t1/refs/heads/main")
+            .is_err());
+        let _ = std::fs::remove_dir_all(root.parent().unwrap());
+    }
+
+    #[test]
+    fn test_rewrite_is_idempotent() {
+        let (root, repo, [head, _prev]) = open_editing("idem");
+        let (old_oid, _path) = feature_blob_at(&repo, head, 3);
+        let subs = HashMap::from([(old_oid, b"substituted".to_vec())]);
+
+        let stats1 = rewrite_history(&repo, &subs, Some("refs/backup/t1")).unwrap();
+        assert!(stats1.commits_rewritten >= 1);
+        let tip_after_first = repo.git.refname_to_id("refs/heads/main").unwrap();
+
+        // Second call with the same map: old_oid is no longer present anywhere
+        // outside the backup namespace -> noop, refs unchanged, no backup-exists
+        // error since noop is detected before backups are created.
+        let stats2 = rewrite_history(&repo, &subs, Some("refs/backup/t1")).unwrap();
+        assert_eq!(stats2.commits_rewritten, 0);
+        assert!(stats2.refs_updated.is_empty());
+        assert!(stats2.backup_refs.is_empty());
+        assert_eq!(
+            repo.git.refname_to_id("refs/heads/main").unwrap(),
+            tip_after_first
+        );
+        // Backup still points at the original tip from the first run.
+        assert_eq!(
+            repo.git
+                .refname_to_id("refs/backup/t1/refs/heads/main")
+                .unwrap(),
+            head
+        );
+        let _ = std::fs::remove_dir_all(root.parent().unwrap());
+    }
+
+    #[test]
+    fn test_rewrite_preexisting_backup_blocks_all_mutation() {
+        let (root, repo, [head, _prev]) = open_editing("prebackup");
+        // A second branch, so more than one ref needs a backup.
+        repo.git
+            .reference("refs/heads/other", head, false, "test")
+            .unwrap();
+        let (old_oid, _path) = feature_blob_at(&repo, head, 3);
+        // Pre-existing backup for ONE of the refs.
+        repo.git
+            .reference("refs/backup/t1/refs/heads/other", head, false, "test")
+            .unwrap();
+
+        let err = rewrite_history(
+            &repo,
+            &HashMap::from([(old_oid, b"x".to_vec())]),
+            Some("refs/backup/t1"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("already exists"), "{err}");
+
+        // Nothing was mutated: no backup created for the OTHER ref, no flips.
+        assert!(repo
+            .git
+            .find_reference("refs/backup/t1/refs/heads/main")
+            .is_err());
+        assert_eq!(repo.git.refname_to_id("refs/heads/main").unwrap(), head);
+        assert_eq!(repo.git.refname_to_id("refs/heads/other").unwrap(), head);
+
+        let _ = std::fs::remove_dir_all(root.parent().unwrap());
+    }
+
+    #[test]
+    fn test_rewrite_backup_prefix_must_start_with_refs() {
+        let (root, repo, [head, _prev]) = open_editing("badprefix");
+        let (old_oid, _path) = feature_blob_at(&repo, head, 3);
+        for prefix in ["backup", "backup/t1", "refs"] {
+            let err = rewrite_history(
+                &repo,
+                &HashMap::from([(old_oid, b"x".to_vec())]),
+                Some(prefix),
+            )
+            .unwrap_err();
+            assert!(err.to_string().contains("must start with 'refs/'"), "{err}");
+        }
+        // Refs untouched.
+        assert_eq!(repo.git.refname_to_id("refs/heads/main").unwrap(), head);
+        let _ = std::fs::remove_dir_all(root.parent().unwrap());
+    }
+
+    #[test]
+    fn test_rewrite_errors_on_annotated_tag() {
+        let (root, repo, [head, _prev]) = open_editing("anntag");
+        let (old_oid, _path) = feature_blob_at(&repo, head, 3);
+        let obj = repo.git.find_object(head, None).unwrap();
+        let sig = git2::Signature::now("tagger", "tagger@example.com").unwrap();
+        repo.git.tag("v1", &obj, &sig, "a tag", false).unwrap();
+
+        let err = rewrite_history(
+            &repo,
+            &HashMap::from([(old_oid, b"x".to_vec())]),
+            Some("refs/backup/t1"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("annotated tag"), "{err}");
+        // Refs untouched.
+        assert_eq!(repo.git.refname_to_id("refs/heads/main").unwrap(), head);
+        let _ = std::fs::remove_dir_all(root.parent().unwrap());
+    }
+}

--- a/libkart/src/rewrite.rs
+++ b/libkart/src/rewrite.rs
@@ -272,33 +272,12 @@ fn rewrite_tree(
 mod tests {
     use super::*;
     use crate::query::{find_feature_blobs, FeatureQuery};
+    use crate::test_support::extract_fixture;
     use git2::ObjectType;
     use rmpv::Value as MpValue;
     use std::collections::HashSet;
-    use std::process::Command;
 
     const EDITING_TGZ: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/editing.tgz");
-
-    fn extract_fixture(tgz: &str, subdir: &str, label: &str) -> std::path::PathBuf {
-        crate::test_support::disable_owner_validation();
-        let base = std::env::temp_dir().join(format!(
-            "libkart-rewritetest-{}-{}-{}",
-            label,
-            subdir,
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&base);
-        std::fs::create_dir_all(&base).unwrap();
-        let status = Command::new("tar")
-            .arg("xzf")
-            .arg(tgz)
-            .arg("-C")
-            .arg(&base)
-            .status()
-            .expect("run tar");
-        assert!(status.success(), "tar failed for {tgz}");
-        base.join(subdir)
-    }
 
     /// Editing fixture: two commits on branch `main` ("Import ..." then "R1 edits")
     /// over dataset `editing` (int pk `id`, text `value`). Returns [head, head~1].

--- a/libkart/src/tile.rs
+++ b/libkart/src/tile.rs
@@ -206,6 +206,7 @@ mod tests {
         Dataset {
             dataset_type: "point-cloud".to_string(),
             path: "auckland".to_string(),
+            inner_name: ".point-cloud-dataset.v1".to_string(),
             meta,
             geom_column_name: None,
             geom_column_id: None,

--- a/libkart/src/tile.rs
+++ b/libkart/src/tile.rs
@@ -212,6 +212,7 @@ mod tests {
             geom_column_id: None,
             primary_key: None,
             legend_geom_index: std::sync::Mutex::new(HashMap::new()),
+            path_encoder: std::sync::OnceLock::new(),
         }
     }
 

--- a/libkart/tests_py/golden_check.py
+++ b/libkart/tests_py/golden_check.py
@@ -154,8 +154,6 @@ def repo_list_datasets(repo, refish):
     rc = lib.kart_repo_list_datasets(repo, refish.encode(), pp, n)
     if rc != 0:
         raise KartError(f"list_datasets: {last_error()}")
-    import json
-
     return json.loads(_take_bytes(pp, n).decode("utf-8"))
 
 
@@ -222,8 +220,6 @@ def dataset_schema_json(ds):
     rc = lib.kart_dataset_schema_json(ds, pp, n)
     if rc != 0:
         raise KartError(f"schema_json: {last_error()}")
-    import json
-
     return json.loads(_take_bytes(pp, n).decode("utf-8"))
 
 
@@ -252,8 +248,6 @@ def tile_summary_json(ds, blob):
     rc = lib.kart_tile_summary_json(ds, blob, len(blob), pp, n)
     if rc != 0:
         raise KartError(f"tile_summary_json: {last_error()}")
-    import json
-
     return json.loads(_take_bytes(pp, n).decode("utf-8"))
 
 
@@ -380,8 +374,6 @@ def check_vector(tgz, subdir, ds_path, expected_datasets):
             )
 
             # columns byte-faithful to the raw meta/schema.json blob
-            import json
-
             meta_schema = json.loads((pyds.inner_tree / "meta" / "schema.json").data)
             check(
                 f"{subdir}: schema columns match meta/schema.json",
@@ -568,7 +560,7 @@ def check_rewrite(tgz, subdir, ds_path):
                 f"c={ds_path}/{path_c} py={path_py}",
             )
 
-            # find the pk=1 blob at HEAD; cross-check against pygit2
+            # find the pk=3 blob at HEAD; cross-check against pygit2
             hits = repo_find_feature_blobs(repo, [head_oid], ds_path, {"pk": [PK]})
             check(
                 f"{subdir}: find_feature_blobs one hit", len(hits) == 1, f"hits={hits}"

--- a/libkart/tests_py/golden_check.py
+++ b/libkart/tests_py/golden_check.py
@@ -11,6 +11,8 @@ pointing at the built library; CTest does this automatically via the
 """
 
 import atexit
+import base64
+import json
 import os
 import shutil
 import subprocess
@@ -74,6 +76,9 @@ int kart_repo_open(const char *path, uint64_t *out_repo);
 void kart_repo_free(uint64_t repo);
 int kart_repo_table_dataset_version(uint64_t repo, int *out_version);
 int kart_repo_list_datasets(uint64_t repo, const char *refish, uint8_t **out_json, size_t *out_len);
+int kart_repo_find_feature_blobs(uint64_t repo, const char *commits_json, const char *dataset_path, const char *query_json, uint8_t **out, size_t *out_len);
+int kart_repo_rewrite_history(uint64_t repo, const char *substitutions_json, const char *backup_ref_prefix, uint8_t **out, size_t *out_len);
+int kart_repo_blob(uint64_t repo, const char *oid_hex, uint8_t **out, size_t *out_len);
 
 int kart_dataset_open(uint64_t repo, const char *refish, const char *path, uint64_t *out_ds);
 void kart_dataset_free(uint64_t ds);
@@ -81,8 +86,10 @@ int kart_dataset_type(uint64_t ds, uint8_t **out, size_t *out_len);
 int kart_dataset_schema_json(uint64_t ds, uint8_t **out, size_t *out_len);
 int kart_dataset_crs_wkt(uint64_t ds, uint8_t **out, size_t *out_len);
 int kart_dataset_meta_item(uint64_t ds, const char *name, uint8_t **out, size_t *out_len);
+int kart_dataset_feature_path(uint64_t ds, const char *pk_values_json, uint8_t **out, size_t *out_len);
 
 int kart_feature_geometry(uint64_t ds, const uint8_t *blob, size_t blob_len, uint8_t **out, size_t *out_len);
+int kart_feature_update_blob(uint64_t ds, const uint8_t *blob, size_t blob_len, const char *updates_json, uint8_t **out, size_t *out_len);
 int kart_tile_summary_json(uint64_t ds, const uint8_t *blob, size_t blob_len, uint8_t **out, size_t *out_len);
 
 int kart_gpkg_is_empty(const uint8_t *g, size_t n, int *out);
@@ -150,6 +157,63 @@ def repo_list_datasets(repo, refish):
     import json
 
     return json.loads(_take_bytes(pp, n).decode("utf-8"))
+
+
+def repo_find_feature_blobs(repo, commit_oids, dataset_path, query):
+    pp = ffi.new("uint8_t **")
+    n = ffi.new("size_t *")
+    rc = lib.kart_repo_find_feature_blobs(
+        repo,
+        json.dumps(commit_oids).encode(),
+        dataset_path.encode(),
+        json.dumps(query).encode(),
+        pp,
+        n,
+    )
+    if rc != 0:
+        raise KartError(f"find_feature_blobs: {last_error()}")
+    return json.loads(_take_bytes(pp, n).decode("utf-8"))
+
+
+def repo_rewrite_history(repo, substitutions, backup_ref_prefix):
+    pp = ffi.new("uint8_t **")
+    n = ffi.new("size_t *")
+    prefix = backup_ref_prefix.encode() if backup_ref_prefix is not None else ffi.NULL
+    rc = lib.kart_repo_rewrite_history(
+        repo, json.dumps(substitutions).encode(), prefix, pp, n
+    )
+    if rc != 0:
+        raise KartError(f"rewrite_history: {last_error()}")
+    return json.loads(_take_bytes(pp, n).decode("utf-8"))
+
+
+def repo_blob(repo, oid_hex):
+    pp = ffi.new("uint8_t **")
+    n = ffi.new("size_t *")
+    rc = lib.kart_repo_blob(repo, oid_hex.encode(), pp, n)
+    if rc != 0:
+        raise KartError(f"repo_blob: {last_error()}")
+    return _take_bytes(pp, n)
+
+
+def dataset_feature_path(ds, pk_values_json):
+    pp = ffi.new("uint8_t **")
+    n = ffi.new("size_t *")
+    rc = lib.kart_dataset_feature_path(ds, pk_values_json.encode(), pp, n)
+    if rc != 0:
+        raise KartError(f"feature_path: {last_error()}")
+    return _take_bytes(pp, n).decode("utf-8")
+
+
+def feature_update_blob(ds, blob, updates):
+    pp = ffi.new("uint8_t **")
+    n = ffi.new("size_t *")
+    rc = lib.kart_feature_update_blob(
+        ds, blob, len(blob), json.dumps(updates).encode(), pp, n
+    )
+    if rc != 0:
+        raise KartError(f"feature_update_blob: {last_error()}")
+    return _take_bytes(pp, n)
 
 
 def dataset_schema_json(ds):
@@ -472,6 +536,137 @@ def check_pointcloud(tgz, subdir, ds_path):
         lib.kart_repo_free(repo)
 
 
+# ---- history-rewrite end-to-end check (points.tgz) ---------------------------
+
+
+def check_rewrite(tgz, subdir, ds_path):
+    """Redact one feature attribute across history via the C ABI, then verify the
+    rewritten repo with kart's own Python implementation."""
+    print(f"\n=== rewrite repo {subdir} ({ds_path}) ===")
+    PK = 3  # pk=3 has a non-null name_ascii ('Tauwhare Pa'), so the redaction is observable
+    root = extract(tgz, subdir)
+    pyrepo = KartRepo(root)
+    pyds = [d for d in pyrepo.structure("HEAD").datasets() if d.path == ds_path][0]
+
+    geom_name = [c for c in pyds.schema if c.data_type == "geometry"][0].name
+    pre_feature = pyds.get_feature([PK])
+    pre_name = pre_feature["name_ascii"]
+    pre_geom = bytes(pre_feature[geom_name])
+    pre_count = pyds.feature_count
+    head_oid = str(pyrepo.head_commit.id)
+
+    repo = repo_open(root)
+    try:
+        ds = dataset_open(repo, "HEAD", ds_path)
+        try:
+            # feature path: C ABI (dataset-dir-relative) vs kart's own encoder (full path)
+            path_c = dataset_feature_path(ds, json.dumps([PK]))
+            path_py = pyds.encode_1pk_to_path(PK)
+            check(
+                f"{subdir}: feature_path matches kart encoder",
+                f"{ds_path}/{path_c}" == path_py,
+                f"c={ds_path}/{path_c} py={path_py}",
+            )
+
+            # find the pk=1 blob at HEAD; cross-check against pygit2
+            hits = repo_find_feature_blobs(repo, [head_oid], ds_path, {"pk": [PK]})
+            check(
+                f"{subdir}: find_feature_blobs one hit", len(hits) == 1, f"hits={hits}"
+            )
+            hit = hits[0]
+            old_oid = hit["oid"]
+            py_entry = pyrepo.head_commit.tree / hit["path"]
+            check(
+                f"{subdir}: found blob oid matches pygit2",
+                hit["commit"] == head_oid
+                and hit["path"] == path_py
+                and old_oid == str(py_entry.id),
+                f"c={hit} py_oid={py_entry.id}",
+            )
+
+            # old blob content via C ABI, byte-equal to pygit2
+            old_blob = repo_blob(repo, old_oid)
+            check(
+                f"{subdir}: repo_blob byte-equal to pygit2",
+                old_blob == py_entry.data,
+                f"c_len={len(old_blob)} py_len={len(py_entry.data)}",
+            )
+
+            # build the redacted blob and rewrite history
+            new_blob = feature_update_blob(
+                ds, old_blob, {"name_ascii": "GOLDEN-REDACTED"}
+            )
+            stats = repo_rewrite_history(
+                repo,
+                {old_oid: base64.b64encode(new_blob).decode("ascii")},
+                "refs/kx/backup/golden",
+            )
+            check(
+                f"{subdir}: rewrite stats",
+                stats["commits_rewritten"] >= 1
+                and stats["blobs_written"] >= 1
+                and stats["refs_updated"]
+                and stats["backup_refs"],
+                f"stats={stats}",
+            )
+        finally:
+            lib.kart_dataset_free(ds)
+    finally:
+        lib.kart_repo_free(repo)
+
+    # ---- verify the rewritten repo with kart's Python implementation ----
+    pyrepo2 = KartRepo(root)  # fresh open: the rewrite happened behind pyrepo's back
+    pyds2 = [d for d in pyrepo2.structure("HEAD").datasets() if d.path == ds_path][0]
+    feature = pyds2.get_feature([PK])
+    check(
+        f"{subdir}: kart reads redacted attribute at HEAD",
+        feature["name_ascii"] == "GOLDEN-REDACTED",
+        f"name_ascii={feature['name_ascii']!r}",
+    )
+    check(
+        f"{subdir}: geometry unchanged",
+        bytes(feature[geom_name]) == pre_geom,
+        f"eq={bytes(feature[geom_name]) == pre_geom}",
+    )
+    check(
+        f"{subdir}: feature count unchanged",
+        pyds2.feature_count == pre_count,
+        f"pre={pre_count} post={pyds2.feature_count}",
+    )
+
+    # old blob unreachable from (rewritten) HEAD
+    rev_list = subprocess.run(
+        ["git", "-C", root, "rev-list", "--objects", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    check(
+        f"{subdir}: old blob absent from HEAD object walk",
+        old_oid not in rev_list.stdout,
+        f"old_oid={old_oid}",
+    )
+
+    # backup ref exists and the OLD feature is readable there via kart
+    backup_ref = stats["backup_refs"][0]
+    check(
+        f"{subdir}: backup ref exists",
+        backup_ref in pyrepo2.listall_references(),
+        f"backup_ref={backup_ref}",
+    )
+    pyds_backup = [
+        d for d in pyrepo2.structure(backup_ref).datasets() if d.path == ds_path
+    ][0]
+    backup_feature = pyds_backup.get_feature([PK])
+    check(
+        f"{subdir}: pre-rewrite feature readable at backup ref",
+        backup_feature["name_ascii"] == pre_name
+        and pre_name not in (None, "GOLDEN-REDACTED")
+        and bytes(backup_feature[geom_name]) == pre_geom,
+        f"backup name_ascii={backup_feature['name_ascii']!r} pre={pre_name!r}",
+    )
+
+
 def ds_type_bytes(ds):
     pp = ffi.new("uint8_t **")
     n = ffi.new("size_t *")
@@ -503,6 +698,11 @@ def main():
         os.path.join(DATA, "point-cloud", "auckland.tgz"),
         "auckland",
         "auckland",
+    )
+    check_rewrite(
+        os.path.join(DATA, "points.tgz"),
+        "points",
+        "nz_pa_points_topo_150k",
     )
 
     print("\n==== SUMMARY ====")


### PR DESCRIPTION
## Description

Adds generic kart-format primitives to libkart for substituting feature blobs throughout history:

- Feature blob decode/encode (byte-identical msgpack round-trip) and single-value substitution
- Dataset schema/legend helpers and PK→path encoders (int, msgpack/hash and legacy schemes)
- Multi-commit blob search by PK or column filter
- `rewrite_history`: memoized tree rewrite with parent remapping; backup refs and ref flips happen in one atomic transaction
- C ABI for the above, plus a golden end-to-end check that verifies a rewrite through the kart Python read path



## Related links:



## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?
