### PR TITLE
Speed up CI test runs: disable coverage, exclude build dirs from Defender

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -85,6 +85,12 @@ jobs:
 
       # Setup
 
+      # Defender real-time scanning taxes every compiler/test subprocess spawn
+      # and temp file; the runner is ephemeral so scanning the build is pointless.
+      - name: "setup: defender exclusions"
+        shell: pwsh
+        run: Add-MpPreference -ExclusionPath "${{ github.workspace }}", "$env:TEMP", "$env:LOCALAPPDATA\Temp"
+
       - name: "msvc setup"
         uses: ilammy/msvc-dev-cmd@v1
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,7 +13,8 @@
             "cacheVariables": {
                 "USE_VCPKG": "ON",
                 "CMAKE_BUILD_TYPE": "Release",
-                "KART_VERSION": "$env{KART_VERSION}"
+                "KART_VERSION": "$env{KART_VERSION}",
+                "PYTEST_ARGS": "--no-cov"
             },
             "environment": {
                 "CI": "true"


### PR DESCRIPTION
## Description

Two zero-cost CI speedups, aimed mostly at the ~60-minute Windows unit-test step:

- Pass `--no-cov` to pytest in CI (via the `ci-base` preset): every CI test run pays coverage instrumentation overhead, but no workflow uploads or reads the coverage data. Local runs are unchanged.
- Exclude the workspace and temp dirs from Windows Defender real-time scanning: the runner is ephemeral, and scanning taxes every one of the thousands of compiler/git/kart subprocess spawns and temp files.

## Related links:

## Checklist:

- [x] Have you reviewed your own change?
- [ ] Have you included test(s)? (n/a - CI config)
- [ ] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)? (n/a - no user-facing change)

### Risks involved

- [x] No notable risks