### PR TITLE
Helper mode: give subprocesses the caller's stdin/stdout/stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 - Piped (non-tty) output is now always UTF-8 on all platforms. Previously text output used the locale codepage on Windows (e.g. cp1252), inconsistent with JSON output (which is always UTF-8). [#1115](https://github.com/koordinates/kart/issues/1115)
 - `export`: Fixed a crash (`KeyError: 'GEOMETRY Z'`) when exporting datasets whose geometry type is the generic `GEOMETRY` with a `Z`, `M`, or `ZM` suffix. [#1063](https://github.com/koordinates/kart/issues/1063)
 - `log`: Fixed `<dataset>:tile` and raw-path filters silently matching nothing for point-cloud and raster datasets. [#1119](https://github.com/koordinates/kart/pull/1119)
-- Fixed commands that write text output (eg `log`) hanging forever when stdin is a pipe that is never written to or closed, as happens under some CI runners. [#1121](https://github.com/koordinates/kart/pull/1121)
 - Update PDAL to 2.10.1. [#1121](https://github.com/koordinates/kart/pull/1121)
+- log: Fixed intermittent empty output when using helper mode. [#1125](https://github.com/koordinates/kart/pull/1125)
 
 ## 0.17.1
 

--- a/kart/helper.py
+++ b/kart/helper.py
@@ -138,11 +138,15 @@ def helper(ctx, socket_filename, timeout, args):
             client, info = sock.accept()
             _helper_log("pre-fork messaged received")
             if os.fork() != 0:
-                # parent
+                # parent - the child owns the connection from here on
+                client.close()
                 continue
             else:
                 # child
                 _helper_log("post-fork")
+                # don't hold the listening socket open in the child, or in any subprocess
+                # it goes on to spawn
+                sock.close()
 
                 payload, fds = recv_json_and_fds(client, maxfds=4)
                 if not payload or len(fds) != 4:

--- a/kart/helper.py
+++ b/kart/helper.py
@@ -31,6 +31,29 @@ def getsid():
     return 0
 
 
+def _become_stdio(fds):
+    """
+    Move the caller's [stdin, stdout, stderr] onto this process's fds 0, 1 and 2,
+    closing the originals.
+
+    Rebinding sys.stdin/stdout/stderr isn't enough: subprocesses we spawn - the pager,
+    git, etc - inherit the OS-level descriptors, and in the helper those don't belong to
+    the caller at all. cli_helper/kart.c closes 0, 1 and 2 before exec'ing the helper, so
+    they get reused for whatever the helper opens next (its own sockets, in practice).
+    """
+    # Unix-only; the helper doesn't run on Windows.
+    import fcntl
+
+    # Duplicate above fd 2 first, so a dup2() below can't clobber a source fd.
+    caller_fds = [fcntl.fcntl(fd, fcntl.F_DUPFD, 3) for fd in fds]
+    for fd in fds:
+        if fd > 2:
+            os.close(fd)
+    for target, caller_fd in enumerate(caller_fds):
+        os.dup2(caller_fd, target)
+        os.close(caller_fd)
+
+
 @click.command(context_settings=dict(ignore_unknown_options=True))
 @click.pass_context
 @click.option(
@@ -138,12 +161,12 @@ def helper(ctx, socket_filename, timeout, args):
 
                 # set this processes stdin/stdout/stderr to the calling processes passed in fds
                 # TODO - have these passed as named pipes paths, will work on windows as well
-
-                # 0,1,2 are the wrong places since they were closed before the helper was attached
-
-                sys.stdin = os.fdopen(fds[0], "r")
-                sys.stdout = os.fdopen(fds[1], "w")
-                sys.stderr = os.fdopen(fds[2], "w")
+                _become_stdio(fds[:3])
+                sys.stdin = os.fdopen(0, "r")
+                sys.stdout = os.fdopen(1, "w")
+                sys.stderr = os.fdopen(2, "w")
+                if fds[3] > 2:
+                    os.close(fds[3])
 
                 # re-enable SIGCHLD so subprocess handling works
                 signal.signal(signal.SIGCHLD, signal.SIG_DFL)

--- a/tests/scripts/e2e-1.sh
+++ b/tests/scripts/e2e-1.sh
@@ -89,13 +89,19 @@ kart log
 # Paged output (only happens when attached to a terminal). In helper mode the pager is
 # spawned by the helper process, so it has to be given the caller's stdout rather than
 # the helper's own. Run twice: this used to work only every second invocation.
-for i in 1 2; do
-    PAGED_LOG=$(python3 "$HERE/pty-run.py" kart log --output-format=text:oneline)
-    if ! echo "$PAGED_LOG" | grep -q merge-1; then
-        echo "paged log output missing on attempt ${i}: ${PAGED_LOG}"
-        exit 1
-    fi
-done
+# Needs python3 for a pty - the slim distro images used by the install-check jobs don't
+# have one, but the runners that test helper mode do.
+if command -v python3 >/dev/null; then
+    for i in 1 2; do
+        PAGED_LOG=$(python3 "$HERE/pty-run.py" kart log --output-format=text:oneline)
+        if ! echo "$PAGED_LOG" | grep -q merge-1; then
+            echo "paged log output missing on attempt ${i}: ${PAGED_LOG}"
+            exit 1
+        fi
+    done
+else
+    echo "skipping paged-output test: no python3"
+fi
 
 # Briefly try a remote to ensure the CA cert bundle is working
 kart git ls-remote https://github.com/koordinates/kart.git HEAD

--- a/tests/scripts/e2e-1.sh
+++ b/tests/scripts/e2e-1.sh
@@ -86,6 +86,17 @@ kart status
 kart merge edit-1 --no-ff -m merge-1
 kart log
 
+# Paged output (only happens when attached to a terminal). In helper mode the pager is
+# spawned by the helper process, so it has to be given the caller's stdout rather than
+# the helper's own. Run twice: this used to work only every second invocation.
+for i in 1 2; do
+    PAGED_LOG=$(python3 "$HERE/pty-run.py" kart log --output-format=text:oneline)
+    if ! echo "$PAGED_LOG" | grep -q merge-1; then
+        echo "paged log output missing on attempt ${i}: ${PAGED_LOG}"
+        exit 1
+    fi
+done
+
 # Briefly try a remote to ensure the CA cert bundle is working
 kart git ls-remote https://github.com/koordinates/kart.git HEAD
 

--- a/tests/scripts/pty-run.py
+++ b/tests/scripts/pty-run.py
@@ -1,0 +1,22 @@
+"""
+Runs a command with stdin/stdout/stderr attached to a pty, and echoes whatever the
+command writes to our own stdout.
+
+Used by the e2e tests to exercise the code paths Kart only takes when it's attached to
+a terminal - notably the pager.
+"""
+
+import os
+import pty
+import sys
+
+
+def main(argv: list[str]) -> int:
+    # Don't forward our own stdin: the e2e tests are non-interactive, and reading from a
+    # closed/redirected stdin here would just hang.
+    status = pty.spawn(argv, lambda fd: os.read(fd, 4096), lambda fd: b"")
+    return os.waitstatus_to_exitcode(status)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Description

In helper mode the pager produced no output, or `cat: standard output: Bad file descriptor` with `PAGER=cat` - and it alternated, working every second invocation.

The helper child only rebound `sys.stdin`/`stdout`/`stderr` to the fds passed over the socket. The process's real fds 0/1/2 still pointed at whatever the helper daemon had there: `cli_helper/kart.c` marks 0/1/2 `FD_CLOEXEC` before exec'ing the helper, so they get reused for its own sockets. Subprocesses inherit those, so the pager wrote into a socket or a closed descriptor. The alternation came from the accept loop holding each connection open until the next `accept()`, which shifted the received fd numbers by one each time - on every second run the caller's stdin happened to land on fd 1 and the pager wrote to the terminal by accident.

Fixed by `dup2()`ing the caller's fds onto 0/1/2 in the helper child. Second commit closes the sockets each process no longer needs after forking.

Also fixes the same problem for subprocess stderr, which was going to the caller's *stdin* fd.

## Related links:

Introduced as a user-visible bug by #1080 (pager support), though the underlying fd handling has always been wrong.

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?