### PR TITLE
log: add --with-change-counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## UNRELEASED
 
+- `log`: Adds `--with-change-counts`, which reports the exact number of features (or tiles) inserted, updated and deleted by each commit, per dataset.
 - Adds `libkart`, a native shared library exposing a C API for reading Kart repositories in-process (without invoking the `kart` CLI). It is shipped in the bundle alongside the `kart` executable; see the libkart C API reference in the developer docs. [#1110](https://github.com/koordinates/kart/pull/1110)
 - Add pager support to `diff` and `show` commands. [#1080](https://github.com/koordinates/kart/pull/1080)
 - Piped (non-tty) output is now always UTF-8 on all platforms. Previously text output used the locale codepage on Windows (e.g. cp1252), inconsistent with JSON output (which is always UTF-8). [#1115](https://github.com/koordinates/kart/issues/1115)

--- a/kart/annotations/__init__.py
+++ b/kart/annotations/__init__.py
@@ -14,23 +14,28 @@ class DiffAnnotations:
     def __init__(self, repo):
         self.repo = repo
 
-    def _object_id(self, base, target):
-        # this is actually symmetric, so we can marginally increase hit rate by sorting first
+    def _object_id(self, base, target, ordered=False):
         base = base.peel(pygit2.Tree)
         target = target.peel(pygit2.Tree)
-        tree_ids = sorted(r.id for r in (base, target))
+        tree_ids = [base.id, target.id]
+        if not ordered:
+            # most annotations are symmetric, so we can marginally increase hit rate by sorting first
+            tree_ids = sorted(tree_ids)
         return f"{tree_ids[0]}...{tree_ids[1]}"
 
-    def store(self, *, base, target, annotation_type, data):
+    def store(self, *, base, target, annotation_type, data, ordered=False):
         """
         Stores a diff annotation to the repo's sqlite database,
         and returns the annotation itself.
 
         base: base Tree or Commit object for this diff (revA in a 'revA...revB' diff)
         target: target Tree or Commit object for this diff (revB in a 'revA...revB' diff)
+        ordered: set for annotation types whose data isn't the same in both
+            directions (eg counts of inserts vs deletes), so that base and target
+            aren't used interchangeably.
         """
         assert isinstance(data, dict)
-        object_id = self._object_id(base, target)
+        object_id = self._object_id(base, target, ordered=ordered)
         data = json.dumps(data)
         with annotations_session(self.repo) as session:
             if session.is_readonly:
@@ -61,16 +66,17 @@ class DiffAnnotations:
                         raise
         return data
 
-    def get(self, *, base, target, annotation_type):
+    def get(self, *, base, target, annotation_type, ordered=False):
         """
         Returns a diff annotation from the sqlite database.
         Returns None if it isn't found.
 
         base: base Tree or Commit object for this diff (revA in a 'revA...revB' diff)
         target: target Tree or Commit object for this diff (revB in a 'revA...revB' diff)
+        ordered: see store()
         """
         with annotations_session(self.repo) as session:
-            object_id = self._object_id(base, target)
+            object_id = self._object_id(base, target, ordered=ordered)
             try:
                 annotations = list(
                     session.query(KartAnnotation).filter(

--- a/kart/diff_estimation.py
+++ b/kart/diff_estimation.py
@@ -45,6 +45,62 @@ def get_exact_diff_blob_count(repo, tree1, tree2):
     return count
 
 
+def get_exact_diff_blob_type_counts(repo, tree1, tree2):
+    """
+    Returns exact counts of the blobs added, modified and deleted between the two
+    pygit2.Tree instances, as a dict: {"inserts": int, "updates": int, "deletes": int}
+    Types with a count of zero are omitted, as they are by DeltaDiff.type_counts()
+    """
+    if tree1 == tree2:
+        return {}
+
+    git_rev_spec = f"{tree1.id}..{tree2.id}"
+    p = subprocess.Popen(
+        [
+            "git",
+            "-C",
+            repo.path,
+            "diff",
+            "--name-status",
+            "--no-renames",
+            # -z makes git use \0 as a separator, both between entries and between
+            # each entry's status and path. Without it, unusual paths are quoted
+            # and escaped, which is harder to parse.
+            "-z",
+            git_rev_spec,
+        ],
+        stdout=subprocess.PIPE,
+        encoding="utf-8",
+    )
+    counts = {"inserts": 0, "updates": 0, "deletes": 0}
+    # Each entry is "<status>\0<path>\0" - we only care about the statuses.
+    # --no-renames means R (rename) can't occur, and C (copy) requires -C.
+    pieces = iter(p.stdout.read().split("\0"))
+    for status in pieces:
+        if not status:
+            # trailing separator at the end of the output
+            continue
+        try:
+            next(pieces)  # the path this status refers to
+        except StopIteration:
+            raise SubprocessError(f"Truncated git diff output at status {status!r}")
+        if status == "A":
+            counts["inserts"] += 1
+        elif status == "D":
+            counts["deletes"] += 1
+        elif status in ("M", "T"):
+            # T is a change of object type, which shouldn't happen inside a dataset,
+            # but if it does, it's a change to a blob that exists in both trees.
+            counts["updates"] += 1
+        else:
+            raise SubprocessError(f"Unexpected git diff status {status!r}")
+
+    retcode = p.wait()
+    if retcode != 0:
+        raise SubprocessError("Error calling git diff", exit_code=retcode)
+    return {k: v for k, v in counts.items() if v}
+
+
 def get_approximate_diff_blob_count(
     repo, accuracy, tree1, tree2, dataset_path, path_encoder
 ):
@@ -74,6 +130,99 @@ def get_data_tree(repo, ds):
         return ds.feature_tree if ds.DATASET_TYPE == "table" else ds.tile_tree
     else:
         return repo.empty_tree
+
+
+TYPE_COUNTS_ANNOTATION_TYPE = "feature-change-type-counts-exact"
+
+
+def _invert_type_counts(counts):
+    """
+    Given type counts for a diff, returns the type counts for the reverse diff:
+    what was inserted was deleted, and vice versa.
+    """
+    result = {}
+    if "deletes" in counts:
+        result["inserts"] = counts["deletes"]
+    if "updates" in counts:
+        result["updates"] = counts["updates"]
+    if "inserts" in counts:
+        result["deletes"] = counts["inserts"]
+    return result
+
+
+def get_diff_feature_type_counts(repo, base, target):
+    """
+    Counts the features (or tiles) inserted, updated and deleted by the given diff,
+    for each dataset in it.
+    Returns a dict: {dataset_path: {"inserts": int, "updates": int, "deletes": int}}
+    Datasets with no feature/tile changes are not present in the dict, and neither
+    are types with a count of zero.
+
+    Counts are always exact - unlike estimate_diff_feature_counts(), there's no
+    approximation available, since sampling subtrees can't tell the types apart.
+    """
+    base = base.peel(pygit2.Tree)
+    target = target.peel(pygit2.Tree)
+    if base == target:
+        return {}
+
+    # Unlike the other annotation types, these counts differ depending on which way
+    # around the diff is, so they're stored against an ordered key.
+    annotation = repo.diff_annotations.get(
+        base=base,
+        target=target,
+        annotation_type=TYPE_COUNTS_ANNOTATION_TYPE,
+        ordered=True,
+    )
+    if annotation is not None:
+        return annotation
+    # If we've already done this diff in the other direction, we can just invert it
+    # rather than doing the work again.
+    reverse = repo.diff_annotations.get(
+        base=target,
+        target=base,
+        annotation_type=TYPE_COUNTS_ANNOTATION_TYPE,
+        ordered=True,
+    )
+    if reverse is not None:
+        return {ds_path: _invert_type_counts(c) for ds_path, c in reverse.items()}
+
+    base_rs = repo.structure(base)
+    target_rs = repo.structure(target)
+    all_ds_paths = {ds.path for ds in base_rs.datasets()} | {
+        ds.path for ds in target_rs.datasets()
+    }
+
+    dataset_type_counts = {}
+    for dataset_path in all_ds_paths:
+        if terminate_estimate_thread.is_set():
+            raise ThreadTerminated()
+
+        base_ds = base_rs.datasets().get(dataset_path)
+        target_ds = target_rs.datasets().get(dataset_path)
+        if not base_ds and not target_ds:
+            continue
+
+        counts = get_exact_diff_blob_type_counts(
+            repo,
+            get_data_tree(repo, base_ds),
+            get_data_tree(repo, target_ds),
+        )
+        if counts:
+            dataset_type_counts[dataset_path] = counts
+
+    repo.diff_annotations.store(
+        base=base,
+        target=target,
+        annotation_type=TYPE_COUNTS_ANNOTATION_TYPE,
+        data=dataset_type_counts,
+        ordered=True,
+    )
+
+    if terminate_estimate_thread.is_set():
+        raise ThreadTerminated()
+
+    return dataset_type_counts
 
 
 def estimate_diff_feature_counts(

--- a/kart/log.py
+++ b/kart/log.py
@@ -158,6 +158,16 @@ def convert_user_patterns_to_raw_paths(paths, repo, commits):
         "For non-tabular datasets, the feature count is always exact, and refers to the number of tiles."
     ),
 )
+@click.option(
+    "--with-change-counts",
+    is_flag=True,
+    help=(
+        "Adds a 'featureChangeCounts' object to JSON output: for each dataset, the exact "
+        "number of features inserted, updated and deleted by each commit, relative to its "
+        "first parent. For non-tabular datasets, these refer to numbers of tiles. "
+        "Counts are always exact (this may be slow for large tabular diffs)."
+    ),
+)
 # Some standard git options
 @click.option(
     "-n",
@@ -254,6 +264,7 @@ def log(
     output_path,
     dataset_changes,
     with_feature_count,
+    with_change_counts,
     args,
     **kwargs,
 ):
@@ -271,6 +282,11 @@ def log(
 
     paths = convert_user_patterns_to_raw_paths(filters, repo, commits)
     output_type, fmt = output_format
+
+    if with_change_counts and output_type == "text":
+        raise click.UsageError(
+            "--with-change-counts requires --output-format=json or json-lines"
+        )
 
     log_cmd = [
         "git",
@@ -326,6 +342,7 @@ def log(
                     dataset_changes,
                     dataset_change_cache,
                     with_feature_count,
+                    with_change_counts,
                 )
                 for (commit_id, refs) in commit_ids_and_refs_log
             )
@@ -374,6 +391,7 @@ def commit_obj_to_json(
     dataset_changes=False,
     dataset_change_cache={},
     with_feature_count=None,
+    with_change_counts=False,
 ):
     """Given a commit object, returns a dict ready for dumping as JSON."""
     author = commit.author
@@ -411,7 +429,8 @@ def commit_obj_to_json(
         result["datasetChanges"] = get_dataset_changes(
             repo, commit, dataset_change_cache
         )
-    if with_feature_count:
+    if with_feature_count or with_change_counts:
+        # Both of these describe the diff between this commit and its first parent.
         if (not dataset_changes) or result["datasetChanges"]:
             try:
                 parent_commit = commit.parents[0]
@@ -421,14 +440,26 @@ def commit_obj_to_json(
             else:
                 base = parent_commit
 
-            result["featureChanges"] = diff_estimation.estimate_diff_feature_counts(
-                repo,
-                base=base,
-                target=commit,
-                accuracy=with_feature_count,
-            )
+            if with_feature_count:
+                result["featureChanges"] = diff_estimation.estimate_diff_feature_counts(
+                    repo,
+                    base=base,
+                    target=commit,
+                    accuracy=with_feature_count,
+                )
+            if with_change_counts:
+                result["featureChangeCounts"] = (
+                    diff_estimation.get_diff_feature_type_counts(
+                        repo,
+                        base=base,
+                        target=commit,
+                    )
+                )
         else:
-            result["featureChanges"] = {}
+            if with_feature_count:
+                result["featureChanges"] = {}
+            if with_change_counts:
+                result["featureChangeCounts"] = {}
     return result
 
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,5 +1,6 @@
 import re
 import json
+import click
 import pytest
 
 
@@ -189,6 +190,86 @@ def test_log_with_feature_count_pointcloud(data_archive, cli_runner):
         result = json.loads(r.stdout)
         result = [c["featureChanges"] for c in result]
         assert result == [{"auckland": 16}]
+
+
+def test_log_with_change_counts_tabular(data_archive, cli_runner):
+    with data_archive("points"):
+        r = cli_runner.invoke(["log", "--output-format=json", "--with-change-counts"])
+        assert r.exit_code == 0, r
+        result = [c["featureChangeCounts"] for c in json.loads(r.stdout)]
+        assert result == [
+            {"nz_pa_points_topo_150k": {"updates": 5}},
+            # the initial import, so everything is an insert
+            {"nz_pa_points_topo_150k": {"inserts": 2143}},
+        ]
+        # the counts add up to the totals reported by --with-feature-count=exact
+        assert [sum(counts.values()) for counts in result[0].values()] == [5]
+        assert [sum(counts.values()) for counts in result[1].values()] == [2143]
+
+        # not reported unless asked for
+        r = cli_runner.invoke(["log", "--output-format=json"])
+        assert r.exit_code == 0, r
+        assert "featureChangeCounts" not in json.loads(r.stdout)[0]
+
+
+def test_log_with_change_counts_pointcloud(data_archive, cli_runner):
+    with data_archive("point-cloud/auckland.tgz"):
+        r = cli_runner.invoke(["log", "--output-format=json", "--with-change-counts"])
+        assert r.exit_code == 0, r
+        result = [c["featureChangeCounts"] for c in json.loads(r.stdout)]
+        assert result == [{"auckland": {"inserts": 16}}]
+
+
+def test_log_with_change_counts_reverse_diff(data_archive, cli_runner):
+    """
+    Type counts aren't the same in both directions, so they're cached against an
+    ordered key - and a diff we've already done in the other direction is inverted
+    rather than recomputed.
+    """
+    with data_archive("points") as repo_path:
+        from kart import diff_estimation
+        from kart.repo import KartRepo
+
+        repo = KartRepo(repo_path)
+        head = repo.head_commit
+        parent = head.parents[0]
+
+        forwards = diff_estimation.get_diff_feature_type_counts(
+            repo, base=parent, target=head
+        )
+        assert forwards == {"nz_pa_points_topo_150k": {"updates": 5}}
+
+        # cached; same answer
+        assert (
+            diff_estimation.get_diff_feature_type_counts(repo, base=parent, target=head)
+            == forwards
+        )
+
+        # the reverse diff of an update is still an update...
+        assert diff_estimation.get_diff_feature_type_counts(
+            repo, base=head, target=parent
+        ) == {"nz_pa_points_topo_150k": {"updates": 5}}
+
+        # ... but inserts and deletes swap over.
+        empty_tree = repo.empty_tree
+        forwards = diff_estimation.get_diff_feature_type_counts(
+            repo, base=empty_tree, target=parent
+        )
+        assert forwards == {"nz_pa_points_topo_150k": {"inserts": 2143}}
+        assert diff_estimation.get_diff_feature_type_counts(
+            repo, base=parent, target=empty_tree
+        ) == {"nz_pa_points_topo_150k": {"deletes": 2143}}
+
+
+def test_log_with_change_counts_text_output(data_archive, cli_runner):
+    with data_archive("points"):
+        # NOTE: checking the exception rather than r.stderr, since the test runner
+        # doesn't capture stderr separately with the Click version we target.
+        with pytest.raises(
+            click.UsageError,
+            match="--with-change-counts requires --output-format=json or json-lines",
+        ):
+            cli_runner.invoke(["log", "--with-change-counts"], standalone_mode=False)
 
 
 @pytest.mark.parametrize("output_format", ["text", "json"])


### PR DESCRIPTION
## Description

`kart log --with-feature-count` reports a single "features changed" total per dataset, because `estimate_diff_feature_counts()` can't tell delta types apart — the sampling accuracies work by estimating a *total* from sampled subtrees.

This adds `--with-change-counts`, which adds a `featureChangeCounts` object to JSON output: per dataset, the exact number of features (or tiles) inserted, updated and deleted by each commit, relative to its first parent.

```console
$ kart log -o json --with-change-counts
```
```json
[
  {"commit": "...", "featureChangeCounts": {"nz_pa_points_topo_150k": {"updates": 5}}},
  {"commit": "...", "featureChangeCounts": {"nz_pa_points_topo_150k": {"inserts": 2143}}}
]
```

Counts come from a `git diff --name-status --no-renames -z` tally over each dataset's data tree. That's the same tree walk the existing exact count already does with `--name-only` (`get_exact_diff_blob_count`), so it costs the same — we just keep the status letter instead of discarding it. Types with a zero count are omitted, matching `DeltaDiff.type_counts()`, whose `inserts`/`updates`/`deletes` naming this reuses (already used by `kart status` and `kart commit`).

### Tradeoffs / alternatives considered

- **Exact only, no accuracy argument.** Subtree sampling can't produce a per-type split, so folding a by-type mode into the `--with-feature-count` accuracy enum would misrepresent what the values mean. A boolean flag says what it does.
- **Left `featureChanges` alone** rather than making it richer. Cave and `kart diff --only-feature-count` depend on its current int-valued shape, and the total is derivable as the sum.
- **Cache key ordering.** Unlike the existing annotation types, these counts differ depending on which way around the diff is — reversing base and target swaps inserts and deletes. `DiffAnnotations._object_id()` deliberately sorts the two tree IDs to raise the hit rate, so `store()`/`get()` now take an `ordered` flag that skips the sort. Default behaviour and existing cached rows are untouched. Rather than storing the direction inside the payload, the caller does a reverse lookup and inverts the result, which keeps the cached data identical to what's returned.

### Why

So per-commit change counts can reach the dataset History table in the Koordinates web UI, which currently renders `0` in its add/mod/del columns for every commit of a kart-backed dataset. Cave will forward this over gRPC.

## Related links:

- Cave side: koordinates/kart-infra#600 (draft — currently exposes the *total*; will be repurposed to forward these counts)

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)?

Tests: 4 new cases in `tests/test_log.py` (tabular, point cloud, absent-unless-requested, and cache direction — updates stay updates, inserts/deletes swap). The new counts sum to exactly the totals already pinned by `test_log_with_feature_count_*`. Locally: 66 passed across `test_log.py`, `test_annotations.py` and `test_diff_feature_count.py`; pre-commit (ruff + mypy) clean.

Unrelated pre-existing issue noticed while writing the tests: `Result.stderr` is unusable in this repo's test runner with the Click version we target — `tests/test_diff.py::test_diff_geojson_usage` fails on unmodified code with `ValueError: stderr not separately captured`. The new usage-error test asserts on the raised `UsageError` instead, so it doesn't depend on that being fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)