### PR TITLE
log: report dataset size alongside the change counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## UNRELEASED
 
-- `log`: Adds `--with-change-counts`, which reports, per dataset that each commit changed, the exact number of features (or tiles) inserted, updated and deleted, and how many the dataset contains at that commit. [#1127](https://github.com/koordinates/kart/pull/1127)
+- `log`: Adds `--with-change-counts`. For each dataset changed by a commit, it reports the exact number of features (or tiles) inserted, updated and deleted, and how many features that dataset contains at that commit. [#1127](https://github.com/koordinates/kart/pull/1127), [#1128](https://github.com/koordinates/kart/pull/1128)
 - Adds `libkart`, a native shared library exposing a C API for reading Kart repositories in-process (without invoking the `kart` CLI). It is shipped in the bundle alongside the `kart` executable; see the libkart C API reference in the developer docs. [#1110](https://github.com/koordinates/kart/pull/1110)
 - Add pager support to `diff` and `show` commands. [#1080](https://github.com/koordinates/kart/pull/1080)
 - Piped (non-tty) output is now always UTF-8 on all platforms. Previously text output used the locale codepage on Windows (e.g. cp1252), inconsistent with JSON output (which is always UTF-8). [#1115](https://github.com/koordinates/kart/issues/1115)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ _When adding new entries to the changelog, please include issue/PR numbers where
 
 ## UNRELEASED
 
-- `log`: Adds `--with-change-counts`, which reports the exact number of features (or tiles) inserted, updated and deleted by each commit, per dataset.
+- `log`: Adds `--with-change-counts`, which reports, per dataset that each commit changed, the exact number of features (or tiles) inserted, updated and deleted, and how many the dataset contains at that commit. [#1127](https://github.com/koordinates/kart/pull/1127)
 - Adds `libkart`, a native shared library exposing a C API for reading Kart repositories in-process (without invoking the `kart` CLI). It is shipped in the bundle alongside the `kart` executable; see the libkart C API reference in the developer docs. [#1110](https://github.com/koordinates/kart/pull/1110)
 - Add pager support to `diff` and `show` commands. [#1080](https://github.com/koordinates/kart/pull/1080)
 - Piped (non-tty) output is now always UTF-8 on all platforms. Previously text output used the locale codepage on Windows (e.g. cp1252), inconsistent with JSON output (which is always UTF-8). [#1115](https://github.com/koordinates/kart/issues/1115)

--- a/kart/diff_estimation.py
+++ b/kart/diff_estimation.py
@@ -133,6 +133,51 @@ def get_data_tree(repo, ds):
 
 
 TYPE_COUNTS_ANNOTATION_TYPE = "feature-change-type-counts-exact"
+TOTALS_ANNOTATION_TYPE = "feature-totals-exact"
+
+
+def get_dataset_feature_totals(repo, commit, dataset_paths):
+    """
+    Counts the features (or tiles, for non-tabular datasets) that each of the given
+    datasets contains at the given commit.
+    Returns a dict: {dataset_path: int}
+
+    Unlike the change counts, this is O(the size of the dataset) rather than O(the size
+    of the diff), so it's cached against each dataset's data tree - commits that don't
+    touch a dataset share its tree, and therefore its cached count.
+    """
+    dataset_paths = set(dataset_paths)
+    if not dataset_paths:
+        return {}
+
+    rs = repo.structure(commit)
+    totals = {}
+    for ds in rs.datasets():
+        if ds.path not in dataset_paths:
+            continue
+        if terminate_estimate_thread.is_set():
+            raise ThreadTerminated()
+
+        data_tree = get_data_tree(repo, ds)
+        # An annotation is stored against a pair of trees; here both sides are the same
+        # tree, since the count describes one tree rather than a diff between two.
+        annotation = repo.diff_annotations.get(
+            base=data_tree, target=data_tree, annotation_type=TOTALS_ANNOTATION_TYPE
+        )
+        if annotation is None:
+            total = ds.feature_count if ds.DATASET_TYPE == "table" else ds.tile_count
+            repo.diff_annotations.store(
+                base=data_tree,
+                target=data_tree,
+                annotation_type=TOTALS_ANNOTATION_TYPE,
+                data={"total": total},
+            )
+        else:
+            total = annotation["total"]
+
+        totals[ds.path] = total
+
+    return totals
 
 
 def _invert_type_counts(counts):

--- a/kart/diff_estimation.py
+++ b/kart/diff_estimation.py
@@ -146,14 +146,17 @@ def get_dataset_feature_totals(repo, commit, dataset_paths):
     of the diff), so it's cached against each dataset's data tree - commits that don't
     touch a dataset share its tree, and therefore its cached count.
     """
-    dataset_paths = set(dataset_paths)
     if not dataset_paths:
         return {}
 
-    rs = repo.structure(commit)
+    # Looked up by path rather than by iterating the datasets, which would walk the whole
+    # repo tree for what is usually one dataset.
+    datasets = repo.structure(commit).datasets()
     totals = {}
-    for ds in rs.datasets():
-        if ds.path not in dataset_paths:
+    for ds_path in sorted(dataset_paths):
+        ds = datasets.get(ds_path)
+        if ds is None:
+            # eg the commit deleted the dataset; it has changes but no size.
             continue
         if terminate_estimate_thread.is_set():
             raise ThreadTerminated()

--- a/kart/log.py
+++ b/kart/log.py
@@ -162,10 +162,11 @@ def convert_user_patterns_to_raw_paths(paths, repo, commits):
     "--with-change-counts",
     is_flag=True,
     help=(
-        "Adds a 'featureChangeCounts' object to JSON output: for each dataset, the exact "
-        "number of features inserted, updated and deleted by each commit, relative to its "
-        "first parent. For non-tabular datasets, these refer to numbers of tiles. "
-        "Counts are always exact (this may be slow for large tabular diffs)."
+        "Adds a 'featureChangeCounts' object to JSON output: for each dataset the commit "
+        "changed, the exact number of features inserted, updated and deleted relative to "
+        "its first parent, plus 'features' - how many features the dataset contains at "
+        "that commit. For non-tabular datasets these are numbers of tiles. Counts are "
+        "always exact (this may be slow for large tabular datasets)."
     ),
 )
 # Some standard git options
@@ -448,13 +449,25 @@ def commit_obj_to_json(
                     accuracy=with_feature_count,
                 )
             if with_change_counts:
-                result["featureChangeCounts"] = (
-                    diff_estimation.get_diff_feature_type_counts(
-                        repo,
-                        base=base,
-                        target=commit,
-                    )
+                change_counts = diff_estimation.get_diff_feature_type_counts(
+                    repo,
+                    base=base,
+                    target=commit,
                 )
+                # How big each dataset is, alongside how much of it changed. Only for the
+                # datasets this commit changed: counting one is O(its size), and a commit
+                # that didn't touch a dataset leaves it the same size as its parent did.
+                totals = diff_estimation.get_dataset_feature_totals(
+                    repo, commit, change_counts.keys()
+                )
+                result["featureChangeCounts"] = {
+                    ds_path: (
+                        {**counts, "features": totals[ds_path]}
+                        if ds_path in totals
+                        else counts
+                    )
+                    for ds_path, counts in change_counts.items()
+                }
         else:
             if with_feature_count:
                 result["featureChanges"] = {}

--- a/kart/log.py
+++ b/kart/log.py
@@ -162,11 +162,11 @@ def convert_user_patterns_to_raw_paths(paths, repo, commits):
     "--with-change-counts",
     is_flag=True,
     help=(
-        "Adds a 'featureChangeCounts' object to JSON output: for each dataset the commit "
-        "changed, the exact number of features inserted, updated and deleted relative to "
-        "its first parent, plus 'features' - how many features the dataset contains at "
-        "that commit. For non-tabular datasets these are numbers of tiles. Counts are "
-        "always exact (this may be slow for large tabular datasets)."
+        "Adds a 'featureChangeCounts' object to JSON output. For each dataset changed by "
+        "the commit, it gives the exact number of features inserted, updated and deleted "
+        "relative to the commit's first parent, plus 'features' - how many features that "
+        "dataset contains at the commit. For non-tabular datasets these are numbers of "
+        "tiles. Counts are always exact (this may be slow for large tabular datasets)."
     ),
 )
 # Some standard git options

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -198,13 +198,19 @@ def test_log_with_change_counts_tabular(data_archive, cli_runner):
         assert r.exit_code == 0, r
         result = [c["featureChangeCounts"] for c in json.loads(r.stdout)]
         assert result == [
-            {"nz_pa_points_topo_150k": {"updates": 5}},
+            {"nz_pa_points_topo_150k": {"updates": 5, "features": 2143}},
             # the initial import, so everything is an insert
-            {"nz_pa_points_topo_150k": {"inserts": 2143}},
+            {"nz_pa_points_topo_150k": {"inserts": 2143, "features": 2143}},
         ]
-        # the counts add up to the totals reported by --with-feature-count=exact
-        assert [sum(counts.values()) for counts in result[0].values()] == [5]
-        assert [sum(counts.values()) for counts in result[1].values()] == [2143]
+        # the change counts add up to the totals reported by --with-feature-count=exact
+        assert [
+            sum(v for k, v in counts.items() if k != "features")
+            for counts in result[0].values()
+        ] == [5]
+        assert [
+            sum(v for k, v in counts.items() if k != "features")
+            for counts in result[1].values()
+        ] == [2143]
 
         # not reported unless asked for
         r = cli_runner.invoke(["log", "--output-format=json"])
@@ -217,7 +223,7 @@ def test_log_with_change_counts_pointcloud(data_archive, cli_runner):
         r = cli_runner.invoke(["log", "--output-format=json", "--with-change-counts"])
         assert r.exit_code == 0, r
         result = [c["featureChangeCounts"] for c in json.loads(r.stdout)]
-        assert result == [{"auckland": {"inserts": 16}}]
+        assert result == [{"auckland": {"inserts": 16, "features": 16}}]
 
 
 def test_log_with_change_counts_reverse_diff(data_archive, cli_runner):


### PR DESCRIPTION
## Description

Follow-up to #1127. `--with-change-counts` reported how much of each dataset a commit changed, but not how big the dataset was — so a consumer can say "648 tiles added" but not "of 3,265".

Adds `features` to each dataset's entry in the same object:

```console
$ kart log -o json --with-change-counts
```
```json
[
  {"commit": "...", "featureChangeCounts": {"nz_pa_points_topo_150k": {"updates": 5, "features": 2143}}},
  {"commit": "...", "featureChangeCounts": {"nz_pa_points_topo_150k": {"inserts": 2143, "features": 2143}}}
]
```

### Tradeoffs / alternatives considered

- **One object rather than a second top-level key.** Four numbers about one dataset belong together, and the consumer does one lookup. A sibling `featureCounts` key was the first idea and got rejected: it reads far too much like the existing `featureChanges`, which is a *change* count despite the name.
- **`features` as the key.** Kart already uses "feature count" to mean tiles for non-tabular datasets (see `--with-feature-count`'s help), so this matches existing usage rather than inventing a word.
- **Counted in-process, not via `[EMPTY]...<ref>`.** `ds.feature_count` / `ds.tile_count` (`count_blobs_in_subtree`) already do this without a subprocess. Cave's `get_feature_counts` gets totals by diffing against the empty tree, which works but spawns a process per ref.
- **Only for datasets the commit changed.** This count is O(the size of the dataset), unlike the change counts which are O(the size of the diff). A commit that didn't touch a dataset leaves it the same size as its parent did, so there's nothing to learn by counting it again — and metadata-only commits keep reporting `{}`. Consequence: a dataset *deleted* by a commit gets change counts but no `features`.
- **Cached against the data tree**, not the commit, so a run of commits that don't touch a dataset shares one computation. New annotation type `feature-totals-exact`; the existing `ordered` flag isn't needed since both sides of the key are the same tree.

### Why

The dataset History table in the Koordinates web UI has a Tiles/Rows column that shows the dataset's size at each revision. For kart-backed datasets it's currently blank, because nothing in the log response carries that number.

## Related links:

- #1127 added `--with-change-counts`
- Consumers: koordinates/kart-infra#604 (merged), koordinates/dandelion#5923, koordinates/kawaka#9407

## Checklist:

- [x] Have you reviewed your own change?
- [x] Have you included test(s)?
- [x] Have you updated the [changelog](https://github.com/koordinates/kart/blob/master/CHANGELOG.md)? (amended #1127's unreleased entry)

Tests: the existing `--with-change-counts` cases now assert `features` too, including one commit where the total and the deltas differ (`{"updates": 5, "features": 2143}`). Locally: 66 passed across `test_log.py`, `test_annotations.py`, `test_diff_feature_count.py`; pre-commit (ruff + mypy) clean.

Not covered by a test: `features` shrinking after a delete-heavy commit — no fixture has one, and building a working copy to create it seemed out of proportion. The count itself is `count_blobs_in_subtree`, which `test_diff_feature_count.py` already exercises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)